### PR TITLE
random sampling of holo/apo during featurization

### DIFF
--- a/docs/DATA_STRUCTURE.md
+++ b/docs/DATA_STRUCTURE.md
@@ -158,9 +158,9 @@ ref_pos = atom_layout.ref_pos  # Shape: (Natom, 3)
 | `atom_to_token` | $^2$ | `(Natom, Ntoken)` vs `(Natom,)` | Mapping from atom to token (one-hot vs integer) |
 | `atom_pad_masks` | `pad_mask` | `(Natom,)` | Mask for valid atoms or padding |
 | `atom_resolved_mask` | `resolved_mask` | `(Natom,)` | Mask for resolved atoms |
-| `coords` | `label_coords` | `(Nholo, Natom, 3)` vs `(Natom, Nholo, 3)` | Target coordinates for training $^3$ |
-| - | `apo_coords` | `(Natom, Napo, 3)` | Apo structure coordinates |
-| - | `apo_mask` | `(Natom, Napo)` | Apo structure mask |
+| `coords` | `label_coords` | `(Nholo, Natom, 3)` vs `(Natom, 3)` | Target coordinates for training $^3$ |
+| - | `apo_coords` | `(Natom, 3)` | Apo structure coordinates |
+| - | `apo_mask` | `(Natom,)` | Apo structure mask |
 
 > $^1$ **Note:** In K-Fold, we are considering replacing `ref_pos` with `apo_coords`.
 > $^2$ **Note:** `atom_to_token` in Boltz can be accessed via `FoldingInput` instead of `AtomLayout`: `model_input.atom_to_token`.

--- a/src/kfold/data/featurize.py
+++ b/src/kfold/data/featurize.py
@@ -77,9 +77,9 @@ def do_augment_apo_structure(
     Parameters
     ----------
     apo_coords : np.ndarray
-        Apo structure coordinates of shape [Napo, Natom, 3].
+        Apo structure coordinates of shape [Natom, 3].
     mask : np.ndarray
-        Mask indicating valid atoms of shape [Napo, Natom].
+        Mask indicating valid atoms of shape [Natom].
     chain_sizes : np.ndarray
         Array of number of atoms per each chain.
     rng : np.random.Generator | None
@@ -88,17 +88,17 @@ def do_augment_apo_structure(
     Returns
     -------
     augmented_apo_coords : np.ndarray
-        Augmented apo structure coordinates of shape [Napo, Natom, 3].
+        Augmented apo structure coordinates of shape [Natom, 3].
     """
     # Apply random rotation and translation per apo coords
     new_coords = np.zeros_like(apo_coords)
     start_idx = 0
     for natom in chain_sizes:
         end_idx = start_idx + natom
-        new_coords[:, start_idx:end_idx] = center_random_augmentation(
-            apo_coords[:, start_idx:end_idx],  # =apo_chain_coords
-            mask[:, start_idx:end_idx],  # =apo_chain_mask
-            rng=rng,
+        chain_coords = apo_coords[start_idx:end_idx]
+        chain_mask = mask[start_idx:end_idx]
+        new_coords[start_idx:end_idx] = center_random_augmentation(
+            chain_coords, chain_mask, rng=rng
         )
         start_idx = end_idx
     return new_coords
@@ -179,17 +179,20 @@ def featurize_structure(
         k: cast(v)[atom_to_token, atom_in_token_idx]  # Fancy indexing - no loop!
         for k, v in atom_data.to_dict().items()
     }
-    atom_dict["label_coords"] = atom_dict.pop("coords")  # Rename for clarity
     atom_dict["token_index"] = atom_to_token
     atom_dict["pad_mask"] = np.ones((num_total_atoms,), dtype=np.bool_)  # Remove padding
 
+    # Random sample the ground truth holo coords if multiple holo coords are given.
+    # [Natom, Nholo, 3] -> [Natom, 3]
+    label_coords = atom_dict.pop("coords")  # Rename for clarity
+    n_holo = label_coords.shape[-2]
+    assert n_holo == 1, "Currently only single holo coordinate is supported."
+    sampled_idx = rng and rng.integers(0, n_holo) or np.random.randint(0, n_holo)
+    label_coords = label_coords[:, sampled_idx, :]
+
     # Centering the ground truth coords
-    # [Natom, Nholo, 3] -> [Nholo, Natom, 3] -> [Natom, Nholo, 3]
-    atom_dict["label_coords"] = do_centering(
-        atom_dict["label_coords"].transpose(1, 0, 2),
-        atom_dict["resolved_mask"].reshape(1, -1),
-        mask_to_zero=True,
-    ).transpose(1, 0, 2)
+    label_coords = do_centering(label_coords, atom_dict["resolved_mask"])
+    atom_dict["label_coords"] = label_coords
 
     # === Bond-level features ===
     num_bonds = bond_data.length
@@ -241,12 +244,8 @@ def featurize_structure(
 
     # add disto/center coords
     # HACK: we assume there is only one holo coordinate set.
-    token_dict["disto_coords"] = atom_dict["label_coords"][:, 0][
-        token_dict["disto_index"]
-    ]
-    token_dict["center_coords"] = atom_dict["label_coords"][:, 0][
-        token_dict["center_index"]
-    ]
+    token_dict["disto_coords"] = atom_dict["label_coords"][token_dict["disto_index"]]
+    token_dict["center_coords"] = atom_dict["label_coords"][token_dict["center_index"]]
 
     # Masks indicating whether the center/disto atoms are resolved
     token_dict["resolved_mask"] = (
@@ -296,23 +295,27 @@ def featurize_structure(
             rng=rng,
         )
 
-    # TODO: if we use multiple apo structures, randomly sample one apo structure here.
     # TODO: If we use CCD, use random ETKDG conformers here.
+    # [Natom, Napo, 3] -> [Natom, 3]
+    apo_coords = atom_dict.pop("apo_coords")
+    apo_mask = atom_dict.pop("apo_mask")
+    n_apo = apo_coords.shape[-2]
+    assert n_apo == 1, "Currently only single apo coordinate is supported."
+    sampled_idx = rng and rng.integers(0, n_holo) or np.random.randint(0, n_holo)
+    apo_coords = apo_coords[:, sampled_idx, :]
+    apo_mask = apo_mask[:, sampled_idx]
     if augment_apo:
+        # Augment apo structure (chain-wise)
         num_atoms_per_chains = chain_dict["num_atoms"]
-        # [Natom, Napo, 3] -> [Napo, Natom, 3] -> [Natom, Napo, 3]
-        atom_dict["apo_coords"] = do_augment_apo_structure(
-            apo_coords=atom_dict["apo_coords"].transpose(1, 0, 2),
-            mask=atom_dict["apo_mask"].transpose(1, 0),
+        apo_coords = do_augment_apo_structure(
+            apo_coords=apo_coords,
+            mask=apo_mask,
             chain_sizes=num_atoms_per_chains,
             rng=rng,
-        ).transpose(1, 0, 2)
-    else:
-        # [Natom, Napo, 3] -> [Napo, Natom, 3] -> [Natom, Napo, 3]
-        atom_dict["apo_coords"] = do_centering(
-            atom_dict["apo_coords"].transpose(1, 0, 2),
-            atom_dict["apo_mask"].transpose(1, 0),
-        ).transpose(1, 0, 2)
+        )
+    apo_coords = do_centering(apo_coords, apo_mask)
+    atom_dict["apo_coords"] = apo_coords
+    atom_dict["apo_mask"] = apo_mask
 
     # === Bond-level features ===
 

--- a/src/kfold/data/featurize.py
+++ b/src/kfold/data/featurize.py
@@ -187,7 +187,7 @@ def featurize_structure(
     label_coords = atom_dict.pop("coords")  # Rename for clarity
     n_holo = label_coords.shape[-2]
     assert n_holo == 1, "Currently only single holo coordinate is supported."
-    sampled_idx = rng and rng.integers(0, n_holo) or np.random.randint(0, n_holo)
+    sampled_idx = rng.integers(0, n_holo) if rng else np.random.randint(0, n_holo)
     label_coords = label_coords[:, sampled_idx, :]
 
     # Centering the ground truth coords
@@ -301,7 +301,7 @@ def featurize_structure(
     apo_mask = atom_dict.pop("apo_mask")
     n_apo = apo_coords.shape[-2]
     assert n_apo == 1, "Currently only single apo coordinate is supported."
-    sampled_idx = rng and rng.integers(0, n_holo) or np.random.randint(0, n_holo)
+    sampled_idx = rng.integers(0, n_apo) if rng else np.random.randint(0, n_apo)
     apo_coords = apo_coords[:, sampled_idx, :]
     apo_mask = apo_mask[:, sampled_idx]
     if augment_apo:

--- a/src/kfold/data/model_input.py
+++ b/src/kfold/data/model_input.py
@@ -349,8 +349,7 @@ class AtomLayout(TensorLayout):
     token_index: torch.Tensor (long)
         Token indices mapping atoms to their parent tokens of shape [Natom,].
     apo_coords: torch.Tensor (float32)
-        Apo (unbound) state coordinates of shape [Natom, Napo, 3],
-        where Napo is the number of apo conformations.
+        Apo (unbound) state coordinates of shape [Natom, 3],
     resolved_mask: torch.Tensor (bool)
         Boolean mask of shape [Natom,] indicating atoms to be resolved.
     apo_mask: torch.Tensor (bool)
@@ -358,8 +357,7 @@ class AtomLayout(TensorLayout):
     pad_mask: torch.Tensor (bool)
         Boolean mask of shape [Natom,] indicating valid (non-padded) atoms.
     label_coords: torch.Tensor (float32)
-        Holo (bound) state coordinates of shape [Natom, Nholo, 3],
-        where Nholo is the number of ensemble holo conformations.
+        Holo (bound) state coordinates of shape [Natom, 3],
         This is used as the ground truth for training, and may be set to 0
         for inference.
     """
@@ -367,13 +365,13 @@ class AtomLayout(TensorLayout):
     ref_atom_name_chars: torch.Tensor  # [Natom, 4, 64], float32
     ref_element: torch.Tensor  # [Natom, 128], float32
     ref_charge: torch.Tensor  # [Natom,], float32
-    ref_pos: torch.Tensor  # [Natom, Nholo, 3], float32
+    ref_pos: torch.Tensor  # [Natom, 3], float32
     ref_space_uid: torch.Tensor  # [Natom,], long
     token_index: torch.Tensor  # [Natom,], long
-    label_coords: torch.Tensor  # [Natom, Nholo, 3], float32
-    apo_coords: torch.Tensor  # [Natom, Napo, 3], float32
+    label_coords: torch.Tensor  # [Natom, 3], float32
+    apo_coords: torch.Tensor  # [Natom, 3], float32
     resolved_mask: torch.Tensor  # [Natom,], bool
-    apo_mask: torch.Tensor  # [Natom, Napo], bool
+    apo_mask: torch.Tensor  # [Natom,], bool
     pad_mask: torch.Tensor  # [Natom,], bool
 
     @property
@@ -406,15 +404,15 @@ class AtomLayout(TensorLayout):
             self.label_coords,
             name="label_coords",
             dtype=torch.float32,
-            shape=(*shape, -1, 3),
+            shape=(*shape, 3),
         )
         check_tensor(
-            self.apo_coords, name="apo_coords", dtype=torch.float32, shape=(*shape, -1, 3)
+            self.apo_coords, name="apo_coords", dtype=torch.float32, shape=(*shape, 3)
         )
         check_tensor(
             self.resolved_mask, name="resolved_mask", dtype=torch.bool, shape=shape
         )
-        check_tensor(self.apo_mask, name="apo_mask", dtype=torch.bool, shape=(*shape, -1))
+        check_tensor(self.apo_mask, name="apo_mask", dtype=torch.bool, shape=shape)
         check_tensor(self.pad_mask, name="pad_mask", dtype=torch.bool, shape=shape)
 
     def pad(self, *pad_shape: int) -> Self:

--- a/src/kfold/model/modules/structure_module/af3_edm.py
+++ b/src/kfold/model/modules/structure_module/af3_edm.py
@@ -6,8 +6,8 @@ import torch
 import torch.nn.functional as F
 
 from kfold.data.model_input import FoldingInput
-from kfold.model.layers.alphafold3.utils import CenterRandomAugmentation
 from kfold.model.modules.score_model.base import BaseScoreModel
+from kfold.utils.geometry.random_augment import CenterRandomAugmentation
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
 from .base import BaseStructureModule
@@ -89,6 +89,12 @@ class AF3SampleDiffusion(BaseStructureModule):
             augmentation=self.coordinate_augmentation,
             s_trans=1.0,  # not used when augmentation is False
         )
+
+    def apply_random_augmentation(
+        self, coords: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply random augmentation to coordinates."""
+        return self.random_augmentation(coords, mask=mask)
 
     # === EDM diffusion coefficients === #
     def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:
@@ -217,25 +223,6 @@ class AF3SampleDiffusion(BaseStructureModule):
             # use different sigmas for each diffusion sample
             return _sample(batch_size, num_diffusion_samples)
 
-    def sample_holo(
-        self,
-        f_input: FoldingInput,
-        num_diffusion_samples: int = 1,
-    ) -> torch.Tensor:
-        """Sample from the prior distribution."""
-        holo_coords = super().sample_holo(
-            f_input, num_diffusion_samples
-        )  # [B, N, Latom, 3]
-        atom_mask = f_input.atom.resolved_mask.float()  # (B, Latom)
-
-        # Apply coordinate augmentation
-        holo_coords = self.random_augmentation(
-            holo_coords,
-            mask=atom_mask.unsqueeze(1),  # (B, 1, Latom)
-        )
-
-        return holo_coords
-
     def interpolate(
         self,
         noise_coords: torch.Tensor,
@@ -302,7 +289,7 @@ class AF3SampleDiffusion(BaseStructureModule):
 
         # NOTE: for sampling, there is no unresolved atoms.
         # Therefore, we can use pad_mask here.
-        atom_mask = f_input.atom.pad_mask.float().unsqueeze(1)  # (B, 1, Latom)
+        atom_mask = f_input.atom.pad_mask.unsqueeze(1)  # (B, 1, Latom)
 
         # Line 1
         init_sigma = sigmas[0]

--- a/src/kfold/model/modules/structure_module/base.py
+++ b/src/kfold/model/modules/structure_module/base.py
@@ -4,7 +4,8 @@ import torch
 
 from kfold.data.model_input import FoldingInput
 from kfold.model.modules.score_model import BaseScoreModel
-from kfold.utils.geometry.random_augment import center_random_augmentation
+from kfold.utils.geometry.random_augment import do_centering
+from kfold.utils.misc import repeat_dim
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
 
@@ -74,6 +75,46 @@ class BaseStructureModule(ABC):
     ) -> torch.Tensor:
         """Get the noise schedule for diffusion sampling."""
 
+    def apply_random_augmentation(
+        self, coords: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply random augmentation to coordinates.
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            Coordinates. Shape (*, L, 3).
+        mask : torch.Tensor
+            Mask. Shape (*, L).
+
+        Returns
+        -------
+        augmented_coords : torch.Tensor
+            Augmented Coordinates. Shape (*, La, 3).
+        """
+        # Default: simple centering without augmentation
+        coords = do_centering(coords, mask, mask_to_zero=True)
+        return coords
+
+    def sample_label(
+        self, f_input: FoldingInput, num_diffusion_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample label coordinates from input features.
+        Return shape: [B, N, La, 3], where N is number of diffusion samples
+        and La is number of atoms.
+
+        Parameters
+        -----------
+        f_input: FoldingInput
+            Input features
+        """
+        # if the model is equivariance, skip augment
+        random_augment = True
+
+        holo_coords = self.sample_holo(f_input, num_diffusion_samples, random_augment)
+
+        return holo_coords
+
     def sample_prior(
         self,
         f_input: FoldingInput,
@@ -94,7 +135,6 @@ class BaseStructureModule(ABC):
             Label coordinates. Shape: [B, N, La, 3]
             where N is the number of diffusion samples
         """
-
         # if the model is equivariance, skip augment
         random_augment = True
 
@@ -167,6 +207,45 @@ class BaseStructureModule(ABC):
             Denoised atom coordinates. Shape (B, N, Lt, 3).
         """
 
+    # === Sampling holo/apo structures === #
+    def sample_holo(
+        self,
+        f_input: FoldingInput,
+        num_diffusion_samples: int = 1,
+        random_augment: bool = True,
+    ) -> torch.Tensor:
+        """Sample holo structures from input for model training.
+
+        Parameters
+        ----------
+        f_input : FoldingInput
+            FoldingInput object containing model inputs.
+        num_diffusion_samples : int, optional
+            Number of diffusion samples to generate, by default 1.
+        random_augment: bool
+            Whether to apply random augmentation to holo coordinates.
+
+        Returns
+        -------
+        holo_coords : torch.Tensor
+            Sampled holo coordinates. Shape (B, N, L, 3),
+            where N is number of diffusion samples and L is the number of atoms.
+        """
+        holo_coords = f_input.atom.label_coords  # [B, L, 3]
+        atom_mask = f_input.atom.resolved_mask  # [B, L]
+
+        # repeat holo coords
+        holo_coords = repeat_dim(
+            holo_coords, num_diffusion_samples, dim=-3
+        )  # [B, N, L, 3]
+        atom_mask = atom_mask.unsqueeze(-2)  # [B, 1, L]
+
+        # Apply coordinate augmentation or centering
+        if random_augment:
+            holo_coords = self.apply_random_augmentation(holo_coords, atom_mask)
+
+        return holo_coords  # [B, N, L, 3]
+
     def sample_apo(
         self,
         f_input: FoldingInput,
@@ -193,31 +272,19 @@ class BaseStructureModule(ABC):
             where N is number of diffusion samples and L is the number of atoms.
         """
 
-        all_apo_coords = f_input.atom.apo_coords  # [B, L, Napo, 3]
-        all_apo_coords = all_apo_coords.permute(
-            0, 2, 1, 3
-        ).contiguous()  # [B, Napo, L, 3]
-        all_apo_mask = f_input.atom.apo_mask  # [B, L, Napo, 3]
-        all_apo_mask = all_apo_mask.permute(0, 2, 1).contiguous()  # [B, Napo, L]
+        apo_coords = f_input.atom.apo_coords  # [B, L, 3]
+        apo_mask = f_input.atom.apo_mask  # [B, L]
 
-        B, Napo, L = all_apo_mask.shape  # noqa
-        assert Napo == 1
         # TODO(SeonghwanSeo): Currently only supports a single apo structure (Napo == 1).
         # Update this code to support multiple apo structures in the future.
-        sampled_apo_coords = all_apo_coords.repeat(1, num_diffusion_samples, 1, 1)
-        sampled_apo_mask = all_apo_mask.repeat(1, num_diffusion_samples, 1)
+        apo_coords = repeat_dim(apo_coords, num_diffusion_samples, dim=-3)  # [B, N, L, 3]
+        apo_mask = apo_mask.unsqueeze(-2)  # [B, 1, L]
 
+        # Apply coordinate augmentation or centering
         if random_augment:
-            sampled_apo_coords = center_random_augmentation(
-                sampled_apo_coords,
-                sampled_apo_mask,
-                s_trans=0.0,  # Keep center to zero.
-            )
+            apo_coords = self.apply_random_augmentation(apo_coords, apo_mask)
 
-        # Mask out to zero
-        sampled_apo_coords = sampled_apo_coords * sampled_apo_mask[..., None]
-
-        return sampled_apo_coords  # [B, N, L, 3]
+        return apo_coords  # [B, N, L, 3]
 
     # === For model training === #
     def training_step(
@@ -241,14 +308,17 @@ class BaseStructureModule(ABC):
                 batch_size, num_diffusion_samples, device=f_input.device
             )  # [B, N]
 
-            # sample xt from label (Currently, there is only one holo structure per input)
-            holo_coords = self.sample_holo(f_input, num_diffusion_samples)
+            # sample xT from label
+            label_coords = self.sample_label(f_input, num_diffusion_samples)
+            label_coords = label_coords * mask[..., None, :, None]
 
             # sample x0 from prior
-            prior_coords = self.sample_prior(f_input, num_diffusion_samples, holo_coords)
+            prior_coords = self.sample_prior(f_input, num_diffusion_samples, label_coords)
+            prior_coords = prior_coords * mask[..., None, :, None]
 
-            noised_atom_coords = self.interpolate(prior_coords, holo_coords, t_hat, mask)
-            noised_atom_coords = noised_atom_coords * mask[:, None, :, None]
+            # sample xt via interpolation
+            noised_atom_coords = self.interpolate(prior_coords, label_coords, t_hat, mask)
+            noised_atom_coords = noised_atom_coords * mask[..., None, :, None]
 
         denoised_atom_coords = self.forward_model(
             x_noisy=noised_atom_coords,  # [B, N, La, 3]
@@ -269,7 +339,7 @@ class BaseStructureModule(ABC):
             "prior_atom_coords": prior_coords,
             "noised_atom_coords": noised_atom_coords,
             "denoised_atom_coords": denoised_atom_coords,
-            "true_atom_coords": holo_coords,
+            "true_atom_coords": label_coords,
         }
 
     @abstractmethod
@@ -277,44 +347,3 @@ class BaseStructureModule(ABC):
         """Compute loss weights based on noise levels t_hat.
         See Section 3.7.1 Equation 6 of AlphaFold3 paper.
         """
-
-    def sample_holo(
-        self, f_input: FoldingInput, num_diffusion_samples: int = 1
-    ) -> torch.Tensor:
-        """Sample holo structures from input for model training.
-
-        Parameters
-        ----------
-        f_input : FoldingInput
-            FoldingInput object containing model inputs.
-        num_diffusion_samples : int, optional
-            Number of diffusion samples to generate, by default 1.
-
-        Returns
-        -------
-        holo_coords : torch.Tensor
-            Sampled holo coordinates. Shape (B, N, L, 3),
-            where N is number of diffusion samples and L is the number of atoms.
-        """
-
-        holo_coords = f_input.atom.label_coords  # [B, L, Nholo, 3]
-        holo_coords = holo_coords.permute(0, 2, 1, 3)  # [B, Nholo, L, 3]
-        Nholo = holo_coords.shape[1]
-        if Nholo != 1:
-            raise NotImplementedError(
-                "Multiple holo structures per input not supported yet."
-            )
-
-        if Nholo == 1:
-            # repeat holo coords
-            holo_coords = holo_coords.repeat(1, num_diffusion_samples, 1, 1)
-        else:
-            # sample holo indices
-            raise NotImplementedError("sample not implemented")
-
-        # Mask out unresolved atoms
-        atom_mask = f_input.atom.resolved_mask  # (B, Latom)
-        atom_mask = atom_mask.to(holo_coords.dtype)[:, None, :, None]
-        holo_coords = holo_coords * atom_mask
-
-        return holo_coords  # [B, N, L, 3]

--- a/src/kfold/model/modules/structure_module/boltz1_edm.py
+++ b/src/kfold/model/modules/structure_module/boltz1_edm.py
@@ -6,8 +6,8 @@ import torch
 import torch.nn.functional as F
 
 from kfold.data.model_input import FoldingInput
-from kfold.model.layers.alphafold3.utils import CenterRandomAugmentation
 from kfold.model.modules.score_model.base import BaseScoreModel
+from kfold.utils.geometry.random_augment import CenterRandomAugmentation
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
 from .base import BaseStructureModule
@@ -87,6 +87,12 @@ class Boltz1SampleDiffusion(BaseStructureModule):
             augmentation=self.coordinate_augmentation,
             s_trans=1.0,  # not used when augmentation is False
         )
+
+    def apply_random_augmentation(
+        self, coords: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply random augmentation to coordinates."""
+        return self.random_augmentation(coords, mask=mask)
 
     # === EDM diffusion coefficients === #
     def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:
@@ -215,25 +221,6 @@ class Boltz1SampleDiffusion(BaseStructureModule):
             # use different sigmas for each diffusion sample
             return _sample(batch_size, num_diffusion_samples)
 
-    def sample_holo(
-        self,
-        f_input: FoldingInput,
-        num_diffusion_samples: int = 1,
-    ) -> torch.Tensor:
-        """Sample from the prior distribution."""
-        holo_coords = super().sample_holo(
-            f_input, num_diffusion_samples
-        )  # [B, N, Latom, 3]
-        atom_mask = f_input.atom.resolved_mask.float()  # (B, Latom)
-
-        # Apply coordinate augmentation
-        holo_coords = self.random_augmentation(
-            holo_coords,
-            mask=atom_mask.unsqueeze(1),  # (B, 1, Latom)
-        )
-
-        return holo_coords
-
     def interpolate(
         self,
         noise_coords: torch.Tensor,
@@ -300,7 +287,7 @@ class Boltz1SampleDiffusion(BaseStructureModule):
 
         # NOTE: for sampling, there is no unresolved atoms.
         # Therefore, we can use pad_mask here.
-        atom_mask = f_input.atom.pad_mask.float().unsqueeze(1)  # (B, 1, Latom)
+        atom_mask = f_input.atom.pad_mask.unsqueeze(1)  # (B, 1, Latom)
 
         # Line 1
         init_sigma = sigmas[0]

--- a/src/kfold/model/modules/structure_module/kfold_ddbm.py
+++ b/src/kfold/model/modules/structure_module/kfold_ddbm.py
@@ -1,15 +1,12 @@
 # started from code from https://github.com/jwohlwend/boltz, MIT License
 # adapted with DDBM bridge diffusion approach
 
-from dataclasses import dataclass
-
 import torch
 import torch.nn.functional as F
 
 from kfold.data.model_input import FoldingInput
-from kfold.model.layers.alphafold3.utils import CenterRandomAugmentation
 from kfold.model.modules.score_model.base import BaseScoreModel
-from kfold.utils.geometry.random_augment import do_centering
+from kfold.utils.geometry.random_augment import CenterRandomAugmentation, do_centering
 from kfold.utils.geometry.rigid_align import rigid_align
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
@@ -30,7 +27,6 @@ class KFoldBridgeDiffusion(BaseStructureModule):
                            Models"
     """
 
-    @dataclass
     class Config(BaseConfig):
         """Configuration for the Bridge Diffusion Structure module.
 
@@ -118,12 +114,17 @@ class KFoldBridgeDiffusion(BaseStructureModule):
         self.synchronize_sigmas: bool = cfg.synchronize_sigmas
         self.normalize_data_end: bool = cfg.normalize_data_end
 
-        if self.coordinate_augmentation:
-            self.random_augmentation = CenterRandomAugmentation(
-                centering=True,
-                augmentation=self.coordinate_augmentation,
-                s_trans=1.0,  # not used when augmentation is False
-            )
+        self.random_augmentation = CenterRandomAugmentation(
+            centering=True,
+            augmentation=self.coordinate_augmentation,
+            s_trans=1.0,  # not used when augmentation is False
+        )
+
+    def apply_random_augmentation(
+        self, coords: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply random augmentation to coordinates."""
+        return self.random_augmentation(coords, mask=mask)
 
     # === Bridge EDM diffusion coefficients === #
     def _get_bridge_scalings(
@@ -430,49 +431,6 @@ class KFoldBridgeDiffusion(BaseStructureModule):
 
         return apo_coords
 
-    def sample_holo(
-        self,
-        f_input: FoldingInput,
-        num_diffusion_samples: int = 1,
-    ) -> torch.Tensor:
-        """Sample holo structures (target for bridge diffusion).
-
-        In bridge diffusion, the holo (bound) structure is the target
-        that we condition on during sampling.
-
-        Parameters
-        ----------
-        f_input : FoldingInput
-            FoldingInput object containing model inputs.
-        num_diffusion_samples : int, optional
-            Number of diffusion samples, by default 1.
-
-        Returns
-        -------
-        holo_coords : torch.Tensor
-            Holo coordinates. Shape (B, N, La, 3).
-        """
-        holo_coords = super().sample_holo(
-            f_input, num_diffusion_samples
-        )  # [B, N, Latom, 3]
-
-        if self.coordinate_augmentation:
-            atom_mask = f_input.atom.pad_mask.float()  # (B, Latom)
-
-            B, N, L = holo_coords.shape[:3]
-            holo_coords = holo_coords.view(B * N, L, 3)  # (B*N, Latom, 3)
-            atom_mask = atom_mask.repeat_interleave(N, dim=0)  # (B * N, Latom)
-
-            # Apply coordinate augmentation
-            holo_coords = self.random_augmentation(holo_coords, mask=atom_mask)
-
-            # Mask out the padding atoms
-            holo_coords = holo_coords * atom_mask[:, :, None]  # (B*N, Latom, 3)
-
-            holo_coords = holo_coords.view(B, N, L, 3)
-
-        return holo_coords
-
     def interpolate(
         self,
         noise_coords: torch.Tensor,
@@ -566,7 +524,7 @@ class KFoldBridgeDiffusion(BaseStructureModule):
 
         # NOTE: for sampling, there is no unresolved atoms.
         # Therefore, we can use pad_mask here.
-        atom_mask = f_input.atom.pad_mask.float().unsqueeze(1)  # (B, 1, Latom)
+        atom_mask = f_input.atom.pad_mask.unsqueeze(1)  # (B, 1, Latom)
 
         # Line 1-2: sample x_N from q_data(y), not N(0, I)
         x_apo = self.sample_prior(f_input, num_diffusion_samples)  # (B, N, Latom, 3)

--- a/src/kfold/training/folding/metrics/structure.py
+++ b/src/kfold/training/folding/metrics/structure.py
@@ -453,9 +453,7 @@ def permute_label_coordinates(
 
     else:
         """Perform weighted rigid alignment without symmetry correction."""
-        true_coords = f_input.atom.label_coords  # [B, Natom, Nholo, 3]
-        # HACK: we only consider the first bio-assembly
-        true_coords = true_coords[:, :, 0, :]
+        true_coords = f_input.atom.label_coords  # [B, Natom, 3]
         mask = f_input.atom.resolved_mask  # [B, Natom]
 
         # Weighted rigid alignment for best permutation

--- a/src/kfold/utils/geometry/random_augment.py
+++ b/src/kfold/utils/geometry/random_augment.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Sequence
-from typing import TypeVar
+from typing import TypeVar, overload
 
 import numpy as np
 import torch
@@ -318,3 +318,119 @@ def quaternion_to_matrix(quaternions: ArrayT) -> ArrayT:
         dim=-1,
     )
     return o.reshape(quaternions.shape[:-1] + (3, 3))
+
+
+class CenterRandomAugmentation:
+    """Centering and Random Augmentation Module
+    See Section 3.7 Algorithm 19 CentreRandomAugmentation
+
+    Usage)
+    ```python
+    augment = CenterRandomAugmentation(...)
+    x = augment(x, mask=mask)
+    x, y = augment(x, y, mask=mask)
+    ```
+    """
+
+    def __init__(
+        self,
+        augmentation: bool = True,
+        centering: bool = True,
+        s_trans: float = 1.0,
+        mask_to_zero: bool = True,
+    ):
+        self.augmentation: bool = augmentation
+        self.centering: bool = centering
+        self.s_trans: float = s_trans
+        self.mask_to_zero: bool = mask_to_zero
+
+    @overload
+    def __call__(
+        self,
+        coords: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+    @overload
+    def __call__(
+        self,
+        coords1: torch.Tensor,
+        coords2: torch.Tensor,
+        *others: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, ...]: ...
+
+    def __call__(  # type: ignore[override]
+        self,
+        *coords: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        return self.augment(*coords, mask=mask)
+
+    @overload
+    def augment(
+        self,
+        coords: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+    @overload
+    def augment(
+        self,
+        coords1: torch.Tensor,
+        coords2: torch.Tensor,
+        *others: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, ...]: ...
+
+    def augment(  # type: ignore[override]
+        self,
+        *coords: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        """See Section 3.7 Algorithm 19 CentreRandomAugmentation
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            One or more tensors of shape (..., L, 3) representing atomic coordinates.
+        mask : torch.Tensor
+            A tensor of shape (..., L) representing the atom mask.
+        """
+        coords_list: list[torch.Tensor] = list(coords)
+        # Check all input coords have the same batch size and number of atoms
+        ref_coords = coords_list[0]
+        coords_shape = ref_coords.shape
+        for c in coords_list:
+            assert c.shape == coords_shape, (
+                "All input coordinate tensors must have the same batch size and length."
+                f" Got {c.shape} vs {coords_shape}."
+            )
+
+        # Line 1
+        if self.centering:
+            coords_list = [do_centering(x, mask, mask_to_zero=False) for x in coords_list]
+
+        if self.augmentation:
+            # Line 2,4
+            R = random_rotations_torch(
+                coords_shape[:-2], ref_coords.dtype, ref_coords.device
+            )  # [..., 3, 3]
+            rotate = lambda x: torch.einsum("...md,...ds->...ms", x, R)  # noqa
+            coords_list = [rotate(x) for x in coords_list]
+
+            # Line 3,4
+            if self.s_trans > 0.0:
+                random_trans = torch.randn_like(ref_coords[..., 0:1, :]) * self.s_trans
+                coords_list = [x + random_trans for x in coords_list]
+
+        # Mask out
+        if self.mask_to_zero:
+            coords_list = [x * mask[..., None] for x in coords_list]
+
+        if len(coords) == 1:
+            # Single tensor input, return tensor
+            return coords_list[0]
+        else:
+            # Multiple tensor input, return list of tensors
+            return tuple(coords_list)


### PR DESCRIPTION
This pull request changes the handling logic of holo and apo structure coordinates in model forward, simplifying their shapes.

**Changes**:
- `label_coords`: `[B, Natom, Nholo, 3] -> [B, Natom, 3]`
- `apo_coords`: `[B, Natom, Napo, 3] -> [B, Natom, 3]`
- `apo_mask`: `[B, Natom, Napo] -> [B, Natom]`

The coordinates are randomly sampled during featurization function in `Dataset.__getitem__`.