### PR TITLE
remove anti patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,210 @@
+experiments/
+wandb/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/

--- a/configs/af3.yaml
+++ b/configs/af3.yaml
@@ -20,7 +20,7 @@ train:
     precision: bf16-mixed
     max_epochs: 100
     limit_train_batches: 10_000
-    log_every_n_steps: 10
+    log_every_n_steps: 1 # `1` means: log per `accumulate_grad_batches`
     enable_checkpointing: true
     accumulate_grad_batches: 32 # set according to number of GPUs
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -70,6 +70,7 @@ def build_trainer(cfg, default_root_dir: Path) -> pl.Trainer:
             group=train_cfg.wandb.group,
             entity=train_cfg.wandb.entity,
             config=to_dict(cfg),
+            save_dir=default_root_dir,
         )
         loggers = [wandb_logger]
     else:

--- a/src/kfold/model/modules/confidence_head/__init__.py
+++ b/src/kfold/model/modules/confidence_head/__init__.py
@@ -3,8 +3,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
-
 # Get all Python module names in current directory
 _package_dir = Path(__file__).parent
 _modules = [f.stem for f in _package_dir.glob("*.py") if f.stem != "__init__"]

--- a/src/kfold/model/modules/distogram_head/__init__.py
+++ b/src/kfold/model/modules/distogram_head/__init__.py
@@ -2,7 +2,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseDistogramHead
 
 # Get all Python module names in current directory
@@ -15,3 +14,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseDistogramHead"]

--- a/src/kfold/model/modules/input_embedder/__init__.py
+++ b/src/kfold/model/modules/input_embedder/__init__.py
@@ -3,7 +3,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseInputEmbedder
 
 # Get all Python module names in current directory
@@ -16,3 +15,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseInputEmbedder"]

--- a/src/kfold/model/modules/score_model/__init__.py
+++ b/src/kfold/model/modules/score_model/__init__.py
@@ -3,7 +3,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseScoreModel
 
 # Get all Python module names in current directory
@@ -16,3 +15,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseScoreModel"]

--- a/src/kfold/model/modules/sequence_encoder/__init__.py
+++ b/src/kfold/model/modules/sequence_encoder/__init__.py
@@ -2,7 +2,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseSequenceEncoder
 
 # Get all Python module names in current directory
@@ -15,3 +14,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseSequenceEncoder"]

--- a/src/kfold/model/modules/structure_encoder/__init__.py
+++ b/src/kfold/model/modules/structure_encoder/__init__.py
@@ -2,7 +2,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseStructureEncoder
 
 # Get all Python module names in current directory
@@ -15,3 +14,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseStructureEncoder"]

--- a/src/kfold/model/modules/structure_module/__init__.py
+++ b/src/kfold/model/modules/structure_module/__init__.py
@@ -3,7 +3,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseStructureModule
 
 # Get all Python module names in current directory
@@ -16,3 +15,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseStructureModule"]

--- a/src/kfold/model/modules/trunk/__init__.py
+++ b/src/kfold/model/modules/trunk/__init__.py
@@ -3,7 +3,6 @@
 import importlib
 from pathlib import Path
 
-from . import *  # noqa
 from .base import BaseTrunk
 
 # Get all Python module names in current directory
@@ -16,3 +15,5 @@ for _module in _modules:
 
 # Clean up
 del Path, importlib, _package_dir, _modules
+
+__all__ = ["BaseTrunk"]


### PR DESCRIPTION
This pull request refactors the `__init__.py` files across several module directories in `src/kfold/model/modules` to improve import clarity and maintainability. The main changes involve removing wildcard imports and explicitly defining the `__all__` variable to control what is exported from each module.

**Refactoring of module initialization:**

* Removed wildcard imports (`from . import *`) from all affected `__init__.py` files to prevent unintended symbol exports and improve clarity. 
* Added explicit `__all__` definitions to each module, listing only the main base class as the public API (e.g., `__all__ = ["BaseDistogramHead"]`).

**Consistency improvements:**

* Ensured all modules (`distogram_head`, `input_embedder`, `score_model`, `sequence_encoder`, `structure_encoder`, `structure_module`, `trunk`) follow the same pattern for imports and exports, making the codebase more consistent and easier to maintain. (all references above)