### PR TITLE
Refactor/modularize structure module

### DIFF
--- a/src/kfold/model/modules/structure_module/af3_edm.py
+++ b/src/kfold/model/modules/structure_module/af3_edm.py
@@ -10,11 +10,11 @@ from kfold.model.modules.score_model.base import BaseScoreModel
 from kfold.utils.geometry.random_augment import CenterRandomAugmentation
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
-from .base import BaseStructureModule
+from .base import BaseEDM
 
 
 @STRUCTURE_MODULE.register()
-class AF3SampleDiffusion(BaseStructureModule):
+class AF3SampleDiffusion(BaseEDM):
     """Atom diffusion module used in AlphaFold3.
     See Section 3.7 Algorithm 18: SampleDiffusion in the AF3 paper.
     """

--- a/src/kfold/model/modules/structure_module/base.py
+++ b/src/kfold/model/modules/structure_module/base.py
@@ -11,163 +11,13 @@ from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
 @STRUCTURE_MODULE.register()
 class BaseStructureModule(ABC):
-    """High-level diffusion framework for structure generation.
-    You may want to implement diffusion bridge methods here.
-
-    See Section 3.7, Algorithm18 (Sample Diffusion) of AlphaFold3 paper.
-
-    NOTE: this is not a torch.nn.Module, as it may not have learnable parameters.
-    """
+    """High-level flow-based framework for structure generation."""
 
     def __init__(self, cfg: BaseConfig, score_model: BaseScoreModel):
         self.cfg = cfg
         self.score_model = score_model
 
-    # === EDM (Elucidating Diffusion Models) preconditioning coefficients === #
-    # Reference: Karras et al., "Elucidating the Design Space of Diffusion-Based "
-    # Generative Models"
-    # Check Boltz Implementation
-    @abstractmethod
-    def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:
-        """Skip connection coefficient for EDM preconditioning."""
-
-    @abstractmethod
-    def c_out(self, sigma: torch.Tensor) -> torch.Tensor:
-        """Output scaling coefficient for EDM preconditioning."""
-
-    @abstractmethod
-    def c_in(self, sigma: torch.Tensor) -> torch.Tensor:
-        """Input scaling coefficient for EDM preconditioning."""
-
-    @abstractmethod
-    def c_noise(self, sigma: torch.Tensor) -> torch.Tensor:
-        """Noise level conditioning coefficient for EDM preconditioning."""
-
-    # === Sampling and Interpolation Methods === #
-    @abstractmethod
-    def sample_structure(
-        self,
-        f_input: FoldingInput,
-        s_inputs: torch.Tensor,
-        s_trunk: torch.Tensor,
-        z_trunk: torch.Tensor,
-        num_steps: int | None = None,
-        num_diffusion_samples: int = 1,
-        max_parallel_samples: int | None = None,
-        return_traj: bool = False,
-    ) -> dict[str, torch.Tensor]:
-        """Sample structures via diffusion sampling."""
-
-    @abstractmethod
-    def sample_noise_level(
-        self,
-        batch_size: int,
-        num_diffusion_samples: int,
-        device: torch.device | None = None,
-    ) -> torch.Tensor:
-        """Sample noise levels (t_hat) during model training. Shape: (B, N)."""
-
-    @abstractmethod
-    def get_sampling_schedule(
-        self,
-        num_steps: int | None = None,
-        device: torch.device | None = None,
-    ) -> torch.Tensor:
-        """Get the noise schedule for diffusion sampling."""
-
-    def apply_random_augmentation(
-        self, coords: torch.Tensor, mask: torch.Tensor
-    ) -> torch.Tensor:
-        """Apply random augmentation to coordinates.
-
-        Parameters
-        ----------
-        coords : torch.Tensor
-            Coordinates. Shape (*, L, 3).
-        mask : torch.Tensor
-            Mask. Shape (*, L).
-
-        Returns
-        -------
-        augmented_coords : torch.Tensor
-            Augmented Coordinates. Shape (*, La, 3).
-        """
-        # Default: simple centering without augmentation
-        coords = do_centering(coords, mask, mask_to_zero=True)
-        return coords
-
-    def sample_label(
-        self, f_input: FoldingInput, num_diffusion_samples: int = 1
-    ) -> torch.Tensor:
-        """Sample label coordinates from input features.
-        Return shape: [B, N, La, 3], where N is number of diffusion samples
-        and La is number of atoms.
-
-        Parameters
-        -----------
-        f_input: FoldingInput
-            Input features
-        """
-        # if the model is equivariance, skip augment
-        random_augment = True
-
-        holo_coords = self.sample_holo(f_input, num_diffusion_samples, random_augment)
-
-        return holo_coords
-
-    def sample_prior(
-        self,
-        f_input: FoldingInput,
-        num_diffusion_samples: int = 1,
-        label_coords: torch.Tensor | None = None,
-    ) -> torch.Tensor:
-        """Sample from the prior distribution.
-        Return shape: [B, N, La, 3], where N is number of diffusion samples
-        and La is number of atoms.
-
-        Parameters
-        -----------
-        f_input: FoldingInput
-            Input features
-        num_diffusion_samples:
-            Number of diffusion samples
-        label_coords: torch.Tensor
-            Label coordinates. Shape: [B, N, La, 3]
-            where N is the number of diffusion samples
-        """
-        # if the model is equivariance, skip augment
-        random_augment = True
-
-        # Sample apo coordinates
-        apo_coords = self.sample_apo(f_input, num_diffusion_samples, random_augment)
-
-        # If required, align to label coordinates
-        return apo_coords
-
-    @abstractmethod
-    def interpolate(
-        self,
-        noise_coords: torch.Tensor,
-        label_coords: torch.Tensor,
-        t_hat: torch.Tensor,
-        mask: torch.Tensor,
-    ) -> torch.Tensor:
-        """Interpolate between noise and label coordinates.
-
-        We may want to perform kabsch alignment here before interpolation.
-
-        Parameters
-        ----------
-        noise_coords : torch.Tensor
-            The noisy coordinates. Shape (B, N, La, 3).
-        label_coords : torch.Tensor
-            The label coordinates. Shape (B, N, La, 3).
-        t_hat : torch.Tensor
-            The dffusion noise levels (or sigmas of EDM). Shape (B, N).
-        mask : torch.Tensor
-            The atom mask. Shape (B, La).
-        """
-
+    # === Model Call === #
     @abstractmethod
     def forward_model(
         self,
@@ -206,6 +56,211 @@ class BaseStructureModule(ABC):
         denoised_coords : torch.Tensor
             Denoised atom coordinates. Shape (B, N, Lt, 3).
         """
+
+    # === Sampling and Interpolation Methods === #
+    @abstractmethod
+    def sample_structure(
+        self,
+        f_input: FoldingInput,
+        s_inputs: torch.Tensor,
+        s_trunk: torch.Tensor,
+        z_trunk: torch.Tensor,
+        num_steps: int | None = None,
+        num_diffusion_samples: int = 1,
+        max_parallel_samples: int | None = None,
+        return_traj: bool = False,
+    ) -> dict[str, torch.Tensor]:
+        """Sample structures via diffusion sampling."""
+
+    @abstractmethod
+    def sample_noise_level(
+        self,
+        batch_size: int,
+        num_diffusion_samples: int,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        """Sample noise levels (t_hat) during model training. Shape: (B, N)."""
+
+    @abstractmethod
+    def get_sampling_schedule(
+        self,
+        num_steps: int | None = None,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        """Get the noise schedule for diffusion sampling. Shape: (num_steps,)."""
+
+    def loss_weights(self, t_hat: torch.Tensor) -> torch.Tensor:
+        """Compute loss weights based on noise levels t_hat. Shape: (B, N)."""
+        return torch.ones_like(t_hat)
+
+    def apply_random_augmentation(
+        self, coords: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply random augmentation to coordinates.
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            Coordinates. Shape (*, L, 3).
+        mask : torch.Tensor
+            Mask. Shape (*, L).
+
+        Returns
+        -------
+        augmented_coords : torch.Tensor
+            Augmented Coordinates. Shape (*, La, 3).
+        """
+        # Default: simple centering without augmentation
+        coords = do_centering(coords, mask, mask_to_zero=True)
+        return coords
+
+    def sample_label(
+        self, f_input: FoldingInput, num_diffusion_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample label coordinates from input features.
+        Return shape: [B, N, La, 3], where N is number of diffusion samples
+        and La is number of atoms.
+
+        Parameters
+        -----------
+        f_input: FoldingInput
+            Input features
+        num_diffusion_samples:
+            Number of diffusion samples
+        label_coords: torch.Tensor
+            Label coordinates. Shape: [B, N, La, 3]
+            where N is the number of diffusion samples
+
+        Returns
+        -------
+        label_coords: torch.Tensor
+            Label coordinates. Shape: [B, N, La, 3]
+        """
+        # if the model is equivariance, skip augment
+        random_augment = True
+
+        holo_coords = self.sample_holo(f_input, num_diffusion_samples, random_augment)
+
+        return holo_coords
+
+    def sample_prior(
+        self,
+        f_input: FoldingInput,
+        num_diffusion_samples: int = 1,
+        label_coords: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Sample from the prior distribution.
+        Return shape: [B, N, La, 3], where N is number of diffusion samples
+        and La is number of atoms.
+
+        Parameters
+        -----------
+        f_input: FoldingInput
+            Input features
+        num_diffusion_samples:
+            Number of diffusion samples
+        label_coords: torch.Tensor
+            Label coordinates. Shape: [B, N, La, 3]
+            where N is the number of diffusion samples
+
+        Returns
+        -------
+        apo_coords: torch.Tensor
+            Apo coordinates. Shape: [B, N, La, 3]
+        """
+        # if the model is equivariance, skip augment
+        random_augment = True
+
+        # Sample apo coordinates
+        apo_coords = self.sample_apo(f_input, num_diffusion_samples, random_augment)
+
+        # If required, align to label coordinates
+        return apo_coords
+
+    @abstractmethod
+    def interpolate(
+        self,
+        noise_coords: torch.Tensor,
+        label_coords: torch.Tensor,
+        t_hat: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Interpolate between noise and label coordinates.
+
+        We may want to perform kabsch alignment here before interpolation.
+
+        Parameters
+        ----------
+        noise_coords : torch.Tensor
+            The noisy coordinates. Shape (B, N, La, 3).
+        label_coords : torch.Tensor
+            The label coordinates. Shape (B, N, La, 3).
+        t_hat : torch.Tensor
+            The dffusion noise levels (or sigmas of EDM). Shape (B, N).
+        mask : torch.Tensor
+            The atom mask. Shape (B, La).
+
+        Returns
+        -------
+        interpolated_coords : torch.Tensor
+            The interpolated coordinates. Shape (B, N, La, 3).
+        """
+
+    # === For model training === #
+    def training_step(
+        self,
+        f_input: FoldingInput,
+        s_inputs: torch.Tensor,
+        s_trunk: torch.Tensor,
+        z_trunk: torch.Tensor,
+        diffusion_batch_size: int = 1,
+        model_cache: dict | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Perform a single training step for the structure module.
+        See Section 5 of EDM paper.
+        """
+        batch_size = f_input.batch_size  # =B
+        num_diffusion_samples = diffusion_batch_size  # =N
+        mask = f_input.atom.pad_mask  # [B, La]
+
+        with torch.no_grad():
+            t_hat = self.sample_noise_level(
+                batch_size, num_diffusion_samples, device=f_input.device
+            )  # [B, N]
+
+            # sample xT from label
+            label_coords = self.sample_label(f_input, num_diffusion_samples)
+            label_coords = label_coords * mask[..., None, :, None]
+
+            # sample x0 from prior
+            prior_coords = self.sample_prior(f_input, num_diffusion_samples, label_coords)
+            prior_coords = prior_coords * mask[..., None, :, None]
+
+            # sample xt via interpolation
+            noised_atom_coords = self.interpolate(prior_coords, label_coords, t_hat, mask)
+            noised_atom_coords = noised_atom_coords * mask[..., None, :, None]
+
+        denoised_atom_coords = self.forward_model(
+            x_noisy=noised_atom_coords,  # [B, N, La, 3]
+            t_hat=t_hat,  # [B, N]
+            f_input=f_input,
+            s_inputs=s_inputs,  # [B, Lt, c_s]
+            s_trunk=s_trunk,  # [B, Lt, c_s]
+            z_trunk=z_trunk,  # [B, Lt, Lt, c_z]
+            model_cache=model_cache,
+            prior_coords=prior_coords,  # [B, N, La, 3]
+        )  # [B, N, La, 3]
+
+        loss_weights = self.loss_weights(t_hat)  # [B, N]
+
+        return {
+            "t_hat": t_hat,
+            "loss_weights": loss_weights,
+            "prior_atom_coords": prior_coords,
+            "noised_atom_coords": noised_atom_coords,
+            "denoised_atom_coords": denoised_atom_coords,
+            "true_atom_coords": label_coords,
+        }
 
     # === Sampling holo/apo structures === #
     def sample_holo(
@@ -286,64 +341,30 @@ class BaseStructureModule(ABC):
 
         return apo_coords  # [B, N, L, 3]
 
-    # === For model training === #
-    def training_step(
-        self,
-        f_input: FoldingInput,
-        s_inputs: torch.Tensor,
-        s_trunk: torch.Tensor,
-        z_trunk: torch.Tensor,
-        diffusion_batch_size: int = 1,
-        model_cache: dict | None = None,
-    ) -> dict[str, torch.Tensor]:
-        """Perform a single training step for the structure module.
-        See Section 5 of EDM paper.
-        """
-        batch_size = f_input.batch_size  # =B
-        num_diffusion_samples = diffusion_batch_size  # =N
-        mask = f_input.atom.pad_mask  # [B, La]
 
-        with torch.no_grad():
-            t_hat = self.sample_noise_level(
-                batch_size, num_diffusion_samples, device=f_input.device
-            )  # [B, N]
+@STRUCTURE_MODULE.register()
+class BaseEDM(BaseStructureModule):
+    """High-level EDM framework for structure generation.
 
-            # sample xT from label
-            label_coords = self.sample_label(f_input, num_diffusion_samples)
-            label_coords = label_coords * mask[..., None, :, None]
+    See Section 3.7, Algorithm18 (Sample Diffusion) of AlphaFold3 paper.
+    """
 
-            # sample x0 from prior
-            prior_coords = self.sample_prior(f_input, num_diffusion_samples, label_coords)
-            prior_coords = prior_coords * mask[..., None, :, None]
-
-            # sample xt via interpolation
-            noised_atom_coords = self.interpolate(prior_coords, label_coords, t_hat, mask)
-            noised_atom_coords = noised_atom_coords * mask[..., None, :, None]
-
-        denoised_atom_coords = self.forward_model(
-            x_noisy=noised_atom_coords,  # [B, N, La, 3]
-            t_hat=t_hat,  # [B, N]
-            f_input=f_input,
-            s_inputs=s_inputs,  # [B, Lt, c_s]
-            s_trunk=s_trunk,  # [B, Lt, c_s]
-            z_trunk=z_trunk,  # [B, Lt, Lt, c_z]
-            model_cache=model_cache,
-            prior_coords=prior_coords,  # [B, N, La, 3]
-        )  # [B, N, La, 3]
-
-        loss_weights = self.loss_weights(t_hat)  # [B, N]
-
-        return {
-            "t_hat": t_hat,
-            "loss_weights": loss_weights,
-            "prior_atom_coords": prior_coords,
-            "noised_atom_coords": noised_atom_coords,
-            "denoised_atom_coords": denoised_atom_coords,
-            "true_atom_coords": label_coords,
-        }
+    # === EDM (Elucidating Diffusion Models) preconditioning coefficients === #
+    # Reference: Karras et al., "Elucidating the Design Space of Diffusion-Based "
+    # Generative Models"
+    # Check Boltz Implementation
+    @abstractmethod
+    def c_skip(self, sigma: torch.Tensor) -> torch.Tensor:
+        """Skip connection coefficient for EDM preconditioning."""
 
     @abstractmethod
-    def loss_weights(self, t_hat: torch.Tensor) -> torch.Tensor:
-        """Compute loss weights based on noise levels t_hat.
-        See Section 3.7.1 Equation 6 of AlphaFold3 paper.
-        """
+    def c_out(self, sigma: torch.Tensor) -> torch.Tensor:
+        """Output scaling coefficient for EDM preconditioning."""
+
+    @abstractmethod
+    def c_in(self, sigma: torch.Tensor) -> torch.Tensor:
+        """Input scaling coefficient for EDM preconditioning."""
+
+    @abstractmethod
+    def c_noise(self, sigma: torch.Tensor) -> torch.Tensor:
+        """Noise level conditioning coefficient for EDM preconditioning."""

--- a/src/kfold/model/modules/structure_module/base.py
+++ b/src/kfold/model/modules/structure_module/base.py
@@ -368,3 +368,7 @@ class BaseEDM(BaseStructureModule):
     @abstractmethod
     def c_noise(self, sigma: torch.Tensor) -> torch.Tensor:
         """Noise level conditioning coefficient for EDM preconditioning."""
+
+    def loss_weights(self, t_hat: torch.Tensor) -> torch.Tensor:
+        """Compute loss weights based on noise levels t_hat. Shape: (B, N)."""
+        return 1 / self.c_out(t_hat) ** 2

--- a/src/kfold/model/modules/structure_module/base.py
+++ b/src/kfold/model/modules/structure_module/base.py
@@ -31,7 +31,6 @@ class BaseStructureModule(ABC):
         prior_coords: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Forward pass through the score model.
-        See Section 3.7: Diffusion Module, Algorithm 20 of AlphaFold3 paper.
 
         Parameters
         ----------
@@ -39,7 +38,7 @@ class BaseStructureModule(ABC):
             Noisy atom coordinates. Shape (B, N, La, 3),
             where N is number of diffusion samples and La is number of atoms.
         t_hat : torch.Tensor | float
-            Diffusion noise level (or sigmas of EDM). Shape (B, N,).
+            Time step or noise level. Shape (B, N) or float.
         f_input : FoldingInput
             FoldingInput object containing model inputs.
         s_inputs : torch.Tensor
@@ -127,9 +126,6 @@ class BaseStructureModule(ABC):
             Input features
         num_diffusion_samples:
             Number of diffusion samples
-        label_coords: torch.Tensor
-            Label coordinates. Shape: [B, N, La, 3]
-            where N is the number of diffusion samples
 
         Returns
         -------

--- a/src/kfold/model/modules/structure_module/boltz1_edm.py
+++ b/src/kfold/model/modules/structure_module/boltz1_edm.py
@@ -10,11 +10,11 @@ from kfold.model.modules.score_model.base import BaseScoreModel
 from kfold.utils.geometry.random_augment import CenterRandomAugmentation
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
-from .base import BaseStructureModule
+from .base import BaseEDM
 
 
 @STRUCTURE_MODULE.register()
-class Boltz1SampleDiffusion(BaseStructureModule):
+class Boltz1SampleDiffusion(BaseEDM):
     """Atom diffusion module used in Boltz1."""
 
     class Config(BaseConfig):

--- a/src/kfold/model/modules/structure_module/kfold_ddbm.py
+++ b/src/kfold/model/modules/structure_module/kfold_ddbm.py
@@ -10,11 +10,11 @@ from kfold.utils.geometry.random_augment import CenterRandomAugmentation, do_cen
 from kfold.utils.geometry.rigid_align import rigid_align
 from kfold.utils.registry import STRUCTURE_MODULE, BaseConfig
 
-from .base import BaseStructureModule
+from .base import BaseEDM
 
 
 @STRUCTURE_MODULE.register()
-class KFoldBridgeDiffusion(BaseStructureModule):
+class KFoldBridgeDiffusion(BaseEDM):
     """Diffusion Bridge module for biomolecular structure prediction.
 
     Implements a bridge diffusion process that transitions from apo (unbound)


### PR DESCRIPTION
This pull request refactors the structure module hierarchy to better separate EDM-specific logic from general structure generation, and improves documentation and modularity. The main change is the introduction of a new `BaseEDM` class for EDM-related methods, with corresponding updates to all relevant modules. Several methods have been moved, restructured, or clarified, and docstrings have been enhanced for clarity.

**Refactoring and Class Hierarchy:**

* Introduced a new `BaseEDM` class in `base.py` that contains EDM-specific preconditioning coefficient methods (`c_skip`, `c_out`, `c_in`, `c_noise`). The original `BaseStructureModule` is now focused on general structure generation, while EDM logic is encapsulated in `BaseEDM`.
* Updated all EDM-based modules (`AF3SampleDiffusion`, `Boltz1SampleDiffusion`, `KFoldBridgeDiffusion`) to inherit from `BaseEDM` instead of `BaseStructureModule`, reflecting the new class hierarchy.

**Method and API Changes:**

* Moved the EDM preconditioning coefficient methods from `BaseStructureModule` to `BaseEDM`, and removed them from the base class.
* Refactored the training step logic: the `training_step` method is now implemented in `BaseStructureModule` and handles sampling, interpolation, and forward model calls, with improved docstrings and parameter descriptions.

**Documentation and Usability Improvements:**

* Enhanced and clarified docstrings for key methods 
* Added explicit return shape documentation to sampling and interpolation methods for better usability and clarity. 

**Other Minor Changes:**

* Added a default `loss_weights` method to `BaseStructureModule` for computing loss weights, returning ones by default.

These changes improve the modularity, readability, and maintainability of the structure module codebase, and clarify the distinction between general and EDM-specific functionality.