### PR TITLE
Fix/training

### DIFF
--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -6,6 +6,7 @@ out_dir: ./experiments/
 
 # Random Seed
 seed: 42
+synchronize_seed: false # Use synchronized seed across DDP processes
 
 data:
   _registry_: "datamodule"

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -139,10 +139,12 @@ loss:
   diffusion_loss:
     # Weighted MSE Loss
     mse_loss:
-      weight_protein: 1.0
-      weight_dna: 5.0
-      weight_rna: 5.0
-      weight_ligand: 10.0
+      # NOTE: these are same to AlphaFold3:
+      # w = 1 + 5 * is_dna + 5 * is_rna + 10 * is_ligand
+      upweight_protein: 0.0
+      upweight_dna: 5.0
+      upweight_rna: 5.0
+      upweight_ligand: 10.0
       scale: false
 
     # Bond Loss

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -223,7 +223,18 @@ def train(args) -> None:
     trainer = build_trainer(cfg, args.debug)
 
     # Set random seed
-    pl.seed_everything(cfg.train.seed + trainer.global_rank, workers=True, verbose=False)
+    # TODO: let's discuss to use different seeds for different ranks or not
+    # Pros: when we use `synchronize_sigma` option, use different seeds is essential to
+    #       train the model on various time steps.
+    # Cons: it makes the training less reproducible.
+    if cfg.train.synchronize_seed:
+        # Same seed for all ranks
+        pl.seed_everything(cfg.train.seed, workers=True, verbose=False)
+    else:
+        # Different seed for each rank
+        pl.seed_everything(
+            cfg.train.seed + trainer.global_rank, workers=True, verbose=False
+        )
 
     model_module = KFoldTrainingModule(cfg)
     data_module = TrainingDataModule(cfg.train.data)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -208,6 +208,7 @@ def build_trainer(cfg, debug_mode: str = "off") -> pl.Trainer:
         enable_checkpointing=pl_trainer_cfg.enable_checkpointing,
         accumulate_grad_batches=pl_trainer_cfg.accumulate_grad_batches,
         gradient_clip_val=pl_trainer_cfg.gradient_clip_val,
+        use_distributed_sampler=False,
         # reload_dataloaders_every_n_epochs=1,
     )
     return trainer
@@ -219,10 +220,11 @@ def train(args) -> None:
 
     cfg = parse_config(args)
 
-    # Set random seed
-    pl.seed_everything(cfg.train.seed)
-
     trainer = build_trainer(cfg, args.debug)
+
+    # Set random seed
+    pl.seed_everything(cfg.train.seed + trainer.global_rank, workers=True, verbose=False)
+
     model_module = KFoldTrainingModule(cfg)
     data_module = TrainingDataModule(cfg.train.data)
 

--- a/src/kfold/data/featurize.py
+++ b/src/kfold/data/featurize.py
@@ -98,8 +98,6 @@ def do_augment_apo_structure(
         new_coords[:, start_idx:end_idx] = center_random_augmentation(
             apo_coords[:, start_idx:end_idx],  # =apo_chain_coords
             mask[:, start_idx:end_idx],  # =apo_chain_mask
-            random_rotate=True,
-            s_trans=0.0,
             rng=rng,
         )
         start_idx = end_idx

--- a/src/kfold/data/featurize.py
+++ b/src/kfold/data/featurize.py
@@ -87,10 +87,7 @@ def do_augment_apo_structure(
     augmented_apo_coords : np.ndarray
         Augmented apo structure coordinates of shape [Napo, Natom, 3].
     """
-    # Apply random rotation per apo coords
-    # NOTE: Unlike holo structure, apo structure is input so that
-    # random translation is not applied.
-
+    # Apply random rotation and translation per apo coords
     new_coords = np.zeros_like(apo_coords)
     start_idx = 0
     for natom in chain_sizes:

--- a/src/kfold/model/layers/alphafold3/utils.py
+++ b/src/kfold/model/layers/alphafold3/utils.py
@@ -113,28 +113,33 @@ class LocalAttentionIndex:
 def center_random_augmentation(
     coords: torch.Tensor,
     mask: torch.Tensor,
-    s_trans: float = 1.0,
     centering: bool = True,
-    random_rotate: bool = True,
+    augmentation: bool = True,
+    s_trans: float = 1.0,
+    mask_to_zero: bool = True,
 ) -> torch.Tensor:
     """Centering and Random Augmentation
     See Section 3.7 Algorithm 19 CentreRandomAugmentation
     """
     # Line 1
     if centering:
-        coords = do_centering(coords, mask)
+        coords = do_centering(coords, mask, mask_to_zero=False)
 
-    # Line 2,4
-    if random_rotate:
+    if augmentation:
+        # Line 2,4
         R = random_rotations(
             coords.shape[:-2], coords.dtype, coords.device
         )  # [..., 3, 3]
         coords = torch.einsum("...md,...ds->...ms", coords, R)  # noqa
 
-    # Line 3,4
-    if s_trans > 0.0:
-        random_trans = torch.randn_like(coords[..., 0:1, :]) * s_trans
-        coords = coords + random_trans
+        # Line 3,4
+        if s_trans > 0.0:
+            random_trans = torch.randn_like(coords[..., 0:1, :]) * s_trans
+            coords = coords + random_trans
+
+    # Mask out
+    if mask_to_zero:
+        coords = coords * mask[..., None]
 
     return coords
 
@@ -152,11 +157,16 @@ class CenterRandomAugmentation:
     """
 
     def __init__(
-        self, s_trans: float = 1.0, centering: bool = True, random_rotate: bool = True
+        self,
+        augmentation: bool = True,
+        centering: bool = True,
+        s_trans: float = 1.0,
+        mask_to_zero: bool = True,
     ):
-        self.s_trans: float = s_trans
+        self.augmentation: bool = augmentation
         self.centering: bool = centering
-        self.random_rotate: bool = random_rotate
+        self.s_trans: float = s_trans
+        self.mask_to_zero: bool = mask_to_zero
 
     @overload
     def __call__(
@@ -223,23 +233,24 @@ class CenterRandomAugmentation:
 
         # Line 1
         if self.centering:
-            coords_list = [do_centering(x, mask) for x in coords_list]
+            coords_list = [do_centering(x, mask, mask_to_zero=False) for x in coords_list]
 
-        # Line 2,4
-        if self.random_rotate:
+        if self.augmentation:
+            # Line 2,4
             R = random_rotations(
                 coords_shape[:-2], ref_coords.dtype, ref_coords.device
             )  # [..., 3, 3]
             rotate = lambda x: torch.einsum("...md,...ds->...ms", x, R)  # noqa
             coords_list = [rotate(x) for x in coords_list]
 
-        # Line 3,4
-        if self.s_trans > 0.0:
-            random_trans = torch.randn_like(ref_coords[..., 0:1, :]) * self.s_trans
-            coords_list = [x + random_trans for x in coords_list]
+            # Line 3,4
+            if self.s_trans > 0.0:
+                random_trans = torch.randn_like(ref_coords[..., 0:1, :]) * self.s_trans
+                coords_list = [x + random_trans for x in coords_list]
 
         # Mask out
-        coords_list = [x * mask[..., None] for x in coords_list]
+        if self.mask_to_zero:
+            coords_list = [x * mask[..., None] for x in coords_list]
 
         if len(coords) == 1:
             # Single tensor input, return tensor
@@ -249,7 +260,9 @@ class CenterRandomAugmentation:
             return tuple(coords_list)
 
 
-def do_centering(coords: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+def do_centering(
+    coords: torch.Tensor, mask: torch.Tensor, mask_to_zero: bool = True
+) -> torch.Tensor:
     """Centering of atom coordinates
     Parameters
     ----------
@@ -264,6 +277,8 @@ def do_centering(coords: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         torch.sum(coords * mask[..., None], dim=-2, keepdim=True) / total_mass[..., None]
     )
     centered_coords = coords - center
+    if mask_to_zero:
+        centered_coords = centered_coords * mask[..., None]
     return centered_coords
 
 
@@ -285,8 +300,7 @@ def _copysign(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     Returns:
         Tensor of the same shape as a with the signs of b.
     """
-    signs_differ = (a < 0) != (b < 0)
-    return torch.where(signs_differ, -a, a)
+    return torch.copysign(a, b)
 
 
 def quaternion_to_matrix(quaternions: torch.Tensor) -> torch.Tensor:

--- a/src/kfold/model/modules/structure_module/af3_edm.py
+++ b/src/kfold/model/modules/structure_module/af3_edm.py
@@ -84,11 +84,11 @@ class AF3SampleDiffusion(BaseStructureModule):
         self.coordinate_augmentation: bool = cfg.coordinate_augmentation
         self.synchronize_sigmas: bool = cfg.synchronize_sigmas
 
-        if self.coordinate_augmentation:
-            self.random_augmentation = CenterRandomAugmentation(
-                centering=True,
-                random_rotate=self.coordinate_augmentation,
-            )
+        self.random_augmentation = CenterRandomAugmentation(
+            centering=True,
+            augmentation=self.coordinate_augmentation,
+            s_trans=1.0,  # not used when augmentation is False
+        )
 
     # === EDM diffusion coefficients === #
     def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:

--- a/src/kfold/model/modules/structure_module/boltz1_edm.py
+++ b/src/kfold/model/modules/structure_module/boltz1_edm.py
@@ -82,11 +82,11 @@ class Boltz1SampleDiffusion(BaseStructureModule):
         self.coordinate_augmentation: bool = cfg.coordinate_augmentation
         self.synchronize_sigmas: bool = cfg.synchronize_sigmas
 
-        if self.coordinate_augmentation:
-            self.random_augmentation = CenterRandomAugmentation(
-                centering=True,
-                random_rotate=self.coordinate_augmentation,
-            )
+        self.random_augmentation = CenterRandomAugmentation(
+            centering=True,
+            augmentation=self.coordinate_augmentation,
+            s_trans=1.0,  # not used when augmentation is False
+        )
 
     # === EDM diffusion coefficients === #
     def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:

--- a/src/kfold/training/folding/dataset/datamodule.py
+++ b/src/kfold/training/folding/dataset/datamodule.py
@@ -174,6 +174,7 @@ class TrainingDataModule(pl.LightningDataModule):
                 weights=weights,  # type: ignore
                 rank=self.trainer.global_rank if self.trainer else 0,
                 world_size=self.trainer.world_size if self.trainer else 1,
+                epoch=self.trainer.current_epoch if self.trainer else 0,
                 replacement=True,
             )
             shuffle = False

--- a/src/kfold/training/folding/dataset/datamodule.py
+++ b/src/kfold/training/folding/dataset/datamodule.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import lightning.pytorch as pl
 from torch.utils.data.dataloader import DataLoader
-from torch.utils.data.sampler import WeightedRandomSampler
 
 from kfold.data.metadata import Metadata
 from kfold.data.model_input import FoldingInput
@@ -19,6 +18,7 @@ from .dataset import (
     TrainingDataset,
     ValidationDataset,
 )
+from .dl_sampler import DistributedWeightedSampler
 from .filter import BaseFilter
 from .sampler import BaseSampler
 
@@ -170,23 +170,26 @@ class TrainingDataModule(pl.LightningDataModule):
 
         weights = dataset.weights
         if weights is not None:
-            sampler = WeightedRandomSampler(
+            sampler = DistributedWeightedSampler(
                 weights=weights,  # type: ignore
-                num_samples=len(weights),
+                rank=self.trainer.global_rank if self.trainer else 0,
+                world_size=self.trainer.world_size if self.trainer else 1,
                 replacement=True,
             )
+            shuffle = False
         else:
             sampler = None
+            shuffle = True
 
         return DataLoader(
             dataset,
             batch_size=self.config.train_batch_size,
-            shuffle=True if sampler is None else False,
+            shuffle=shuffle,
             sampler=sampler,
-            num_workers=self.config.num_workers,
-            pin_memory=self.config.pin_memory,
             drop_last=True,
             collate_fn=collate,
+            num_workers=self.config.num_workers,
+            pin_memory=self.config.pin_memory,
             persistent_workers=True if self.config.num_workers > 0 else False,
         )
 
@@ -197,8 +200,9 @@ class TrainingDataModule(pl.LightningDataModule):
             dataset,
             batch_size=self.config.val_batch_size,
             shuffle=False,
+            drop_last=True,
+            collate_fn=collate,
             num_workers=self.config.num_workers,
             pin_memory=self.config.pin_memory,
-            collate_fn=collate,
             persistent_workers=True if self.config.num_workers > 0 else False,
         )

--- a/src/kfold/training/folding/dataset/dl_sampler.py
+++ b/src/kfold/training/folding/dataset/dl_sampler.py
@@ -1,0 +1,103 @@
+import math
+import warnings
+from collections.abc import Iterator
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from torch.utils.data.sampler import Sampler
+
+__all__ = ["DistributedWeightedSampler"]
+
+
+class DistributedWeightedSampler(Sampler[int]):
+    def __init__(
+        self,
+        weights: np.ndarray | torch.Tensor | list[float],
+        num_samples: int | None = None,
+        replacement: bool = True,
+        rank: int | None = None,
+        world_size: int | None = None,
+        seed: int = 0,
+    ) -> None:
+        is_dist_initialized = dist.is_available() and dist.is_initialized()
+
+        if rank is None:
+            if not is_dist_initialized:
+                warnings.warn(
+                    "Distributed package is not available. Defaulting rank to 0."
+                )
+                rank = 0
+            else:
+                rank = dist.get_rank()
+
+        if world_size is None:
+            if not is_dist_initialized:
+                warnings.warn(
+                    "Distributed package is not available. Defaulting world_size to 1."
+                )
+                world_size = 1
+            else:
+                world_size = dist.get_world_size()
+
+        self.rank: int = rank
+        self.world_size: int = world_size
+        self.epoch: int = 0
+        self.seed: int = seed
+        self.replacement: bool = replacement
+
+        if isinstance(weights, torch.Tensor):
+            weights = weights.cpu().numpy()
+        elif isinstance(weights, list):
+            weights = np.array(weights)
+        if weights.sum() == 0:
+            raise ValueError("Sum of weights cannot be zero.")
+
+        # Normalize weights
+        weights = weights.astype(np.float64)
+        self.weights: np.ndarray = weights / weights.sum()
+        self.dataset_size: int = self.weights.shape[0]
+
+        # Determine number of samples
+        if num_samples is None:
+            # If num_samples is not provided, set it so that each replica gets an equal
+            # share
+            total_global_samples = self.dataset_size
+        else:
+            total_global_samples = num_samples
+
+        self.num_samples: int = int(math.ceil(total_global_samples / self.world_size))
+        self.total_size: int = self.num_samples * self.world_size
+
+    def __iter__(self) -> Iterator[int]:
+        # deterministically shuffle based on epoch and seed
+        rng = np.random.RandomState(self.seed + self.epoch)
+
+        indices = rng.choice(
+            self.dataset_size,
+            self.total_size,
+            p=self.weights,
+            replace=self.replacement,
+        ).tolist()
+        assert len(indices) == self.total_size
+
+        # subsample
+        indices = indices[self.rank : self.total_size : self.world_size]
+        assert len(indices) == self.num_samples
+        return iter(indices)
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""
+        Set the epoch for this sampler.
+
+        When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of
+        this sampler will yield the same ordering.
+
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch

--- a/src/kfold/training/folding/dataset/dl_sampler.py
+++ b/src/kfold/training/folding/dataset/dl_sampler.py
@@ -18,6 +18,7 @@ class DistributedWeightedSampler(Sampler[int]):
         replacement: bool = True,
         rank: int | None = None,
         world_size: int | None = None,
+        epoch: int = 0,
         seed: int = 0,
     ) -> None:
         is_dist_initialized = dist.is_available() and dist.is_initialized()
@@ -42,7 +43,7 @@ class DistributedWeightedSampler(Sampler[int]):
 
         self.rank: int = rank
         self.world_size: int = world_size
-        self.epoch: int = 0
+        self.epoch: int = epoch
         self.seed: int = seed
         self.replacement: bool = replacement
 
@@ -90,12 +91,13 @@ class DistributedWeightedSampler(Sampler[int]):
         return self.num_samples
 
     def set_epoch(self, epoch: int) -> None:
-        r"""
+        """
         Set the epoch for this sampler.
 
-        When :attr:`shuffle=True`, this ensures all replicas
-        use a different random ordering for each epoch. Otherwise, the next iteration of
-        this sampler will yield the same ordering.
+        Changing the epoch ensures all replicas use a different random ordering for each
+        epoch, as the random seed is determined by the combination of the `seed` and
+        `epoch` attributes. If the epoch is not changed, the next iteration of this
+        sampler will yield the same ordering.
 
         Args:
             epoch (int): Epoch number.

--- a/src/kfold/training/folding/dataset/sampler/cluster.py
+++ b/src/kfold/training/folding/dataset/sampler/cluster.py
@@ -9,10 +9,6 @@ from kfold.utils.registry import DATA_SAMPLER
 
 from .base import BaseSampler, Sample
 
-# FIXME: (SeonghwanSeo) Currently, I restrict that only protein and ligand
-# are considered. Need to remove this restriction in the future.
-ALLOW_NUC = True
-
 
 # === Helpers to compute weights === #
 def get_chain_cluster(chain: ChainInfo) -> str:
@@ -66,10 +62,6 @@ def get_chain_weight(
         n_nuc += 1
     else:
         n_ligand += 1
-
-    # FIXME: remove following lines.
-    if not ALLOW_NUC and n_nuc > 0:
-        return 0
 
     cluster_id = get_chain_cluster(chain)
     n_cluster = cluster_sizes[cluster_id]
@@ -125,10 +117,6 @@ def get_interface_weight(
             n_nuc += 1
         else:
             n_ligand += 1
-
-    # FIXME: remove following lines.
-    if not ALLOW_NUC and n_nuc > 0:
-        return 0
 
     cluster_id = get_interface_cluster(interface, chain_dict)
     n_cluster = cluster_sizes[cluster_id]
@@ -251,8 +239,8 @@ class ClusterSampler(BaseSampler):
                 weights.append(weight)
 
         # Normalize weights
-        weights = np.array(weights) / np.sum(weights)
-        return samples, weights
+        weights_arr = np.array(weights) / np.sum(weights)
+        return samples, weights_arr
 
     def estimate_cluster_sizes(self, records: list[Metadata]):
         # Estimate cluster sizes of chains and interfaces

--- a/src/kfold/training/folding/loss/diffusion.py
+++ b/src/kfold/training/folding/loss/diffusion.py
@@ -7,27 +7,48 @@ from kfold.utils.checkpointing import checkpoint_section
 from kfold.utils.geometry.rigid_align import weighted_rigid_align
 
 
+def compute_modality_weights(
+    is_protein: torch.Tensor,
+    is_dna: torch.Tensor,
+    is_rna: torch.Tensor,
+    is_ligand: torch.Tensor,
+    upweight_protein: float = 0.0,
+    upweight_dna: float = 5.0,
+    upweight_rna: float = 5.0,
+    upweight_ligand: float = 10.0,
+) -> torch.Tensor:
+    """Compute weights for loss calculation.
+    See Section 3.7.1 Equation 4 of the AlphaFold 3 paper.
+    """
+    return (
+        1.0
+        + is_protein.float() * upweight_protein
+        + is_dna.float() * upweight_dna
+        + is_rna.float() * upweight_rna
+        + is_ligand.float() * upweight_ligand
+    )  # [B, Ltoken]
+
+
 def get_atom_weights(
     f_input: FoldingInput,
-    weight_protein: float = 1.0,
-    weight_dna: float = 5.0,
-    weight_rna: float = 5.0,
-    weight_ligand: float = 10.0,
+    upweight_protein: float = 0.0,
+    upweight_dna: float = 5.0,
+    upweight_rna: float = 5.0,
+    upweight_ligand: float = 10.0,
 ) -> torch.Tensor:
     """Compute atom weights for loss calculation.
     See Section 3.7.1 Equation 4 of the AlphaFold 3 paper.
     """
-    is_protein = f_input.token.is_protein  # [B, Ltoken]
-    is_dna = f_input.token.is_dna  # [B, Ltoken]
-    is_rna = f_input.token.is_rna  # [B, Ltoken]
-    is_ligand = f_input.token.is_ligand  # [B, Ltoken]
-
-    token_weights = (
-        is_protein.float() * weight_protein
-        + is_dna.float() * weight_dna
-        + is_rna.float() * weight_rna
-        + is_ligand.float() * weight_ligand
-    )  # [B, Ltoken]
+    token_weights = compute_modality_weights(
+        f_input.token.is_protein,
+        f_input.token.is_dna,
+        f_input.token.is_rna,
+        f_input.token.is_ligand,
+        upweight_protein,
+        upweight_dna,
+        upweight_rna,
+        upweight_ligand,
+    )
     batch_indices = torch.arange(f_input.batch_size, device=f_input.device)[:, None]
     atom_weights = token_weights[batch_indices, f_input.atom.token_index]  # [B, Latom]
 
@@ -40,10 +61,10 @@ class WeightedMSELoss(torch.nn.Module):
 
     def __init__(
         self,
-        weight_protein: float = 1.0,
-        weight_dna: float = 5.0,
-        weight_rna: float = 5.0,
-        weight_ligand: float = 10.0,
+        upweight_protein: float = 0.0,
+        upweight_dna: float = 5.0,
+        upweight_rna: float = 5.0,
+        upweight_ligand: float = 10.0,
         scale: bool = False,
     ):
         """Initialize WeightedMSELoss.
@@ -64,10 +85,10 @@ class WeightedMSELoss(torch.nn.Module):
             NOTE: loss value is lower when scale=True.
         """
         super().__init__()
-        self.weight_protein: float = weight_protein
-        self.weight_dna: float = weight_dna
-        self.weight_rna: float = weight_rna
-        self.weight_ligand: float = weight_ligand
+        self.upweight_protein: float = upweight_protein
+        self.upweight_dna: float = upweight_dna
+        self.upweight_rna: float = upweight_rna
+        self.upweight_ligand: float = upweight_ligand
         self.scale: bool = scale
 
     def forward(
@@ -128,10 +149,10 @@ class WeightedMSELoss(torch.nn.Module):
         """
         return get_atom_weights(
             f_input,
-            weight_protein=self.weight_protein,
-            weight_dna=self.weight_dna,
-            weight_rna=self.weight_rna,
-            weight_ligand=self.weight_ligand,
+            upweight_protein=self.upweight_protein,
+            upweight_dna=self.upweight_dna,
+            upweight_rna=self.upweight_rna,
+            upweight_ligand=self.upweight_ligand,
         )
 
 

--- a/src/kfold/training/folding/metrics/structure.py
+++ b/src/kfold/training/folding/metrics/structure.py
@@ -3,7 +3,11 @@ from collections.abc import Sequence
 import torch
 
 from kfold.data.model_input import FoldingInput
-from kfold.training.folding.loss.diffusion import get_atom_weights, weighted_rigid_align
+from kfold.training.folding.loss.diffusion import (
+    compute_modality_weights,
+    get_atom_weights,
+    weighted_rigid_align,
+)
 from kfold.utils.misc import expand_dim
 
 
@@ -32,31 +36,82 @@ def compute_pair_lddt(
 
 
 def compute_rmsd(
-    coords_pred: torch.Tensor,
-    coords_true: torch.Tensor,
+    pred_coords: torch.Tensor,
+    true_coords: torch.Tensor,
     mask: torch.Tensor,
 ):
     """Compute the rmsd score from predicted and true distances.
 
     Parameters
     ----------
-    coords_pred : torch.Tensor
+    pred_coords : torch.Tensor
         Predicted atom coordinates, Shape of [Natom, 3]
-    coords_true : torch.Tensor
+    true_coords : torch.Tensor
         Ground truth atom coordinates, Shape of [Natom, 3]
     mask : torch.Tensor
         Boolean mask for resolved atoms, Shape of [Natom]
+    weights : torch.Tensor | None
+        Weights for each atom, Shape of [Natom]
 
     Returns
     -------
     torch.Tensor
         The rmsd score between predicted and true coordinates
     """
-    diff = ((coords_pred - coords_true) ** 2).sum(-1)
+    diff = ((pred_coords - true_coords) ** 2).sum(-1)
     masked_diff = diff * mask
     mse = masked_diff.sum() / mask.sum()
     rmsd = torch.sqrt(mse)
     return rmsd
+
+
+def compute_weighted_rmsd(
+    pred_coords: torch.Tensor,
+    true_coords: torch.Tensor,
+    mask: torch.Tensor,
+    weights: torch.Tensor | None = None,
+    scale: bool = True,
+):
+    """Compute the weighted mse score from predicted and true distances.
+
+    Parameters
+    ----------
+    pred_coords : torch.Tensor
+        Predicted atom coordinates, Shape of [Natom, 3]
+    true_coords : torch.Tensor
+        Ground truth atom coordinates, Shape of [Natom, 3]
+    mask : torch.Tensor
+        Boolean mask for resolved atoms, Shape of [Natom]
+    weights : torch.Tensor | None
+        Weights for each atom, Shape of [Natom]
+
+    Returns
+    -------
+    torch.Tensor
+        The rmsd score between predicted and true coordinates
+    """
+    if weights is None:
+        weights = mask.float()
+    else:
+        weights = weights * mask.float()
+
+    aligned_coords_true = weighted_rigid_align(
+        coords=true_coords.float(),  # [B, N, L, 3]
+        target=pred_coords.float(),  # [B, N, L, 3]
+        weights=weights,  # [B, 1, L], broadcasted over N
+        mask=mask,  # [B, 1, L]
+    )  # [B, N, L, 3]
+
+    d_sq = ((pred_coords - aligned_coords_true) ** 2).sum(dim=-1)  # [B, N, L]
+    if scale:
+        weight_sum = weights.sum(-1).clamp(min=1)  # [B, 1]
+        mse_loss = (weights * d_sq).sum(-1) / weight_sum  # [B, N]
+    else:
+        mask_sum = mask.sum(-1).clamp(min=1)  # [B, 1]
+        mse_loss = (weights * d_sq).sum(-1) / mask_sum  # [B, N]
+    weighted_rmsd = torch.sqrt(mse_loss)
+
+    return weighted_rmsd
 
 
 def compute_validation_metric_singles(
@@ -105,7 +160,19 @@ def compute_validation_metric_singles(
     rmsd = compute_rmsd(pred_coords, true_coords, atom_mask)
     metrics["rmsd"] = rmsd
     # TODO: to be discussed, should we weight by number of atoms?
-    weights["rmsd"] = atom_mask.sum()
+    # weights["rmsd"] = atom_mask.sum()
+    weights["rmsd"] = torch.tensor(
+        1.0, dtype=pred_coords.dtype, device=pred_coords.device
+    )
+
+    atom_weights = compute_modality_weights(is_protein, is_dna, is_rna, is_ligand)
+    weighted_rmsd = compute_weighted_rmsd(
+        pred_coords, true_coords, atom_mask, atom_weights
+    )
+    metrics["weighted_rmsd"] = weighted_rmsd
+    # TODO: to be discussed, should we weight by number of atoms?
+    # weights["rmsd"] = atom_mask.sum()
+    weights["weighted_rmsd"] = weights["rmsd"]
 
     # === Compute LDDT per modality === #
     modality_mask = {
@@ -238,6 +305,7 @@ def compute_validation_metrics(
 
     metric_keys = [
         ("rmsd", "min"),
+        ("weighted_rmsd", "min"),
         ("lddt", "max"),
         ("lddt_protein_protein", "max"),
         ("lddt_dna_protein", "max"),

--- a/src/kfold/training/folding/metrics/structure.py
+++ b/src/kfold/training/folding/metrics/structure.py
@@ -50,8 +50,6 @@ def compute_rmsd(
         Ground truth atom coordinates, Shape of [Natom, 3]
     mask : torch.Tensor
         Boolean mask for resolved atoms, Shape of [Natom]
-    weights : torch.Tensor | None
-        Weights for each atom, Shape of [Natom]
 
     Returns
     -------
@@ -165,6 +163,7 @@ def compute_validation_metric_singles(
         1.0, dtype=pred_coords.dtype, device=pred_coords.device
     )
 
+    # Use AF3-style weighted RMSD (default weights)
     atom_weights = compute_modality_weights(is_protein, is_dna, is_rna, is_ligand)
     weighted_rmsd = compute_weighted_rmsd(
         pred_coords, true_coords, atom_mask, atom_weights

--- a/src/kfold/training/folding/training_module.py
+++ b/src/kfold/training/folding/training_module.py
@@ -198,6 +198,8 @@ class KFoldTrainingModule(pl.LightningModule):
         # RMSD
         metrics["avg_rmsd"] = MeanMetric()
         metrics["rmsd"] = MeanMetric()
+        metrics["avg_weighted_rmsd"] = MeanMetric()
+        metrics["weighted_rmsd"] = MeanMetric()
 
         # LDDT
         for m in C.training.LDDTType:
@@ -434,12 +436,10 @@ class KFoldTrainingModule(pl.LightningModule):
         avg_values["avg_lddt"] = weighted_lddt  # type: ignore
 
         # NOTE: to match the boltz's metric naming, I swap the name
-        if "rmsd" in avg_values:
-            avg_values["rmsd"], avg_values["best_rmsd"] = (
-                avg_values["avg_rmsd"],
-                avg_values["rmsd"],
-            )
-            avg_values.pop("avg_rmsd")
+        for key in ["rmsd", "weighted_rmsd"]:
+            if key in avg_values:
+                v1, v2 = avg_values.pop(key), avg_values.pop(f"avg_{key}")
+                avg_values[key], avg_values[f"best_{key}"] = v2, v1
 
         avg_values = {f"val/{k}": v for k, v in avg_values.items()}
         self.log_dict(avg_values, sync_dist=True)

--- a/src/kfold/training/folding/training_module.py
+++ b/src/kfold/training/folding/training_module.py
@@ -193,20 +193,26 @@ class KFoldTrainingModule(pl.LightningModule):
 
     def setup_metrics(self):
         """Setup metrics for validation"""
-        metrics = {}
+        val_metrics = {}
 
         # RMSD
-        metrics["avg_rmsd"] = MeanMetric()
-        metrics["rmsd"] = MeanMetric()
-        metrics["avg_weighted_rmsd"] = MeanMetric()
-        metrics["weighted_rmsd"] = MeanMetric()
+        val_metrics["avg_rmsd"] = MeanMetric()
+        val_metrics["rmsd"] = MeanMetric()
+        val_metrics["avg_weighted_rmsd"] = MeanMetric()
+        val_metrics["weighted_rmsd"] = MeanMetric()
 
         # LDDT
         for m in C.training.LDDTType:
-            metrics[f"avg_lddt_{m.value}"] = MeanMetric()
-            metrics[f"lddt_{m.value}"] = MeanMetric()
-            metrics[f"complex_lddt_{m.value}"] = MeanMetric()
-        self.valid_metrics: dict[str, MeanMetric] = torch.nn.ModuleDict(metrics)  # type: ignore
+            val_metrics[f"avg_lddt_{m.value}"] = MeanMetric()
+            val_metrics[f"lddt_{m.value}"] = MeanMetric()
+            val_metrics[f"complex_lddt_{m.value}"] = MeanMetric()
+
+        self.metrics = torch.nn.ModuleDict(
+            {
+                "train_metrics": torch.nn.ModuleDict(),
+                "val_metrics": torch.nn.ModuleDict(val_metrics),
+            }
+        )
 
     def configure_optimizers(self):  # type: ignore
         config = self.optimizer_config
@@ -355,6 +361,8 @@ class KFoldTrainingModule(pl.LightningModule):
         batch_idx: int,
     ):
         # TODO: sample molecules and compute validation metrics
+        val_metrics: dict[str, MeanMetric] = self.metrics["val_metrics"]
+
         val_config = self.validation_config
         num_diffusion_samples = val_config.num_diffusion_samples
 
@@ -394,9 +402,9 @@ class KFoldTrainingModule(pl.LightningModule):
                 pred_coords=sample_coords,
                 atom_mask=atom_mask,
             )
-        for k in self.valid_metrics.keys():
+        for k in val_metrics.keys():
             v, w = metrics[k]
-            self.valid_metrics[k].update(v, w)
+            val_metrics[k].update(v, w)
 
         if val_config.save_structure_path is not None:
             save_dir = pathlib.Path(
@@ -409,9 +417,11 @@ class KFoldTrainingModule(pl.LightningModule):
 
     def on_validation_epoch_end(self):
         """Aggregate and log validation metrics at the end of the epoch."""
+        val_metrics: dict[str, MeanMetric] = self.metrics["val_metrics"]
+
         # Aggregate validation metrics
         avg_values: dict[str, torch.Tensor] = {}
-        for k, m in self.valid_metrics.items():
+        for k, m in val_metrics.items():
             v = m.compute()
             if v.isfinite().all():
                 # Ignore non-finite values (after sanity check)

--- a/src/kfold/utils/geometry/random_augment.py
+++ b/src/kfold/utils/geometry/random_augment.py
@@ -104,10 +104,10 @@ def do_centering(coords: ArrayT, mask: ArrayT, mask_to_zero: bool = True) -> Arr
 def center_random_augmentation(
     coords: ArrayT,
     mask: ArrayT,
-    s_trans: float = 1.0,
+    augmentation: bool = True,
     centering: bool = True,
-    random_rotate: bool = True,
     mask_to_zero: bool = True,
+    s_trans: float = 1.0,
     rng: np.random.Generator | torch.Generator | None = None,
 ) -> ArrayT:
     """Centering and Random Augmentation (NumPy/Torch version)
@@ -119,9 +119,9 @@ def center_random_augmentation(
         return _center_random_augmentation_npy(
             coords,
             mask,
-            s_trans,
             centering,
-            random_rotate,
+            augmentation,
+            s_trans,
             mask_to_zero,
             rng,
         )
@@ -131,9 +131,9 @@ def center_random_augmentation(
         return _center_random_augmentation_torch(
             coords,
             mask,
-            s_trans,
             centering,
-            random_rotate,
+            augmentation,
+            s_trans,
             mask_to_zero,
             rng,
         )
@@ -142,9 +142,9 @@ def center_random_augmentation(
 def _center_random_augmentation_npy(
     coords: np.ndarray,
     mask: np.ndarray,
-    s_trans: float = 1.0,
     centering: bool = True,
-    random_rotate: bool = True,
+    augmentation: bool = True,
+    s_trans: float = 1.0,
     mask_to_zero: bool = True,
     rng: np.random.Generator | None = None,
 ) -> np.ndarray:
@@ -153,28 +153,28 @@ def _center_random_augmentation_npy(
     """
     # Line 1
     if centering:
-        coords = do_centering(coords, mask)
+        coords = do_centering(coords, mask, mask_to_zero=False)
 
-    # Line 2,4
-    if random_rotate:
+    if augmentation:
+        # Line 2,4
         assert isinstance(rng, np.random.Generator | None)
         R = random_rotations_npy(
             coords.shape[:-2], dtype=np.float32, rng=rng
         )  # [..., 3, 3]
         coords = np.einsum("...md,...ds->...ms", coords, R)
 
-    # Line 3,4
-    if s_trans > 0.0:
-        # Create random translation with same shape as coords[..., 0:1, :]
-        trans_shape = list(coords.shape)
-        trans_shape[-2] = 1  # The 'L' dimension becomes 1 for broadcasting
+        # Line 3,4
+        if s_trans > 0.0:
+            # Create random translation with same shape as coords[..., 0:1, :]
+            trans_shape = list(coords.shape)
+            trans_shape[-2] = 1  # The 'L' dimension becomes 1 for broadcasting
 
-        if rng is None:
-            noise = np.random.randn(*trans_shape).astype(coords.dtype)
-        else:
-            noise = rng.normal(size=trans_shape).astype(coords.dtype)
-        random_trans = noise * s_trans
-        coords = coords + random_trans
+            if rng is None:
+                noise = np.random.randn(*trans_shape).astype(coords.dtype)
+            else:
+                noise = rng.normal(size=trans_shape).astype(coords.dtype)
+            random_trans = noise * s_trans
+            coords = coords + random_trans
 
     if mask_to_zero:
         coords = coords * mask[..., None]
@@ -185,9 +185,9 @@ def _center_random_augmentation_npy(
 def _center_random_augmentation_torch(
     coords: torch.Tensor,
     mask: torch.Tensor,
-    s_trans: float = 1.0,
     centering: bool = True,
-    random_rotate: bool = True,
+    augmentation: bool = True,
+    s_trans: float = 1.0,
     mask_to_zero: bool = True,
     rng: torch.Generator | None = None,
 ) -> torch.Tensor:
@@ -196,24 +196,24 @@ def _center_random_augmentation_torch(
     """
     # Line 1
     if centering:
-        coords = do_centering(coords, mask)
+        coords = do_centering(coords, mask, mask_to_zero=False)
 
     # Line 2,4
-    if random_rotate:
+    if augmentation:
         R = random_rotations_torch(
             coords.shape[:-2], coords.dtype, coords.device, rng=rng
         )  # [..., 3, 3]
         coords = torch.einsum("...md,...ds->...ms", coords, R)
 
-    # Line 3,4
-    if s_trans > 0.0:
-        noise = torch.randn(
-            coords[..., 0:1, :].shape,
-            dtype=coords.dtype,
-            device=coords.device,
-            generator=rng,
-        )
-        coords = coords + noise * s_trans
+        # Line 3,4
+        if s_trans > 0.0:
+            noise = torch.randn(
+                coords[..., 0:1, :].shape,
+                dtype=coords.dtype,
+                device=coords.device,
+                generator=rng,
+            )
+            coords = coords + noise * s_trans
 
     if mask_to_zero:
         coords = coords * mask[..., None]
@@ -238,8 +238,8 @@ def _copysign(a: ArrayT, b: ArrayT) -> ArrayT:
     if isinstance(a, np.ndarray):
         return np.copysign(a, b)
     else:
-        signs_differ = (a < 0) != (b < 0)
-        return torch.where(signs_differ, -a, a)
+        assert isinstance(b, torch.Tensor)
+        return torch.copysign(a, b)
 
 
 def random_rotations_npy(


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the structure-only training pipeline, focusing on loss weighting, coordinate augmentation, and distributed data sampling. The main changes include updating the loss weighting scheme to match AlphaFold3, refactoring coordinate augmentation logic for clarity and flexibility, and implementing a distributed weighted sampler for improved data loading in distributed training settings.

### Bugfixes
**Loss weighting updates (AlphaFold3 compatibility):**
* The loss configuration and implementation now use `upweight_*` parameters instead of `weight_*`, matching the AlphaFold3 modality weighting formula for proteins, DNA, RNA, and ligands.(protein:dna:rna:ligand = 1:5:5:10 -> 1:6:6:11)

**Distributed data sampling:**
* A new `DistributedWeightedSampler` is implemented and integrated into the training dataloader, replacing the previous `WeightedRandomSampler`. This enables correct weighted sampling in distributed training and ensures each replica receives a balanced subset of samples.

**Data weighting and normalization fixes:**
* Data weighting logic in cluster-based samplers is cleaned up, removing `ALLOW_NUC`

**Train.py fix (seed):**
* Ensure that each DDP process has different seed.

### Vulnerability fixes
**Coordinate augmentation refactor:**
* The coordinate augmentation pipeline is refactored to use clearer flags (`augmentation`, `mask_to_zero`) and improved centering logic. The augmentation and centering steps are now more explicit, and masking behavior is configurable. The `CenterRandomAugmentation` class and related functions are updated accordingly.