### PR TITLE
save config file with wandb logging

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,9 +4,10 @@ from pathlib import Path
 import lightning.pytorch as pl
 import lightning.pytorch.callbacks as pl_callbacks
 import torch
+from lightning.pytorch.utilities import rank_zero_only
 from omegaconf import DictConfig
 
-from kfold.config import load_config, print_config, to_dict
+from kfold.config import load_config, print_config, save_config, to_dict
 from kfold.training.folding.dataset.datamodule import TrainingDataModule
 from kfold.training.folding.training_module import KFoldTrainingModule
 
@@ -141,6 +142,15 @@ def build_trainer(cfg, debug_mode: str = "off") -> pl.Trainer:
             save_dir=save_dir,
         )
         loggers = [wandb_logger]
+
+        @rank_zero_only
+        def _save_config() -> None:
+            config_out = Path(wandb_logger.experiment.dir) / "config.yaml"
+            save_config(cfg, config_out)
+            wandb_logger.experiment.save(config_out.name)
+
+        _save_config()
+
     else:
         loggers = None  # use default logger
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -147,7 +147,7 @@ def build_trainer(cfg, debug_mode: str = "off") -> pl.Trainer:
         def _save_config() -> None:
             config_out = Path(wandb_logger.experiment.dir) / "config.yaml"
             save_config(cfg, config_out)
-            wandb_logger.experiment.save(config_out.name)
+            wandb_logger.experiment.save("config.yaml")
 
         _save_config()
 

--- a/src/kfold/config.py
+++ b/src/kfold/config.py
@@ -37,6 +37,11 @@ def print_config(config: DictConfig) -> None:
     print(OmegaConf.to_yaml(config))
 
 
+def save_config(config: DictConfig, save_path: str | Path) -> None:
+    """Print the configuration in a human-readable format."""
+    OmegaConf.save(config, save_path)
+
+
 def to_dict(config: DictConfig) -> dict:
     """Convert a DictConfig to a standard Python dictionary."""
     return OmegaConf.to_container(config, resolve=True)

--- a/src/kfold/config.py
+++ b/src/kfold/config.py
@@ -38,7 +38,7 @@ def print_config(config: DictConfig) -> None:
 
 
 def save_config(config: DictConfig, save_path: str | Path) -> None:
-    """Print the configuration in a human-readable format."""
+    """Save the configuration to a YAML file."""
     OmegaConf.save(config, save_path)
 
 


### PR DESCRIPTION
The config yaml file is not stored when we use WandbLogger. To address this issue, I modified the training scripts to save the config file used in training.