### PR TITLE
better train hparam control

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ See [`docs/TRAINING_GUIDE.md`](./docs/TRAINING_GUIDE.md) for detailed training i
 python ./scripts/train.py -h
 
 # Run first with debug mode
-python ./scripts/train.py --config ./configs/train-af3-mini.yaml --debug 'on'
+python ./scripts/train.py --config ./configs/train-af3-tiny.yaml --debug
 
-# If you want to skip validation (e.g., validation not implemented yet), use:
-python ./scripts/train.py --config ./configs/train-af3-mini.yaml --debug 'skip-val'
+# If you want to skip validation, use --skip_val
+python ./scripts/train.py --config ./configs/train-af3-tiny.yaml --debug --skip_val
 
 # If everything works well, run full training
 python ./scripts/train.py --config ./configs/train-af3.yaml --wandb --num_gpus ...

--- a/configs/train-af3-tiny.yaml
+++ b/configs/train-af3-tiny.yaml
@@ -15,26 +15,25 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 384
+    batch_size: 4
+    diffusion_batch_size: 48
+    global_batch_size: 256
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: bf16-mixed
-    max_epochs: 100
-    limit_train_batches: 1000
-    accumulate_grad_batches: 16 # 256 // batch_size // num_gpus
-
-  training:
-    diffusion_batch_size: 48
 
   data:
-    train_batch_size: 4
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 8 # less than 8
+    num_workers: 8
 
   wandb:
     use: false

--- a/configs/train-af3.yaml
+++ b/configs/train-af3.yaml
@@ -10,26 +10,25 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 384
+    batch_size: 2
+    diffusion_batch_size: 48
+    global_batch_size: 256
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: bf16-mixed
-    max_epochs: 100
-    limit_train_batches: 1000
-    accumulate_grad_batches: 16 # 256 // batch_size // num_gpus
-
-  training:
-    diffusion_batch_size: 48
 
   data:
-    train_batch_size: 2
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 4 # recommended value=4-8
+    num_workers: 4
 
   wandb:
     use: false

--- a/configs/train-boltz1-ddbm-pdbbind.yaml
+++ b/configs/train-boltz1-ddbm-pdbbind.yaml
@@ -10,34 +10,34 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 2
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: 32
-    max_epochs: 100
-    limit_train_batches: 1000
-    limit_val_batches: null # set 0 to skip validation
-    accumulate_grad_batches: 16 # 256 // batch_size // num_gpus
 
   training:
-    diffusion_batch_size: 48
-
     train_trunk: false
     train_distogram_head: false
     train_structure_module: true
     train_confidence_head: false
 
   data:
-    train_batch_size: 2
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /mnt/parallel_storage/wykim_lab/icl_shwan/data/manifests/pdbbind_pl_manifest.pkl
     split_path: ./assets/splits/equibind/
-    num_workers: 4 # set to batch_size * 2.
+    num_workers: 4
 
     featurization_args:
+      # NOTE: Set true to use pre-trained Boltz1 trunk
       synchronize_ref_pos_augmentation: true
 
   wandb:

--- a/configs/train-boltz1-ddbm.yaml
+++ b/configs/train-boltz1-ddbm.yaml
@@ -10,34 +10,34 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 2
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: 32
-    max_epochs: 100
-    limit_train_batches: 1000
-    limit_val_batches: null # No validation for now.
-    accumulate_grad_batches: 16
 
   training:
-    diffusion_batch_size: 48
-
     train_trunk: false
     train_distogram_head: false
     train_structure_module: true
     train_confidence_head: false
 
   data:
-    train_batch_size: 2
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 4 # set to batch_size * 4.
+    num_workers: 4
 
     featurization_args:
+      # NOTE: Set true to use pre-trained Boltz1 trunk
       synchronize_ref_pos_augmentation: true
 
   wandb:

--- a/configs/train-boltz1-full.yaml
+++ b/configs/train-boltz1-full.yaml
@@ -16,28 +16,28 @@ train:
   seed: 42
   synchronize_seed: false # Set false with synchronized_sigmas=true
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 1
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
-    devices: 8
+    devices: "auto"
     num_nodes: 1
     precision: 32
-    max_epochs: 100
-    limit_train_batches: 3000 # 3 hours
-    accumulate_grad_batches: 16
-
-  training:
-    diffusion_batch_size: 16
 
   data:
-    train_batch_size: 1
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
     num_workers: 4
 
     featurization_args:
+      # NOTE: Same to Boltz1
       synchronize_ref_pos_augmentation: true
 
   loss:

--- a/configs/train-esmc-ddbm-tiny.yaml
+++ b/configs/train-esmc-ddbm-tiny.yaml
@@ -17,26 +17,25 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 4
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: bf16-mixed
-    max_epochs: 100
-    limit_train_batches: 1000
-    accumulate_grad_batches: 4 # 128 // world_size // num_gpus
-
-  training:
-    diffusion_batch_size: 16
 
   data:
-    train_batch_size: 4
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 8 # batch * 2
+    num_workers: 8
 
     pretrained_embedding_paths:
       seq_embedding_path: /cache/wykim_lab/kfold_data/esm_embeddings/esmc_300m/

--- a/configs/train-esmc-edm-tiny.yaml
+++ b/configs/train-esmc-edm-tiny.yaml
@@ -17,26 +17,25 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 4
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: bf16-mixed
-    max_epochs: 100
-    limit_train_batches: 1000
-    accumulate_grad_batches: 4 # 128 // world_size // num_gpus
-
-  training:
-    diffusion_batch_size: 16
 
   data:
-    train_batch_size: 4
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 8 # batch * 2
+    num_workers: 8
 
     pretrained_embedding_paths:
       seq_embedding_path: /cache/wykim_lab/kfold_data/esm_embeddings/esmc_300m/

--- a/configs/train-esmc-edm.yaml
+++ b/configs/train-esmc-edm.yaml
@@ -12,26 +12,25 @@ train:
   out_dir: ./experiments/
   seed: 42
 
+  global_hparams:
+    max_tokens: 512
+    batch_size: 2
+    diffusion_batch_size: 16
+    global_batch_size: 128
+    num_global_steps_per_epoch: 250
+
   # pytorch lightning trainer hparams
   trainer:
     strategy: "auto"
     devices: "auto"
     num_nodes: 1
     precision: bf16-mixed
-    max_epochs: 100
-    limit_train_batches: 1000
-    accumulate_grad_batches: 16 # 256 // batch_size // num_gpus
-
-  training:
-    diffusion_batch_size: 48
 
   data:
-    train_batch_size: 2
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 4 # recommended value=4-8
+    num_workers: 8
 
     pretrained_embedding_paths:
       seq_embedding_path: /cache/wykim_lab/kfold_data/esm_embeddings/esmc_300m/

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -39,7 +39,7 @@ data:
   train_batch_size: ??? # set by global_hparam
   val_batch_size: 1
   num_workers: 8
-  max_tokens: 384
+  max_tokens: ??? # set by global_hparam
   pin_memory: true
   safe_load: true
 

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -1,12 +1,19 @@
 # Configuration for K-Fold structure module training
 
-# Training Configuration
 name: structure-only
 out_dir: ./experiments/
 
-# Random Seed
+# Reproducibility
 seed: 42
 synchronize_seed: true # Use the same seed across DDP processes
+
+# Training parameters for multi-gpu setup.
+global_hparams:
+  max_tokens: 512
+  batch_size: 1
+  diffusion_batch_size: 48
+  global_batch_size: 256
+  num_global_steps_per_epoch: 1000
 
 data:
   _registry_: "datamodule"
@@ -29,9 +36,9 @@ data:
     struct_embedding_dim: null
 
   # DataLoader
-  train_batch_size: 1
+  train_batch_size: ??? # set by global_hparam
   val_batch_size: 1
-  num_workers: 4
+  num_workers: 8
   max_tokens: 384
   pin_memory: true
   safe_load: true
@@ -75,18 +82,12 @@ trainer:
   num_nodes: "auto"
   precision: bf16-mixed
   max_epochs: -1
-  limit_train_batches: 100_000
+  limit_train_batches: ??? # set by global_hparam
   limit_val_batches: null
   log_every_n_steps: 1
   enable_checkpointing: true
-  accumulate_grad_batches: 256 # 256 // batch_size // num_gpus
+  accumulate_grad_batches: ??? # set by global_hparam
   gradient_clip_val: 10.0
-
-wandb:
-  use: false
-  project: "KFold"
-  group: null # set your group name
-  entity: null # set your entity name
 
 # Exponential Moving Average (EMA)
 training:
@@ -99,7 +100,7 @@ training:
   num_cycles: 4
 
   # For structure module training
-  diffusion_batch_size: 48
+  diffusion_batch_size: ??? # set by global_hparam
 
   # For confidence module training
   num_steps: 20 # Mini-diffusion rollout
@@ -167,3 +168,9 @@ loss:
   # Confidence loss
   # TODO
   confidence_loss: {}
+
+wandb:
+  use: false
+  project: "KFold"
+  group: null # set your group name
+  entity: null # set your entity name

--- a/configs/train/train_pdbbind.yaml
+++ b/configs/train/train_pdbbind.yaml
@@ -1,30 +1,14 @@
 # Configuration for K-Fold structure module training
 
-# Training Configuration
-name: train-pdbbind
-out_dir: ./experiments/
+_yaml_: "structure_only.yaml"
 
-# Random Seed
-seed: 42
-synchronize_seed: false # Use synchronized seed across DDP processes
+name: train-pdbbind
 
 data:
-  _registry_: "datamodule"
-  _class_: TrainingDataModule
-
   # Data paths
   lmdb_path: <LMDB_PATH_PLACEHOLDER>
   manifest_path: <MANIFEST_PATH_PLACEHOLDER>
   split_path: ./assets/splits/equibind/
-  overfit_val: false
-
-  # DataLoader
-  train_batch_size: 1
-  val_batch_size: 1
-  num_workers: 4
-  max_tokens: 384
-  pin_memory: true
-  safe_load: true
 
   filters:
     - _registry_: "data_filter"
@@ -47,110 +31,3 @@ data:
     beta_chain: 0.5
     beta_interface: 1.0
     allow_redundant: True # Same to Boltz1
-
-  # Featurizer configurations:
-  featurization_args:
-    augment_ref_pos: true
-    augment_apo: true
-    synchronize_ref_pos_augmentation: false
-
-# Lightning Trainer Configuration
-trainer:
-  accelerator: "auto"
-  strategy: "auto"
-  devices: "auto"
-  num_nodes: "auto"
-  precision: bf16-mixed
-  max_epochs: -1
-  limit_train_batches: 100_000
-  limit_val_batches: null
-  log_every_n_steps: 1
-  enable_checkpointing: true
-  accumulate_grad_batches: 256 # 256 // batch_size // num_gpus
-  gradient_clip_val: 10.0
-
-wandb:
-  use: false
-  project: "KFold"
-  group: null # set your group name
-  entity: null # set your entity name
-
-# Exponential Moving Average (EMA)
-training:
-  # Training step hyperparameters
-  train_trunk: true
-  train_distogram_head: true
-  train_structure_module: true
-  train_confidence_head: false
-
-  num_cycles: 4
-
-  # For structure module training
-  diffusion_batch_size: 48
-
-  # For confidence module training
-  num_steps: 20 # Mini-diffusion rollout
-  num_diffusion_samples: 1 # Number of diffusion samples for confidence training
-
-validation:
-  # Validation step hyperparameters
-  num_cycles: 4
-  num_steps: 200
-  num_diffusion_samples: 5
-  symmetry_correction: false # TODO: fix get_true_coordinates function to use symmetry correction
-  save_structure_path: null # if given, save structure
-
-optimizer:
-  opt: "adam"
-  beta_1: 0.9
-  beta_2: 0.95
-  eps: 1e-8
-  lr_scheduler: af3
-  base_lr: 0.0
-  max_lr: 0.0018
-  lr_warmup_no_steps: 1000
-  lr_start_decay_after_n_steps: 50000
-  lr_decay_every_n_steps: 50000
-  lr_decay_factor: 0.95
-  use_ema: true
-  ema_decay: 0.999
-
-loss:
-  weights:
-    # global loss weights
-    distogram: 3e-2
-    diffusion: 4.0
-    confidence: 1e-4
-    # diffusion loss weights
-    smooth_lddt: 1. # 0 for fine-tuning (See Section 5.2 for the AF3 paper)
-    bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
-    # confidence loss weights
-    pae: 0.0 # 1 for final stage training
-
-  # Distogram loss
-  distogram_loss:
-    num_bins: 64
-    min_dist: 2.0
-    max_dist: 22.0
-
-  # Diffusion loss
-  diffusion_loss:
-    # Weighted MSE Loss
-    mse_loss:
-      # NOTE: these are same to AlphaFold3:
-      # w = 1 + 5 * is_dna + 5 * is_rna + 10 * is_ligand
-      upweight_protein: 0.0
-      upweight_dna: 5.0
-      upweight_rna: 5.0
-      upweight_ligand: 10.0
-      scale: false
-
-    # Bond Loss
-    bond_loss: {}
-
-    # Smooth LDDT Loss
-    smooth_lddt_loss: {}
-
-  # Confidence loss
-  # TODO
-  confidence_loss: {}

--- a/configs/validate-boltz1-pretrained.yaml
+++ b/configs/validate-boltz1-pretrained.yaml
@@ -18,17 +18,13 @@ train:
     devices: "auto"
     num_nodes: 1
     precision: 32
-    max_epochs: 100
-    limit_train_batches: 3000
-    accumulate_grad_batches: 16
 
   data:
-    train_batch_size: 1
-    max_tokens: 512
     lmdb_path: /cache/wykim_lab/kfold_data1/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data1/manifests/af3_manifest.pkl
     split_path: ./assets/splits/boltz1
-    num_workers: 4
+    num_workers: 8
 
     featurization_args:
+      # NOTE: Set True to use pre-trained Boltz1
       synchronize_ref_pos_augmentation: true

--- a/docs/TRAINING_GUIDE.md
+++ b/docs/TRAINING_GUIDE.md
@@ -45,11 +45,18 @@ You can use this path as an argument for the training script directly and skip t
 export KFOLD_DATA_DIR=/cache/wykim_lab/kfold_data/
 
 cd $KFOLD_DATA_DIR
+# Copy LMDB dataset and manifests to your working directory
 cp -r --sparse always /mnt/parallel_storage/wykim_lab/icl_shwan/data/structures/kfold_rcsb_processed_v251120.lmdb ./
 cp -r /mnt/parallel_storage/wykim_lab/icl_shwan/data/manifests/ ./
-# (optional) ESM embeddings
-cp -r /mnt/parallel_storage/wykim_lab/icl_shwan/data/esm_embeddings.tar ./
-tar -xvf esm_embeddings.tar
+
+# (optional) ESM embeddings (esmc_300m(free) or esmc_600m(non-commercial))
+mkdir esm_embeddings/
+cd ./esm_embeddings
+cp -r /mnt/parallel_storage/wykim_lab/icl_shwan/data/esm_embeddings/esmc_300m.tar ./
+tar -xvf esmc_300m.tar
+cd ../
+
+# Set permissions for other users in the group to read, write, and execute
 chmod 775 -R .
 ```
 
@@ -154,10 +161,10 @@ Modify `config file` to match your training environment.
 
 - Debug mode (single GPU, no workers, no safe data-loading):
   ```bash
-  python scripts/train.py --config ./configs/train-af3-tiny.yaml --debug on
+  python scripts/train.py --config ./configs/train-af3-tiny.yaml --debug
 
-  # Use skip-val when validation is not implemented yet.
-  python scripts/train.py --config ./configs/train-af3-tiny.yaml --debug skip-val
+  # If you want to skip validation (e.g., validation not implemented yet), use --skip_val
+  python ./scripts/train.py --config ./configs/train-af3-tiny.yaml --debug --skip_val
   ```
 
 - Full training mode with prepared config file:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -47,9 +47,14 @@ def parse_args() -> argparse.Namespace:
         help="Batch size for training",
     )
     parser.add_argument(
-        "--accumulate_grad_batches",
+        "--global_batch_size",
         type=int,
-        help="Number of batches for gradient accumulation.",
+        help="Global batch size for training across all GPUs.",
+    )
+    parser.add_argument(
+        "--num_steps_per_epoch",
+        type=int,
+        help="Number of training steps per epoch.",
     )
     parser.add_argument(
         "--num_workers",
@@ -68,10 +73,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--debug",
-        type=str,
-        choices=["off", "on", "default", "skip-val"],
-        default="off",
+        action="store_true",
         help="Enable debug mode",
+    )
+    parser.add_argument(
+        "--skip_val",
+        action="store_true",
+        help="Skip validation steps",
     )
     parser.add_argument(
         "--override",
@@ -95,15 +103,52 @@ def parse_config(args) -> DictConfig:
     if args.num_nodes is not None:
         cfg.train.trainer.num_nodes = args.num_nodes
     if args.batch_size is not None:
-        cfg.train.data.train_batch_size = args.batch_size
-    if args.accumulate_grad_batches is not None:
-        cfg.train.trainer.accumulate_grad_batches = args.accumulate_grad_batches
+        cfg.train.global_hparams.batch_size = args.batch_size
+    if args.global_batch_size is not None:
+        cfg.train.global_hparams.global_batch_size = args.global_batch_size
+    if args.num_steps_per_epoch is not None:
+        cfg.train.global_hparams.num_global_steps_per_epoch = args.num_steps_per_epoch
     if args.num_workers is not None:
         cfg.train.data.num_workers = args.num_workers
     if args.wandb:
         cfg.train.wandb.use = True
 
-    if args.debug != "off":
+    # Compute parameters dependent on global_hparams
+    train_cfg = cfg.train
+    global_hparams = train_cfg.global_hparams
+
+    train_cfg.data.max_tokens = global_hparams.max_tokens
+    train_cfg.data.train_batch_size = global_hparams.batch_size
+    train_cfg.training.diffusion_batch_size = global_hparams.diffusion_batch_size
+
+    # compute accumulate_grad_batches
+    if train_cfg.trainer.devices == "auto":
+        num_gpus = torch.cuda.device_count()
+    else:
+        num_gpus = train_cfg.trainer.devices
+    assert isinstance(num_gpus, int), "num_gpus should be an integer or 'auto'."
+    assert num_gpus > 0, "No GPUs available for training."
+
+    world_size = train_cfg.trainer.num_nodes * num_gpus
+    batch_size = global_hparams.batch_size
+    if global_hparams.global_batch_size % (batch_size * world_size) != 0:
+        raise ValueError(
+            f"Global batch size {global_hparams.global_batch_size} is not "
+            f"divisible by (batch_size {batch_size} * world_size {world_size})"
+        )
+    train_cfg.trainer.accumulate_grad_batches = global_hparams.global_batch_size // (
+        batch_size * world_size
+    )
+    # compute limit_train_batches
+    train_cfg.trainer.limit_train_batches = (
+        global_hparams.num_global_steps_per_epoch
+        * train_cfg.trainer.accumulate_grad_batches
+    )
+    # Remove global_hparams from cfg after overrides
+    del cfg.train.global_hparams
+
+    if args.debug:
+        # Enable debug mode settings
         print("Debug mode is enabled: Single GPU, 0 workers, no wandb.")
         cfg.train.trainer.devices = 1
         cfg.train.trainer.num_nodes = 1
@@ -116,10 +161,11 @@ def parse_config(args) -> DictConfig:
         cfg.train.data.safe_load = False
         cfg.train.wandb.use = False
 
-        if args.debug == "skip-val":
-            # Skip validation steps, use when validation process is not yet ready
-            cfg.train.trainer.num_sanity_val_steps = 0
-            cfg.train.trainer.limit_val_batches = 0
+    if args.skip_val:
+        # Skip validation steps, use when validation process is not yet ready
+        print("Skipping validation steps.")
+        cfg.train.trainer.num_sanity_val_steps = 0
+        cfg.train.trainer.limit_val_batches = 0
 
     return cfg
 


### PR DESCRIPTION
This pull request refactors the training configuration system to centralize global hyperparameters and streamline configuration files. It introduces a new `global_hparams` section in all major config files, removes duplicated and hardcoded parameters, and updates documentation and CLI arguments for clarity and usability. The changes make it easier to manage batch sizes, token limits, and training steps across different training setups, and improve the debug and validation workflow.

**Configuration refactoring and centralization:**

* Added a `global_hparams` section to all major training config files (e.g., `train-af3-tiny.yaml`, `train-af3.yaml`, `train-boltz1-ddbm.yaml`, `train-boltz1-full.yaml`, `train-esmc-edm.yaml`, etc.), consolidating key hyperparameters like `max_tokens`, `batch_size`, `diffusion_batch_size`, `global_batch_size`, and `num_global_steps_per_epoch`. This removes redundancy and ensures consistency across configs.

* Updated config files to remove hardcoded values for batch sizes, token limits, and gradient accumulation, replacing them with references to `global_hparams` or placeholders (e.g., `???`). 

**Documentation and usage improvements:**

* Revised documentation in `README.md` and `docs/TRAINING_GUIDE.md` to reflect new usage patterns, including updated debug/validation flags and instructions for preparing ESM embeddings.

**CLI and argument changes:**

* Changed CLI arguments in `scripts/train.py` to match new config structure: replaced `--accumulate_grad_batches` with `--global_batch_size`, added `--num_steps_per_epoch`, and changed `--debug` to a boolean flag. Added a new `--skip_val` flag for skipping validation steps.

**Config inheritance and simplification:**

* Refactored `train_pdbbind.yaml` to inherit from `structure_only.yaml` using the `_yaml_` key, removing duplicated configuration blocks and centralizing settings. 

**Miscellaneous improvements:**

* Improved comments and notes in config files to clarify usage, recommended values, and options for pre-trained model components.

Let me know if you'd like to see how to use the new `global_hparams` section in your workflow, or if you want an example of how to override these parameters for a specific training run!