### PR TITLE
Major refactoring and corrections

### DIFF
--- a/configs/model/module/structure_module/boltz1.yaml
+++ b/configs/model/module/structure_module/boltz1.yaml
@@ -9,7 +9,7 @@ P_mean: -1.2
 P_std: 1.5
 gamma_0: 0.8
 gamma_min: 1.0
-noise_scale: 1.003
-step_scale: 1.5
+noise_scale: 1.0
+step_scale: 1.0
 coordinate_augmentation: True
 synchronize_sigmas: True

--- a/configs/validate-boltz1-pretrained.yaml
+++ b/configs/validate-boltz1-pretrained.yaml
@@ -3,7 +3,6 @@ model:
   trunk:
     use_cuequiv_kernels: false # true can return slightly different results.
   load_weight: true
-  freeze_weight: true
 
 train:
   _yaml_: "train/structure_only.yaml"
@@ -20,8 +19,8 @@ train:
     precision: 32
 
   data:
-    lmdb_path: /cache/wykim_lab/kfold_data1/kfold_rcsb_processed_v251120.lmdb/
-    manifest_path: /cache/wykim_lab/kfold_data1/manifests/af3_manifest.pkl
+    lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
+    manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     symmetry_path: /cache/wykim_lab/kfold_data/symmetry.pkl
     split_path: ./assets/splits/boltz1
     num_workers: 8

--- a/src/kfold/model/layers/alphafold3/diffusion.py
+++ b/src/kfold/model/layers/alphafold3/diffusion.py
@@ -233,9 +233,13 @@ class DiffusionModule(nn.Module):
             model_cache=model_cache,
         )  # [B, N, Lt, c_s], [B, Lt, Lt, c_z]
 
+        s_trunk = s_trunk.unsqueeze(-3)  # [B, 1, Lt, c_s]
+        z = z.unsqueeze(-4)  # [B, 1, Lt, Lt, c_z]
+
         # Shape:
+        # - s_trunk: [B, 1, Lt, c_s]
         # - s: [B, N, Lt, c_s] where N is number of diffusion samples
-        # - z: [B, Lt, Lt, c_z] (time-independent)
+        # - z: [B, 1, Lt, Lt, c_z] (time-independent)
 
         # Line 2: x_noisy -> r_noisy
         # Already given as input
@@ -245,8 +249,8 @@ class DiffusionModule(nn.Module):
         a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
             f_input=f_input,
             r_noisy=r_noisy,  # [B, N, La, 3]
-            s_trunk=s_trunk,  # [B, Lt, c_s]
-            z_trunk=z,  # [B, Lt, Lt, c_z]
+            s_trunk=s_trunk,  # [B, 1, Lt, c_s], broadcasted to [B, N, Lt, c_s]
+            z_trunk=z,  # [B, 1, Lt, Lt, c_z], broadcasted to [B, N, Lt, Lt, c_z]
             model_cache=model_cache,
         )
         # Shape:
@@ -260,7 +264,6 @@ class DiffusionModule(nn.Module):
         a = a + self.linear_s_to_a(self.layernorm_s(s))  # [Nsample, La, c_token]
 
         # Line 5
-        z = z.unsqueeze(-4)  # [B, 1, Lt, Lt, c_z]
         token_mask = f_input.token.pad_mask.unsqueeze(-2)  # [B, 1, Lt]
         a = self.token_transformer(
             a,  # [B, N, Lt, c_token]

--- a/src/kfold/model/layers/alphafold3/input_encoder.py
+++ b/src/kfold/model/layers/alphafold3/input_encoder.py
@@ -46,8 +46,9 @@ class InputFeatureEmbedder(nn.Module):
         """
         super().__init__()
 
-        self.encoder = AtomAttentionEncoderWithoutStructure(
+        self.encoder = AtomAttentionEncoder(
             channel_s=channel_s,
+            channel_z=None,
             channel_atom=channel_atom,
             channel_atompair=channel_atompair,
             channel_token=channel_s,  # Same to channel_s
@@ -55,6 +56,7 @@ class InputFeatureEmbedder(nn.Module):
             atoms_per_window_keys=atoms_per_window_keys,
             num_blocks=atom_encoder_blocks,
             num_heads=atom_encoder_heads,
+            use_structure=False,
             blocks_per_ckpt=blocks_per_ckpt,
         )
 
@@ -81,71 +83,14 @@ class InputFeatureEmbedder(nn.Module):
             The embedded tokens. [B, Lt, c_s]
         """
         # Atom attention encoder forward
-        a, *_ = self.encoder(f_input)  # [B, Lt, c_s]
+        a, *_ = self.encoder(f_input, None, None, None)  # [B, Lt, c_s]
 
         # Concatenate additional token features
         res_type = f_input.token.res_type  # [B, Lt, 32]
-        s = torch.cat(
-            [a, res_type],
-            dim=-1,
-        )
+        s = torch.cat([a, res_type], dim=-1)
 
         # Project to model dimension
         # NOTE: (SeonghwanSeo) I introduce additional linear layer to unify the dimension.
         s = self.proj_s(s)  # [B, Lt, c_s]
 
         return s
-
-
-class AtomAttentionEncoderWithoutStructure(AtomAttentionEncoder):
-    """Atom attention encoder without structure information.
-    AlphaFold3 Algorithm 5 without noisy structure r_l.
-    """
-
-    def __init__(
-        self,
-        channel_s: int,
-        channel_atom: int,
-        channel_atompair: int,
-        channel_token: int,
-        num_blocks: int = 3,
-        num_heads: int = 4,
-        atoms_per_window_queries: int = 32,
-        atoms_per_window_keys: int = 128,
-        blocks_per_ckpt: int | None = None,
-    ):
-        super().__init__(
-            channel_s=channel_s,
-            channel_z=None,  # no pair embedding used in input embedding
-            channel_atom=channel_atom,
-            channel_atompair=channel_atompair,
-            channel_token=channel_token,
-            num_blocks=num_blocks,
-            num_heads=num_heads,
-            atoms_per_window_queries=atoms_per_window_queries,
-            atoms_per_window_keys=atoms_per_window_keys,
-            use_structure=False,
-            blocks_per_ckpt=blocks_per_ckpt,
-        )
-
-    def forward(
-        self,
-        f_input: FoldingInput,
-        s_trunk: torch.Tensor | None = None,
-        z: torch.Tensor | None = None,
-        r: torch.Tensor | None = None,
-        model_cache: dict | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        assert s_trunk is None and z is None and r is None, (
-            "s_trunk, z_trunk, r must be None"
-        )
-        assert model_cache is None, "model_cache must be None"
-
-        a, q, c, p = super().forward(f_input, s_trunk, z, r)
-
-        assert a.shape[1] == 1, (
-            "Number of diffusion samples (dimension 1) must be 1 for input embedding."
-        )
-        # Squeeze diffusion sample dimension (N)
-        a, q, c, p = a.squeeze(1), q.squeeze(1), c.squeeze(1), p.squeeze(1)
-        return a, q, c, p

--- a/src/kfold/model/layers/alphafold3/transformers.py
+++ b/src/kfold/model/layers/alphafold3/transformers.py
@@ -24,7 +24,6 @@ from .utils import (
     LocalAttentionIndex,
     aggregate_atoms_to_tokens,
     broadcast_tokens_to_atoms,
-    expand_dim,
 )
 
 # === Helper functions for local atom attention === #
@@ -669,9 +668,6 @@ class AtomAttentionEncoder(nn.Module):
         p_skip : torch.Tensor
             The atom pair representation, shape [B, N, W, Lq, Lk, c_atompair]
         """
-        if self.use_structure:
-            assert s_trunk is not None and z_trunk is not None and r_noisy is not None
-
         if model_cache is not None:
             # NOTE: (seonghwanseo) Since atom encoder is used in both InputEmbedder and
             # DiffusionModule, I constrain caching only for DiffusionModule usage
@@ -684,125 +680,75 @@ class AtomAttentionEncoder(nn.Module):
         else:
             layer_cache = {}
 
-        if len(layer_cache) == 0:
-            # Cache the representation for structure-independent components
+        # Get indexing matrix for single to keys conversion
+        local_attn_index = LocalAttentionIndex(
+            num_atoms=f_input.num_atoms,
+            atoms_per_window_queries=self.atoms_per_window_queries,
+            atoms_per_window_keys=self.atoms_per_window_keys,
+            device=f_input.device,
+        )
 
-            # Get indexing matrix for single to keys conversion
-            local_attn_index = LocalAttentionIndex(
-                num_atoms=f_input.num_atoms,
-                atoms_per_window_queries=self.atoms_per_window_queries,
-                atoms_per_window_keys=self.atoms_per_window_keys,
-                device=f_input.device,
-            )
-
-            # Initialize single conditioning and pair representations
-            # Line 1
-            c = self.embed_atom(f_input)  # [B, La, c_atom]
-
-            # Line 2
-            ref_pos = f_input.atom.ref_pos  # [B, La, 3]
-            ref_pos_q = local_attn_index.to_query(ref_pos)  # [B, W, Lq, 3]
-            ref_pos_k = local_attn_index.to_key(ref_pos)  # [B, W, Lk, 3]
-            d = ref_pos_q.unsqueeze(-2) - ref_pos_k.unsqueeze(-3)  # [B, W, Lq, Lk, 3]
-
-            # Line 3
-            residue_uid = f_input.atom.ref_space_uid  # [B, La]
-            mask = f_input.atom.pad_mask  # [B, La]
-            uid_q = local_attn_index.to_query(residue_uid, dim=-1)  # [B, W, Lq]
-            uid_k = local_attn_index.to_key(residue_uid, dim=-1)  # [B, W, Lk]
-            mask_q = local_attn_index.to_query(mask, dim=-1)  # [B, W, Lq]
-            mask_k = local_attn_index.to_key(mask, dim=-1)  # [B, W, Lk]
-            v = uid_q[..., :, None] == uid_k[..., None, :]  # [B, W, Lq, Lk]
-            v = v & (mask_q[..., :, None] & mask_k[..., None, :])
-            v = v.float().unsqueeze(-1)  # [B, W, Lq, Lk, 1]
-
-            # Line 4, skip masking
-            p = self.embed_atompair_ref_pos(d)
-
-            # Line 5, skip masking
-            d_sq = d.pow(2).sum(-1, keepdim=True)
-            p = p + self.embed_atompair_ref_dist(1 / (1 + d_sq))
-
-            # Line 6, skip masking
-            p = p + self.embed_atompair_mask(v)
-
-            # Line 4-6, mask at once
-            p = p * v  # [B, W, Lq, Lk, c_atompair]
-
-            # Line 7
-            q = c  # [B, La, c_atom]
-
-            if self.use_structure:
-                assert s_trunk is not None and z_trunk is not None
-                # Add trunk embedding
-                atom_mask = f_input.atom.pad_mask
-                token_index = f_input.atom.token_index
-                # Line 9
-                c = self.add_trunk_single_conditioning(c, s_trunk, token_index, atom_mask)
-                # Line 10
-                p = self.add_trunk_pair_embedding(
-                    p, z_trunk, token_index, atom_mask, local_attn_index
-                )
-
-            # Line 13-14
-            c_q = local_attn_index.to_query(c)  # [B, W, Lq, c_atom]
-            c_k = local_attn_index.to_key(c)  # [B, W, Lk, c_atom]
-            p = p + self.linear_query(c_q)[..., :, None, :]
-            p = p + self.linear_key(c_k)[..., None, :, :]
-            p = p + self.mlp_pair(p)  # [B, W, Lq, Lk, c_atompair]
-
-            layer_cache["q"] = q  # [B, La, c_atom]
-            layer_cache["c"] = c  # [B, La, c_atom]
-            layer_cache["p"] = p  # [B, W, Lq, Lk, c_atompair]
+        if "qcp" in layer_cache:
+            q, c, p = layer_cache["qcp"]
         else:
-            q = layer_cache["q"]
-            c = layer_cache["c"]
-            p = layer_cache["p"]
+            # Line 1-7
+            q, c, p = self.initialize_atom_representation(f_input, local_attn_index)
+            layer_cache["qcp"] = (q, c, p)
 
         # Shapes at this point:
         # q: [B, La, c_atom]
         # c: [B, La, c_atom]
         # p: [B, W, Lq, Lk, c_atompair]
 
-        # Repeat for diffusion samples
+        mask = f_input.atom.pad_mask  # [B, La]
+        token_index = f_input.atom.token_index  # [B, La]
+
+        # Line 8-12: If provided, add trunk conditioning and noisy structure
         if self.use_structure:
-            assert r_noisy is not None, "r cannot be None when use_structure is True"
-            N = r_noisy.shape[1]  # number of diffusion samples
-        else:
-            N = 1
+            assert s_trunk is not None and z_trunk is not None and r_noisy is not None
+            # Broadcast for multiple diffusion samples
+            # [B, ...] -> [B, *, ...]
+            q = q.unsqueeze(1)  # [B, 1, La, c_atom]
+            c = c.unsqueeze(1)  # [B, 1, La, c_atom]
+            p = p.unsqueeze(1)  # [B, 1, W, Lq, Lk, c_atompair]
+            mask = mask.unsqueeze(1)  # [B, 1, La]
+            token_index = token_index.unsqueeze(1)  # [B, 1, La]
 
-        # [B, ...] -> [B, N, ...]
-        mask = f_input.atom.pad_mask
-        q = expand_dim(q, dim=1, n=N, add_dim=True)
-        c = expand_dim(c, dim=1, n=N, add_dim=True)
-        p = expand_dim(p, dim=1, n=N, add_dim=True)
-        mask = expand_dim(mask, dim=1, n=N, add_dim=True)
-
-        # Shapes at this point:
-        # q: [B, N, La, c_atom]
-        # c: [B, N, La, c_atom]
-        # p: [B, N, W, Lq, Lk, c_atompair]
-        # mask: [B, N, La]
-
-        # Line 11
-        if self.use_structure:
-            assert r_noisy is not None
+            # Line 9
+            c = self.add_trunk_single_conditioning(c, s_trunk, token_index, mask)
+            # Line 10
+            p = self.add_trunk_pair_embedding(
+                p, z_trunk, token_index, mask, local_attn_index
+            )
+            # Line 11
             q = self.add_noise_position(q, r_noisy)
 
-        # Line 15
+        # Shapes at this point:
+        # q: [B, *, La, c_atom]
+        # c: [B, *, La, c_atom]
+        # p: [B, *, W, Lq, Lk, c_atompair]
+        # mask: [B, *, La]
+        # token_index: [B, *, La]
+
+        # Line 13
+        c_q = local_attn_index.to_query(c)  # [B, *, W, Lq, c_atom]
+        c_k = local_attn_index.to_key(c)  # [B, *, W, Lk, c_atom]
+        p = p + self.linear_query(c_q)[..., :, None, :]
+        p = p + self.linear_key(c_k)[..., None, :, :]
+
+        # Line 14
+        p = p + self.mlp_pair(p)
+
+        # Line 15: Atom Transformer
         q = self.atom_encoder(q, c, p, mask)
 
-        # NOTE that c_token can be different from c_s (channel_s)
-        # Line 16
-        q_to_a = self.linear_q_to_a(q)  # [B, N, La, c_token]
-
-        # Aggregate atom representations to token representations
-        # [B, N, La, c_atom] -> [B, N, Lt, c_token]
+        # Line 16: Aggregate atom representations to token representations
+        q_to_a = self.linear_q_to_a(q)  # [B, *, La, c_atom] -> [B, *, Lt, c_token]
         a = aggregate_atoms_to_tokens(
-            q_to_a,  # [B, N, La, c_token]
-            token_index=f_input.atom.token_index[:, None, :],  # [B, 1, La]
+            x_atom=q_to_a,  # [B, *, La, c_token]
+            token_index=token_index,  # [B, *, La]
+            atom_mask=mask,  # [B, *, La]
             num_tokens=f_input.num_tokens,
-            atom_mask=f_input.atom.pad_mask[:, None, :],  # [B, 1, La]
             aggr="mean",
         )
 
@@ -810,6 +756,68 @@ class AtomAttentionEncoder(nn.Module):
         q_skip, c_skip, p_skip = q, c, p
 
         return a, q_skip, c_skip, p_skip
+
+    def initialize_atom_representation(
+        self,
+        f_input: FoldingInput,
+        local_attn_index: LocalAttentionIndex,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Initialize atom representations.
+        See Algorithm 5 Line 1-7 in the AF3 paper for more details.
+
+        Parameters
+        ----------
+        f_input : FoldingInput
+            The folding input.
+        Returns
+        -------
+        q : torch.Tensor
+            The atom single representation, shape [B, La, c_atom].
+        c : torch.Tensor
+            The atom single conditioning, shape [B, La, c_atom].
+        p : torch.Tensor
+            The atom pair representation, shape [B, W, Lq, Lk, c_atompair].
+        """
+        # Get indexing matrix for single to keys conversion
+
+        # Line 1
+        c = self.embed_atom(f_input)  # [B, La, c_atom]
+
+        # Line 2
+        ref_pos = f_input.atom.ref_pos  # [B, La, 3]
+        # [B, La, 3] -> [B, W, Lq, 3], [B, W, Lk, 3]
+        ref_pos_q, ref_pos_k = local_attn_index.to_qk(ref_pos)  # [B, W, Lq|Lk, 3]
+        d = ref_pos_q.unsqueeze(-2) - ref_pos_k.unsqueeze(-3)  # [B, W, Lq, Lk, 3]
+
+        # Line 3
+        uid = f_input.atom.ref_space_uid  # [B, La]
+        uid_q, uid_k = local_attn_index.to_qk(uid, dim=-1)  # [B, W, Lq|Lk]
+        v = uid_q[..., :, None] == uid_k[..., None, :]  # [B, W, Lq, Lk]
+        v = v.float().unsqueeze(-1)  # [B, W, Lq, Lk, 1]
+
+        # Line 4, masking later
+        p = self.embed_atompair_ref_pos(d)
+
+        # Line 5, masking later
+        d_sq = d.pow(2).sum(-1, keepdim=True)
+        p = p + self.embed_atompair_ref_dist(1 / (1 + d_sq))
+
+        # Line 6, masking later
+        p = p + self.embed_atompair_mask(v)
+
+        # Line 4-6, mask at once
+        p = p * v  # [B, W, Lq, Lk, c_atompair]
+
+        # Line 7
+        q = c  # [B, La, c_atom]
+
+        # Mask out padding
+        mask = f_input.atom.pad_mask  # [B, La]
+        mask_q, mask_k = local_attn_index.to_qk(mask, dim=-1)  # [B, W, Lq|Lk]
+        pair_mask = mask_q[..., :, None] & mask_k[..., None, :]  # [B, W, Lq, Lk]
+
+        p = p * pair_mask[..., None]  # [B, W, Lq, Lk, c_atompair]
+        return q, c, p
 
     def add_trunk_single_conditioning(
         self,
@@ -824,19 +832,19 @@ class AtomAttentionEncoder(nn.Module):
         Parameters
         ----------
         c : torch.Tensor
-            The atom single conditioning, shape [B, La, c_atom].
+            The atom single conditioning, shape [*, La, c_atom].
         s_trunk : torch.Tensor
-            The trunk single representation, shape [B,Lt, c_s].
+            The trunk single representation, shape [*, Lt, c_s].
         token_index: torch.Tensor
-            The atom to token mapping, shape [B, La].
+            The atom to token mapping, shape [*, La].
         atom_mask : torch.Tensor
-            The atom padding mask, shape [B, La]
+            The atom padding mask, shape [*, La]
         """
         # Case 2
-        s_trunk = self.linear_s_to_c(s_trunk)  # [B, Lt, c_atom]
-        s_to_c = broadcast_tokens_to_atoms(s_trunk, token_index)  # [B, La, c_atom]
-        s_to_c = s_to_c * atom_mask.unsqueeze(-1)  # [B, La, c_atom]
-        return c + s_to_c  # [B, La, c_atom]
+        s_trunk = self.linear_s_to_c(s_trunk)  # [*, Lt, c_atom]
+        s_to_c = broadcast_tokens_to_atoms(s_trunk, token_index)  # [*, La, c_atom]
+        s_to_c = s_to_c * atom_mask.unsqueeze(-1)  # [*, La, c_atom]
+        return c + s_to_c  # [*, La, c_atom]
 
     def add_trunk_pair_embedding(
         self,
@@ -852,45 +860,48 @@ class AtomAttentionEncoder(nn.Module):
         Parameters
         ----------
         p : torch.Tensor
-            The atom pair representation, shape [B, W, Lq, Lk, c_atompair].
+            The atom pair representation, shape [*, W, Lq, Lk, c_atompair].
         z_trunk : torch.Tensor
-            The trunk pair representation, shape [B, Lt, Lt, c_z].
+            The trunk pair representation, shape [*, Lt, Lt, c_z].
         token_index : torch.Tensor
-            The atom to token mapping, shape [B, La].
+            The atom to token mapping, shape [*, La].
+        atom_mask : torch.Tensor
+            The atom padding mask, shape [*, La].
         local_attn_index : LocalAttentionIndex
             The local attention indexer for atom attention.
         """
-        B = token_index.shape[0]
+        batch_shape = z_trunk.shape[:-3]  # [*]
+        W, Lq, Lk = p.shape[-4:-1]
 
         # 1. Project Trunk features
-        # [B, Lt, Lt, c_z] -> [B, Lt, Lt, c_atompair]
+        # [*, Lt, Lt, c_z] -> [*, Lt, Lt, c_atompair]
         z_trunk = self.linear_z_to_p(z_trunk)
 
         # 2. Get Windowed Indices
-        # [B, La] -> [B, W, Lq], [B, W, Lk]
-        q_idx = local_attn_index.to_query(token_index, dim=-1)  # [B, W, Lq]
-        k_idx = local_attn_index.to_key(token_index, dim=-1)  # [B, W, Lk]
+        # [*, La] -> [*, W, Lq], [*, W, Lk]
+        idx_q, idx_k = local_attn_index.to_qk(token_index, dim=-1)
+        idx_q = idx_q.expand(*batch_shape, W, Lq)
+        idx_k = idx_k.expand(*batch_shape, W, Lk)
 
         # NOTE: safe indexing: Although the pad value of token_index is 0,
         # we clamp indices to be at least 0 to avoid run-time error.
-        q_idx, k_idx = q_idx.clamp(min=0), k_idx.clamp(min=0)
+        idx_q, idx_k = idx_q.clamp(min=0), idx_k.clamp(min=0)
 
-        # 3. Create Batch Indices
-        # Broadcast Trunk Pair Embedding to Atom Pair Representation
-        # [B, Ntoken, c_atom_pair] -> [B, W, Lq, Lk, c_atompair]
-        # batch_idx: [B, 1, 1, 1]
-        # q_idx: [B, W, Lq] -> [B, W, Lq, 1]
-        # k_idx: [B, W, Lk] -> [B, W, 1, Lk]
-        batch_idx = torch.arange(B, device=p.device).view(B, 1, 1, 1)
-
-        # Token pair embedding to atom pair representation
-        z_to_p = z_trunk[batch_idx, q_idx[..., None], k_idx[..., None, :]]
+        # 3. Token pair embedding to atom pair representation
+        # [*, Ntoken, c_atom_pair] -> [*, W, Lq, Lk, c_atompair]
+        B = math.prod(batch_shape)
+        z_trunk = z_trunk.flatten(0, -4)  # [B, Lt, Lt, c_atompair]
+        batch_indices = torch.arange(B, device=p.device)
+        z_to_p = z_trunk[
+            batch_indices.view(B, 1, 1, 1),  # [B, 1, 1, 1]
+            idx_q.view(B, W, Lq, 1),
+            idx_k.view(B, W, 1, Lk),
+        ].unflatten(0, batch_shape)  # [*, W, Lq, Lk, c_atompair]
 
         # 5. Apply Padding Mask
-        q_mask = local_attn_index.to_query(atom_mask, dim=-1)  # [B, W, Lq]
-        k_mask = local_attn_index.to_key(atom_mask, dim=-1)  # [B, W, Lk]
-        pair_mask = q_mask[..., :, None] & k_mask[..., None, :]  # [B, W, Lq, Lk]
-        z_to_p.masked_fill_(~pair_mask[..., None], 0.0)
+        mask_q, mask_k = local_attn_index.to_qk(atom_mask, dim=-1)  # [*, W, Lq|Lk]
+        pair_mask = mask_q[..., :, None] & mask_k[..., None, :]  # [*, W, Lq, Lk]
+        z_to_p = z_to_p * pair_mask[..., None]  # [*, W, Lq, Lk, c_atompair]
 
         return p + z_to_p
 
@@ -905,14 +916,14 @@ class AtomAttentionEncoder(nn.Module):
         Parameters
         ----------
         q : torch.Tensor
-            The atom single representation, shape [B, N, La, c_atom].
+            The atom single representation, shape [*, La, c_atom].
         r_noisy : torch.Tensor
-            The noised structures' positions, shape [B, N, La, 3].
+            The noised structures' positions, shape [*, La, 3].
         """
         with torch.autocast(q.device.type, enabled=False):
             assert r_noisy.dtype == torch.float32, "r_noisy must be float32"
-            r_to_q = self.linear_r_to_q(r_noisy)  # [B, N, La, c_atom]
-        return q + r_to_q  # [B, N, La, c_atom]
+            r_to_q = self.linear_r_to_q(r_noisy)  # [*, La, c_atom]
+        return q + r_to_q  # [*, La, c_atom]
 
 
 class AtomAttentionDecoder(nn.Module):

--- a/src/kfold/model/layers/alphafold3/utils.py
+++ b/src/kfold/model/layers/alphafold3/utils.py
@@ -216,6 +216,29 @@ class LocalAttentionIndex:
 
         return gather_indices, pad_mask
 
+    def to_qk(self, x: torch.Tensor, dim: int = -2) -> tuple[torch.Tensor, torch.Tensor]:
+        """Convert single tensor to query and key tensors.
+        feature: [..., L, D] -> [..., W, Lq, D], [..., W, Lk, D]
+        mask, indices: [..., L] -> [..., W, Lq], [..., W, Lk]
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape [..., L, D] or [..., L]
+        dim : int, optional
+            Dimension corresponding to the atom sequence (default: -2)
+            should be -2 for features and -1 for masks or indices.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            Query tensor of shape [..., W, Lq, D] or [..., W, Lq]
+            Key tensor of shape [..., W, Lk, D] or [..., W, Lk]
+        """
+        queries = self.to_query(x, dim=dim)
+        keys = self.to_key(x, dim=dim)
+        return queries, keys
+
     def to_query(self, x: torch.Tensor, dim: int = -2) -> torch.Tensor:
         """Convert single tensor to query tensor.
         feature: [..., L, D] -> [..., W, Lq, D] (set dim=-2)

--- a/src/kfold/model/layers/boltz1/dropout.py
+++ b/src/kfold/model/layers/boltz1/dropout.py
@@ -27,7 +27,8 @@ def get_dropout_mask(
         The dropout mask
 
     """
-    dropout = dropout * training
+    if not training:
+        return torch.ones_like(z[:, 0:1, :, 0:1] if columnwise else z[:, :, 0:1, 0:1])
     v = z[:, 0:1, :, 0:1] if columnwise else z[:, :, 0:1, 0:1]
     d = torch.rand_like(v) > dropout
     d = d * 1.0 / (1.0 - dropout)

--- a/src/kfold/model/layers/boltz1/msa_module.py
+++ b/src/kfold/model/layers/boltz1/msa_module.py
@@ -363,10 +363,11 @@ class MSAModule(nn.Module):
 
         # Load relevant features
 
-        msa = torch.zeros(
+        msa = torch.ones(
             (f_input.batch_size, 2048, f_input.num_tokens, 33),
             device=f_input.token.res_type.device,
         )  # [B, 2048, L, 33]
+        msa[:, 0, :] = 0.0
         msa[:, 0, :, 1:] = f_input.token.res_type  # [B, 2048, L, 33]
         has_deletion = msa[..., :1] * 0.0  # [B, 2048, L, 1]
         deletion_value = has_deletion  # [B, 2048, L, 1]

--- a/src/kfold/model/layers/kfold/encoder.py
+++ b/src/kfold/model/layers/kfold/encoder.py
@@ -2,10 +2,8 @@ import torch
 
 import kfold.constants as C
 from kfold.data.model_input import FoldingInput
-from kfold.model.layers.alphafold3.input_encoder import (
-    AtomAttentionEncoderWithoutStructure,
-    InputFeatureEmbedder,
-)
+from kfold.model.layers.alphafold3.input_encoder import InputFeatureEmbedder
+from kfold.model.layers.kfold.transformers import AtomAttentionEncoderWithApo
 from kfold.model.layers.primitives import LinearNoBias
 
 
@@ -49,9 +47,97 @@ class PretrainedInputEmbedder(InputFeatureEmbedder):
             The number of heads in atom encoder.
         """
         super().__init__()
+        # pre-trained embedding projection
 
-        self.encoder = AtomAttentionEncoderWithoutStructure(
+        self.use_seq_enc = channel_seq_encoder is not None and channel_seq_encoder > 0
+        if channel_seq_encoder is not None:
+            self.proj_seq_enc = LinearNoBias(channel_seq_encoder, channel_s, init="zero")
+        self.use_struct_enc = (
+            channel_struct_encoder is not None and channel_struct_encoder > 0
+        )
+        if channel_struct_encoder is not None:
+            self.proj_struct_enc = LinearNoBias(
+                channel_struct_encoder, channel_s, init="zero"
+            )
+
+    def forward(self, f_input: FoldingInput) -> torch.Tensor:
+        """Perform the forward pass.
+
+        Parameters
+        ----------
+        input : FoldingInput
+            Input features
+
+        Returns
+        -------
+        Tensor
+            The embedded tokens. [B, Lt, c_s]
+        """
+        s = super().forward(f_input)  # [B, Lt, c_s]
+
+        # Add pre-trained sequence embedding if available
+        if self.use_seq_enc:
+            assert f_input.pretrained.has_sequence_embedding, (
+                "Pre-trained sequence embedding is not available in the input."
+            )
+            seq_enc = f_input.pretrained.sequence_embedding  # [B, Lt, c_seq_enc]
+            s = s + self.proj_seq_enc(seq_enc)
+
+        # Add pre-trained structure embedding if available
+        if self.use_struct_enc:
+            assert f_input.pretrained.has_structure_embedding, (
+                "Pre-trained structure embedding is not available in the input."
+            )
+            struct_enc = f_input.pretrained.structure_embedding  # [B, Lt, c_struct_enc]
+            s = s + self.proj_struct_enc(struct_enc)
+
+        return s
+
+
+class PretrainedInputEmbedderWithApo(torch.nn.Module):
+    """Input embedding module with pre-trained embeddings."""
+
+    def __init__(
+        self,
+        channel_s: int = 384,
+        channel_atom: int = 128,
+        channel_atompair: int = 16,
+        channel_seq_encoder: int | None = None,
+        channel_struct_encoder: int | None = None,
+        atoms_per_window_queries: int = 32,
+        atoms_per_window_keys: int = 128,
+        atom_encoder_blocks: int = 3,
+        atom_encoder_heads: int = 4,
+        blocks_per_ckpt: int | None = None,
+    ) -> None:
+        """Initialize the Input feature embedding module.
+
+        Parameters
+        ----------
+        channel_s : int
+            The token single embedding size.
+        channel_atom : int
+            The token single embedding size.
+        channel_atompair : int
+            The token pairwise embedding size.
+        channel_seq_encoder : int | None
+            The pre-trained sequence encoder output channel size.
+        channel_struct_encoder : int | None
+            The pre-trained structure encoder output channel size.
+        atoms_per_window_queries: int,
+            The number of atoms per window for queries.
+        atoms_per_window_keys: int,
+            The number of atoms per window for keys.
+        atom_encoder_blocks: int,
+            The number of blocks in atom encoder.
+        atom_encoder_heads: int,
+            The number of heads in atom encoder.
+        """
+        super().__init__()
+
+        self.encoder = AtomAttentionEncoderWithApo(
             channel_s=channel_s,
+            channel_z=None,
             channel_atom=channel_atom,
             channel_atompair=channel_atompair,
             channel_token=channel_s,

--- a/src/kfold/model/layers/kfold/transformers.py
+++ b/src/kfold/model/layers/kfold/transformers.py
@@ -1,0 +1,470 @@
+import math
+
+import torch
+import torch.nn as nn
+
+from kfold.data.model_input import FoldingInput
+from kfold.model.layers.alphafold3.embeddings import AtomEmbedding
+from kfold.model.layers.alphafold3.transformers import AtomTransformer
+from kfold.model.layers.alphafold3.utils import (
+    LocalAttentionIndex,
+    aggregate_atoms_to_tokens,
+    broadcast_tokens_to_atoms,
+)
+from kfold.model.layers.primitives import LayerNorm, LinearNoBias
+
+
+class AtomEmbeddingWithApo(AtomEmbedding):
+    """Atom embedding including apo position embedding."""
+
+    def __init__(self, channel_atom: int):
+        """Initialize the atom attention encoder.
+
+        Parameters
+        ----------
+        channel_atom : int
+            The atom single representation dimension.
+        """
+        super().__init__(channel_atom)
+        # additional embedding for apo structures (zero init)
+        self.embed_atom_apo_pos = LinearNoBias(3, channel_atom, init="zero")
+
+    def forward(self, f_input: FoldingInput) -> torch.Tensor:
+        """Embed atom features."""  # noqa: E501
+        atom_feats = super().forward(f_input)
+        # Additional apo position embedding
+        apo_coords = f_input.atom.apo_coords  # [B, La, 3]
+        with torch.autocast(atom_feats.device.type, enabled=False):
+            apo_coords_emb = self.embed_atom_apo_pos(apo_coords)
+        atom_feats = atom_feats + apo_coords_emb
+        return atom_feats
+
+
+class AtomAttentionEncoderWithApo(nn.Module):
+    """Atom attention encoder with apo embedding."""
+
+    def __init__(
+        self,
+        channel_s: int,  # 384 in AF3
+        channel_z: int | None,  # 128 in AF3
+        channel_atom: int,  # 128 in AF3
+        channel_atompair: int,  # 16 in AF3
+        channel_token: int,  # 384 (InputEmbedder) or 768 (Diffusion) in AF3
+        channel_coords: int = 3,
+        num_blocks=3,
+        num_heads=4,
+        atoms_per_window_queries: int = 32,
+        atoms_per_window_keys: int = 128,
+        use_structure: bool = True,
+        blocks_per_ckpt: int | None = None,
+    ):
+        """Initialize the atom attention encoder.
+
+        Parameters
+        ----------
+        channel_s : int
+            The single representation dimension.
+        channel_z : int | None
+            The pair representation dimension.
+        channel_atom : int
+            The atom single representation dimension.
+        channel_atompair : int
+            The atom pair representation dimension.
+        channel_token: int
+            The token single representation dimension.
+        num_blocks : int, optional
+            The number of transformer blocks, by default 3.
+        num_heads : int, optional
+            The number of transformer heads, by default 4.
+        atoms_per_window_queries : int
+            The number of atoms per window for queries.
+        atoms_per_window_keys : int
+            The number of atoms per window for keys.
+        use_structure : bool, optional
+            Whether to use structure information, by default True.
+        blocks_per_ckpt : int | None, optional
+            The number of blocks per checkpoint, by default None.
+
+        """
+        super().__init__()
+        self.atoms_per_window_queries: int = atoms_per_window_queries
+        self.atoms_per_window_keys: int = atoms_per_window_keys
+
+        # Embeddings atom features `c`
+        self.embed_atom = AtomEmbeddingWithApo(channel_atom)
+
+        # Embeddings for atom pair features `p`
+        # Reference position embeddings
+        self.embed_ref_offset = LinearNoBias(3, channel_atompair, init="default")
+        self.embed_ref_inv_dist = LinearNoBias(1, channel_atompair, init="default")
+        self.embed_ref_mask = LinearNoBias(1, channel_atompair, init="default")
+        # Apo position embeddings
+        self.embed_apo_offset = LinearNoBias(3, channel_atompair, init="default")
+        self.embed_apo_inv_dist = LinearNoBias(1, channel_atompair, init="default")
+        self.embed_apo_mask = LinearNoBias(1, channel_atompair, init="default")
+
+        self.use_structure = use_structure
+        if use_structure:
+            assert channel_z is not None, (
+                "channel_z must be provided if use_structure is True"
+            )
+            self.linear_s_to_c = nn.Sequential(
+                LayerNorm(channel_s, create_offset=False),
+                LinearNoBias(channel_s, channel_atom, init="final"),
+            )
+            self.linear_z_to_p = nn.Sequential(
+                LayerNorm(channel_z, create_offset=False),
+                LinearNoBias(channel_z, channel_atompair, init="final"),
+            )
+            self.linear_r_to_q = LinearNoBias(
+                channel_coords, channel_atom, init="default"
+            )
+        else:
+            assert channel_z is None, "channel_z must be None if use_structure is False"
+
+        self.linear_key = nn.Sequential(
+            nn.ReLU(),
+            LinearNoBias(channel_atom, channel_atompair, init="default"),
+        )
+
+        self.linear_query = nn.Sequential(
+            nn.ReLU(),
+            LinearNoBias(channel_atom, channel_atompair, init="default"),
+        )
+
+        self.mlp_pair = nn.Sequential(
+            nn.ReLU(),
+            LinearNoBias(channel_atompair, channel_atompair, init="relu"),
+            nn.ReLU(),
+            LinearNoBias(channel_atompair, channel_atompair, init="relu"),
+            nn.ReLU(),
+            LinearNoBias(channel_atompair, channel_atompair, init="final"),
+        )
+
+        self.atom_encoder = AtomTransformer(
+            channel_a=channel_atom,
+            channel_s=channel_atom,
+            channel_z=channel_atompair,
+            num_blocks=num_blocks,
+            num_heads=num_heads,
+            attn_window_queries=atoms_per_window_queries,
+            attn_window_keys=atoms_per_window_keys,
+            blocks_per_ckpt=blocks_per_ckpt,
+        )
+
+        self.linear_q_to_a = nn.Sequential(
+            LinearNoBias(channel_atom, channel_token, init="default"),
+            nn.ReLU(),
+        )
+
+    def forward(
+        self,
+        f_input: FoldingInput,
+        s_trunk: torch.Tensor | None,
+        z_trunk: torch.Tensor | None,
+        r_noisy: torch.Tensor | None,
+        model_cache: dict | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward pass of the atom attention encoder.
+        See Algorithm 5 in the AF3 paper for more details.
+
+        q: Atom single representation
+        c: Atom single conditioning
+        p: Atom pair representation
+
+        Parameters
+        ----------
+        f_input : FoldingInput
+            The folding input. (batch size B)
+        s_trunk : torch.Tensor | None
+            The trunk single representation, shape [B, N, Lt, c_s].
+            where Nsample is the number of diffusion samples.
+        z_trunk : torch.Tensor | None
+            The conditioning pair representation, shape [B, N, Lt, c_z].
+        r_noisy : torch.Tensor | None
+            The noised structures' positions, shape [B, N, La, c_r],
+        model_cache : dict | None
+            The model cache for storing intermediate representations, by default None.
+
+        Returns
+        -------
+        a : torch.Tensor
+            The token single representation
+            Shape: [B, Lt, c_token] or [B, N, Lt, c_token]
+        q_skip : torch.Tensor
+            The atom single representation
+            shape [B, La, c_atom] or [B, N, La, c_atom]
+        c_skip : torch.Tensor
+            The atom single conditioning
+            shape [B, La, c_atom] or [B, N, La, c_atom]
+        p_skip : torch.Tensor
+            The atom pair representation
+            shape [B, W, Lq, Lk, c_atompair] or [B, N, W, Lq, Lk, c_atompair]
+        """
+        if self.use_structure:
+            assert s_trunk is not None and z_trunk is not None and r_noisy is not None
+
+        if model_cache is not None:
+            assert self.use_structure, "Caching is only supported when using structure."
+            cache_prefix = "atom_attn_encoder"
+            if cache_prefix not in model_cache:
+                model_cache[cache_prefix] = {}
+            layer_cache = model_cache[cache_prefix]
+        else:
+            layer_cache = {}
+
+        local_attn_index = LocalAttentionIndex(
+            num_atoms=f_input.num_atoms,
+            atoms_per_window_queries=self.atoms_per_window_queries,
+            atoms_per_window_keys=self.atoms_per_window_keys,
+            device=f_input.device,
+        )
+        if "qcp" in layer_cache:
+            q, c, p = layer_cache["qcp"]
+        else:
+            q, c, p = self.initialize_atom_representation(f_input, local_attn_index)
+            layer_cache["qcp"] = (q, c, p)
+
+        # Shapes at this point:
+        # q: [B, La, c_atom]
+        # c: [B, La, c_atom]
+        # p: [B, W, Lq, Lk, c_atompair]
+
+        mask = f_input.atom.pad_mask  # [B, La]
+        token_index = f_input.atom.token_index  # [B, La]
+
+        # Add trunk embedding and noise position
+        if self.use_structure:
+            assert s_trunk is not None and z_trunk is not None and r_noisy is not None
+            # Broadcast for multiple diffusion samples
+            # [B, ...] -> [B, N, ...]
+            q = q.unsqueeze(1)  # [B, 1, La, c_atom]
+            c = c.unsqueeze(1)  # [B, 1, La, c_atom]
+            p = p.unsqueeze(1)  # [B, 1, W, Lq, Lk, c_atompair]
+            mask = mask.unsqueeze(1)  # [B, 1, La]
+            token_index = token_index.unsqueeze(1)  # [B, 1, La]
+
+            c = self.add_trunk_single_conditioning(c, s_trunk, token_index, mask)
+            p = self.add_trunk_pair_embedding(
+                p, z_trunk, token_index, mask, local_attn_index
+            )
+            q = self.add_noise_position(q, r_noisy)
+
+        # Add atom-wise contributions to pair representation
+        c_q = local_attn_index.to_query(c)  # [B, *, W, Lq, c_atom]
+        c_k = local_attn_index.to_key(c)  # [B, *, W, Lk, c_atom]
+        p = p + self.linear_query(c_q)[..., :, None, :]
+        p = p + self.linear_key(c_k)[..., None, :, :]
+        p = p + self.mlp_pair(p)  # [B, *, W, Lq, Lk, c_atompair]
+
+        q = self.atom_encoder(q, c, p, mask)
+
+        # Aggregate atom representations to token representations
+        # [B, *, La, c_atom] -> [B, *, Lt, c_token]
+        q_to_a = self.linear_q_to_a(q)  # [B, *, La, c_token]
+        a = aggregate_atoms_to_tokens(
+            q_to_a,  # [*, La, c_token]
+            token_index=token_index,  # [*, La]
+            num_tokens=f_input.num_tokens,
+            atom_mask=mask,  # [*, La]
+            aggr="mean",
+        )
+
+        q_skip, c_skip, p_skip = q, c, p
+
+        return a, q_skip, c_skip, p_skip
+
+    def initialize_atom_representation(
+        self,
+        f_input: FoldingInput,
+        local_attn_index: LocalAttentionIndex,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Initialize atom representations.
+
+        Parameters
+        ----------
+        f_input : FoldingInput
+            The folding input.
+        Returns
+        -------
+        q : torch.Tensor
+            The atom single representation, shape [B, La, c_atom].
+        c : torch.Tensor
+            The atom single conditioning, shape [B, La, c_atom].
+        p : torch.Tensor
+            The atom pair representation, shape [B, W, Lq, Lk, c_atompair].
+        """
+        # Get indexing matrix for single to keys conversion
+
+        # === Initialize single conditioning === #
+        c = self.embed_atom(f_input)  # [B, La, c_atom]
+
+        # === Initialize atom single representation === #
+        q = c  # [B, La, c_atom]
+
+        # === Initialize pair representation === #
+        # 1. Reference positions
+        # Masking with residue identity
+        uid = f_input.atom.ref_space_uid
+        uid_q, uid_k = local_attn_index.to_qk(uid, dim=-1)
+        ref_v = uid_q[..., :, None] == uid_k[..., None, :]  # [B, W, Lq, Lk]
+        ref_v = ref_v.to(dtype=c.dtype).unsqueeze(-1)  # [B, W, Lq, Lk, 1]
+
+        # Shape: [B, W, Lq], [B, W, Lk]
+        ref_pos = f_input.atom.ref_pos  # [B, La, 3]
+        ref_pos_q = local_attn_index.to_query(ref_pos)  # [B, W, Lq, 3]
+        ref_pos_k = local_attn_index.to_key(ref_pos)  # [B, W, Lk, 3]
+
+        # Shape: [B, W, Lq, Lk, 3], [B, W, Lq, Lk, 1]
+        ref_d_offset = ref_pos_q[..., :, None, :] - ref_pos_k[..., None, :, :]
+        ref_dsq_inv = 1.0 / (1.0 + ref_d_offset.pow(2).sum(-1, keepdim=True))
+
+        # Shape: [B, W, Lq, Lk, c_atompair]
+        p_ref = self.embed_ref_offset(ref_d_offset)
+        p_ref = p_ref + self.embed_ref_inv_dist(ref_dsq_inv)
+        p_ref = p_ref + self.embed_ref_mask(ref_v)
+        p_ref = p_ref * ref_v
+
+        # 2. Apo chain positions
+        # Masking with chain identity
+        asym_id = broadcast_tokens_to_atoms(
+            f_input.token.asym_id, f_input.atom.token_index
+        )
+        asym_id_q, asym_id_k = local_attn_index.to_qk(asym_id, dim=-1)
+        apo_v = asym_id_q[..., :, None] == asym_id_k[..., None, :]  # [B, W, Lq, Lk]
+        apo_v = apo_v.to(dtype=c.dtype).unsqueeze(-1)  # [B, W, Lq, Lk, 1]
+
+        with torch.autocast(c.device.type, enabled=False):
+            # Disable autocast for numerical stability
+            apo_pos = f_input.atom.apo_coords  # [B, La, 3]
+            apo_pos_q = local_attn_index.to_query(apo_pos)  # [B, W, Lq, 3]
+            apo_pos_k = local_attn_index.to_key(apo_pos)  # [B, W, Lk, 3]
+            # Shape: [B, W, Lq, Lk, 3], [B, W, Lq, Lk, 1]
+            apo_d_offset = apo_pos_q[..., :, None, :] - apo_pos_k[..., None, :, :]
+            apo_dsq_inv = 1.0 / (1.0 + apo_d_offset.pow(2).sum(-1, keepdim=True))
+
+        # Shape: [B, W, Lq, Lk, c_atompair]
+        p_apo = self.embed_apo_offset(apo_d_offset)
+        p_apo = p_apo + self.embed_apo_inv_dist(apo_dsq_inv)
+        p_apo = p_apo + self.embed_apo_mask(apo_v)
+        p_apo = p_apo * apo_v
+
+        # Combine reference and apo position embeddings
+        p = p_ref + p_apo  # [B, W, Lq, Lk, c_atompair]
+
+        # Masking with padding mask
+        mask_q, mask_k = local_attn_index.to_qk(f_input.atom.pad_mask, dim=-1)
+        pair_mask = mask_q[..., :, None] & mask_k[..., None, :]
+
+        p = p * pair_mask[..., None]  # [B, W, Lq, Lk, c_atompair]
+
+        return q, c, p
+
+    def add_trunk_single_conditioning(
+        self,
+        c: torch.Tensor,
+        s_trunk: torch.Tensor,
+        token_index: torch.Tensor,
+        atom_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Algorithm 5, Line 9 in AlphaFold3 SI
+        Add trunk single embedding to atom single conditioning.
+
+        Parameters
+        ----------
+        c : torch.Tensor
+            The atom single conditioning, shape [*, La, c_atom].
+        s_trunk : torch.Tensor
+            The trunk single representation, shape [*, Lt, c_s].
+        token_index: torch.Tensor
+            The atom to token mapping, shape [*, La].
+        atom_mask : torch.Tensor
+            The atom padding mask, shape [*, La]
+        """
+        # Case 2
+        s_trunk = self.linear_s_to_c(s_trunk)  # [*, Lt, c_atom]
+        s_to_c = broadcast_tokens_to_atoms(s_trunk, token_index)  # [*, La, c_atom]
+        s_to_c = s_to_c * atom_mask[..., None]  # [*, La, c_atom]
+        return c + s_to_c  # [*, La, c_atom]
+
+    def add_trunk_pair_embedding(
+        self,
+        p: torch.Tensor,
+        z_trunk: torch.Tensor,
+        token_index: torch.Tensor,
+        atom_mask: torch.Tensor,
+        local_attn_index: LocalAttentionIndex,
+    ) -> torch.Tensor:
+        """Algorithm 5, Line 10 in AlphaFold3 SI
+        Add trunk pair embedding to atom pair representation.
+
+        Parameters
+        ----------
+        p : torch.Tensor
+            The atom pair representation, shape [*, W, Lq, Lk, c_atompair].
+        z_trunk : torch.Tensor
+            The trunk pair representation, shape [*, Lt, Lt, c_z].
+        token_index : torch.Tensor
+            The atom to token mapping, shape [*, La].
+        local_attn_index : LocalAttentionIndex
+            The local attention indexer for atom attention.
+
+        Returns
+        -------
+        p : torch.Tensor
+            The updated atom pair representation, shape [*, W, Lq, Lk, c_atompair].
+        """
+        batch_shape = z_trunk.shape[:-3]  # [*]
+        W, Lq, Lk = p.shape[-4:-1]
+
+        # 1. Project Trunk features
+        # [*, Lt, Lt, c_z] -> [*, Lt, Lt, c_atompair]
+        z_trunk = self.linear_z_to_p(z_trunk)
+
+        # 2. Get Windowed Indices
+        # [*, La] -> [*, W, Lq], [*, W, Lk]
+        q_idx, k_idx = local_attn_index.to_qk(token_index, dim=-1)
+        q_idx = q_idx.expand(*batch_shape, W, Lq)
+        k_idx = k_idx.expand(*batch_shape, W, Lk)
+
+        # NOTE: safe indexing: Although the pad value of token_index is 0,
+        # we clamp indices to be at least 0 to avoid run-time error.
+        q_idx, k_idx = q_idx.clamp(min=0), k_idx.clamp(min=0)
+
+        # 3. Token pair embedding to atom pair representation
+        # [*, Ntoken, c_atom_pair] -> [*, W, Lq, Lk, c_atompair]
+        B = math.prod(batch_shape)
+        z_trunk = z_trunk.flatten(0, -4)  # [B, Lt, Lt, c_atompair]
+        batch_indices = torch.arange(B, device=p.device)
+        z_to_p = z_trunk[
+            batch_indices.view(B, 1, 1, 1),  # [B, 1, 1, 1]
+            q_idx.view(B, W, Lq, 1),
+            k_idx.view(B, W, 1, Lk),
+        ].unflatten(0, batch_shape)  # [*, W, Lq, Lk, c_atompair]
+
+        # 5. Apply Padding Mask
+        q_mask = local_attn_index.to_query(atom_mask, dim=-1)  # [*, W, Lq]
+        k_mask = local_attn_index.to_key(atom_mask, dim=-1)  # [*, W, Lk]
+        pair_mask = q_mask[..., :, None] & k_mask[..., None, :]  # [*, W, Lq, Lk]
+        z_to_p = z_to_p * pair_mask[..., None]  # [*, W, Lq, Lk, c_atompair]
+
+        return p + z_to_p
+
+    def add_noise_position(
+        self,
+        q: torch.Tensor,
+        r_noisy: torch.Tensor,
+    ) -> torch.Tensor:
+        """Algorithm 5, Line 11
+        Add noise position to atom single representation.
+
+        Parameters
+        ----------
+        q : torch.Tensor
+            The atom single representation, shape [*, La, c_atom].
+        r_noisy : torch.Tensor
+            The noised structures' positions, shape [*, La, 3].
+        """
+        with torch.autocast(q.device.type, enabled=False):
+            r_to_q = self.linear_r_to_q(r_noisy)  # [*, La, c_atom]
+        return q + r_to_q  # [*, La, c_atom]

--- a/src/kfold/model/layers/kfold/transformers.py
+++ b/src/kfold/model/layers/kfold/transformers.py
@@ -30,7 +30,7 @@ class AtomEmbeddingWithApo(AtomEmbedding):
         self.embed_atom_apo_pos = LinearNoBias(3, channel_atom, init="zero")
 
     def forward(self, f_input: FoldingInput) -> torch.Tensor:
-        """Embed atom features."""  # noqa: E501
+        """Embed atom features with Apo positional embedding."""
         atom_feats = super().forward(f_input)
         # Additional apo position embedding
         apo_coords = f_input.atom.apo_coords  # [B, La, 3]
@@ -285,6 +285,9 @@ class AtomAttentionEncoderWithApo(nn.Module):
         ----------
         f_input : FoldingInput
             The folding input.
+        local_attn_index : LocalAttentionIndex
+            The local attention indexer for atom attention.
+
         Returns
         -------
         q : torch.Tensor
@@ -367,8 +370,7 @@ class AtomAttentionEncoderWithApo(nn.Module):
         token_index: torch.Tensor,
         atom_mask: torch.Tensor,
     ) -> torch.Tensor:
-        """Algorithm 5, Line 9 in AlphaFold3 SI
-        Add trunk single embedding to atom single conditioning.
+        """Add trunk single embedding to atom single conditioning.
 
         Parameters
         ----------
@@ -384,7 +386,7 @@ class AtomAttentionEncoderWithApo(nn.Module):
         # Case 2
         s_trunk = self.linear_s_to_c(s_trunk)  # [*, Lt, c_atom]
         s_to_c = broadcast_tokens_to_atoms(s_trunk, token_index)  # [*, La, c_atom]
-        s_to_c = s_to_c * atom_mask[..., None]  # [*, La, c_atom]
+        s_to_c = s_to_c * atom_mask.unsqueeze(-1)  # [*, La, c_atom]
         return c + s_to_c  # [*, La, c_atom]
 
     def add_trunk_pair_embedding(
@@ -395,8 +397,7 @@ class AtomAttentionEncoderWithApo(nn.Module):
         atom_mask: torch.Tensor,
         local_attn_index: LocalAttentionIndex,
     ) -> torch.Tensor:
-        """Algorithm 5, Line 10 in AlphaFold3 SI
-        Add trunk pair embedding to atom pair representation.
+        """Add trunk pair embedding to atom pair representation.
 
         Parameters
         ----------
@@ -406,13 +407,10 @@ class AtomAttentionEncoderWithApo(nn.Module):
             The trunk pair representation, shape [*, Lt, Lt, c_z].
         token_index : torch.Tensor
             The atom to token mapping, shape [*, La].
+        atom_mask : torch.Tensor
+            The atom padding mask, shape [*, La].
         local_attn_index : LocalAttentionIndex
             The local attention indexer for atom attention.
-
-        Returns
-        -------
-        p : torch.Tensor
-            The updated atom pair representation, shape [*, W, Lq, Lk, c_atompair].
         """
         batch_shape = z_trunk.shape[:-3]  # [*]
         W, Lq, Lk = p.shape[-4:-1]
@@ -423,13 +421,13 @@ class AtomAttentionEncoderWithApo(nn.Module):
 
         # 2. Get Windowed Indices
         # [*, La] -> [*, W, Lq], [*, W, Lk]
-        q_idx, k_idx = local_attn_index.to_qk(token_index, dim=-1)
-        q_idx = q_idx.expand(*batch_shape, W, Lq)
-        k_idx = k_idx.expand(*batch_shape, W, Lk)
+        idx_q, idx_k = local_attn_index.to_qk(token_index, dim=-1)
+        idx_q = idx_q.expand(*batch_shape, W, Lq)
+        idx_k = idx_k.expand(*batch_shape, W, Lk)
 
         # NOTE: safe indexing: Although the pad value of token_index is 0,
         # we clamp indices to be at least 0 to avoid run-time error.
-        q_idx, k_idx = q_idx.clamp(min=0), k_idx.clamp(min=0)
+        idx_q, idx_k = idx_q.clamp(min=0), idx_k.clamp(min=0)
 
         # 3. Token pair embedding to atom pair representation
         # [*, Ntoken, c_atom_pair] -> [*, W, Lq, Lk, c_atompair]
@@ -438,14 +436,13 @@ class AtomAttentionEncoderWithApo(nn.Module):
         batch_indices = torch.arange(B, device=p.device)
         z_to_p = z_trunk[
             batch_indices.view(B, 1, 1, 1),  # [B, 1, 1, 1]
-            q_idx.view(B, W, Lq, 1),
-            k_idx.view(B, W, 1, Lk),
+            idx_q.view(B, W, Lq, 1),
+            idx_k.view(B, W, 1, Lk),
         ].unflatten(0, batch_shape)  # [*, W, Lq, Lk, c_atompair]
 
         # 5. Apply Padding Mask
-        q_mask = local_attn_index.to_query(atom_mask, dim=-1)  # [*, W, Lq]
-        k_mask = local_attn_index.to_key(atom_mask, dim=-1)  # [*, W, Lk]
-        pair_mask = q_mask[..., :, None] & k_mask[..., None, :]  # [*, W, Lq, Lk]
+        mask_q, mask_k = local_attn_index.to_qk(atom_mask, dim=-1)  # [*, W, Lq|Lk]
+        pair_mask = mask_q[..., :, None] & mask_k[..., None, :]  # [*, W, Lq, Lk]
         z_to_p = z_to_p * pair_mask[..., None]  # [*, W, Lq, Lk, c_atompair]
 
         return p + z_to_p
@@ -466,5 +463,6 @@ class AtomAttentionEncoderWithApo(nn.Module):
             The noised structures' positions, shape [*, La, 3].
         """
         with torch.autocast(q.device.type, enabled=False):
+            assert r_noisy.dtype == torch.float32, "r_noisy must be float32"
             r_to_q = self.linear_r_to_q(r_noisy)  # [*, La, c_atom]
         return q + r_to_q  # [*, La, c_atom]

--- a/src/kfold/model/layers/primitives/dropout.py
+++ b/src/kfold/model/layers/primitives/dropout.py
@@ -29,7 +29,8 @@ def get_dropout_mask(
         The dropout mask
 
     """
-    dropout = dropout * training
+    if (not training) or (dropout == 0.0):
+        return torch.ones_like(z[:, 0:1, :, 0:1] if columnwise else z[:, :, 0:1, 0:1])
     v = z[:, 0:1, :, 0:1] if columnwise else z[:, :, 0:1, 0:1]
     d = torch.rand_like(v) >= dropout
     d = d * 1.0 / (1.0 - dropout)

--- a/src/kfold/training/folding/dataset/datamodule.py
+++ b/src/kfold/training/folding/dataset/datamodule.py
@@ -205,7 +205,6 @@ class TrainingDataModule(pl.LightningDataModule):
         with open(validation_split) as f:
             val_ids = set([line.strip().lower() for line in f if line.strip()])
         val_records = [r for r in all_records if r.id.lower() in val_ids]
-        val_records = sorted(val_records, key=lambda r: r.num_residues)
 
         # Sort validation records by length (for efficient batching)
         val_records.sort(key=lambda r: r.num_valid_residues, reverse=False)

--- a/src/kfold/training/folding/metrics/structure.py
+++ b/src/kfold/training/folding/metrics/structure.py
@@ -6,9 +6,9 @@ from kfold.data.model_input import FoldingInput
 from kfold.training.folding.dataset.utils.permutation import get_aligned_true_coords
 from kfold.training.folding.loss.diffusion import (
     compute_modality_weights,
-    get_atom_weights,
     weighted_rigid_align,
 )
+from kfold.utils.geometry.rigid_align import rigid_align
 
 
 def compute_pair_lddt(
@@ -56,6 +56,12 @@ def compute_rmsd(
     torch.Tensor
         The rmsd score between predicted and true coordinates
     """
+    true_coords = rigid_align(
+        coords=true_coords,  # [B, N, L, 3]
+        target=pred_coords,  # [B, N, L, 3]
+        mask=mask,  # [B, 1, L]
+    )  # [B, N, L, 3]
+
     diff = ((pred_coords - true_coords) ** 2).sum(-1)
     masked_diff = diff * mask
     mse = masked_diff.sum() / mask.sum()
@@ -94,8 +100,8 @@ def compute_weighted_rmsd(
         weights = weights * mask.float()
 
     aligned_coords_true = weighted_rigid_align(
-        coords=true_coords.float(),  # [B, N, L, 3]
-        target=pred_coords.float(),  # [B, N, L, 3]
+        coords=true_coords,  # [B, N, L, 3]
+        target=pred_coords,  # [B, N, L, 3]
         weights=weights,  # [B, 1, L], broadcasted over N
         mask=mask,  # [B, 1, L]
     )  # [B, N, L, 3]
@@ -153,6 +159,8 @@ def compute_validation_metric_singles(
     assert pred_coords.shape == true_coords.shape, (
         "Predicted and true coordinates must have the same shape."
     )
+    # Convert to float32
+    pred_coords, true_coords = pred_coords.float(), true_coords.float()
 
     metrics: dict[str, torch.Tensor] = {}
     weights: dict[str, torch.Tensor] = {}
@@ -194,6 +202,8 @@ def compute_validation_metric_singles(
     valid_mask.diagonal().fill_(0)  # Exclude self-pairs
     local_mask_15 = pdist_true < 15.0
     local_mask_30 = pdist_true < 30.0  # For DNA/RNA intra-chains and interfaces
+    local_mask_15 = local_mask_15 & valid_mask
+    local_mask_30 = local_mask_30 & valid_mask
 
     # Compute intra-chain metrics
     intra_mask = asym_id[:, None] == asym_id[None, :]
@@ -249,6 +259,9 @@ def compute_validation_metric_singles(
         total_pairs = lddt_mask.sum()
         lddt = (lddt_score * lddt_mask).sum() / total_pairs.clamp(1)
         metrics[metric_name] = lddt
+        if ctype1 != ctype2:
+            # Count both sides for hetero-interfaces
+            total_pairs = total_pairs * 2
         weights[metric_name] = total_pairs
 
     # Compute complex lddt
@@ -383,18 +396,22 @@ def compute_validation_metrics(
     # No prefix: best values for each metric across samples.
     # "avg_" prefix: average over all samples
     # "complex_" prefix: values of the highest-lddt sample.
+    # NOTE: use binary weights instead of number of pairs for averaging,
     validation_metrics: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
     for k in all_metrics.keys():
         v = torch.stack(all_metrics[k], dim=0)
         w = torch.stack(all_weights[k], dim=0)
+        w = (w > 0).float()  # Use binary weights for averaging
         validation_metrics[f"avg_{k}"] = (v, w)
     for k in all_best_metrics.keys():
         v = torch.stack(all_best_metrics[k], dim=0)
         w = torch.stack(all_best_weights[k], dim=0)
+        w = (w > 0).float()  # Use binary weights for averaging
         validation_metrics[k] = (v, w)
     for k in all_best_complex_metrics.keys():
         v = torch.stack(all_best_complex_metrics[k], dim=0)
         w = torch.stack(all_best_complex_weights[k], dim=0)
+        w = (w > 0).float()  # Use binary weights for averaging
         validation_metrics[f"complex_{k}"] = (v, w)
 
     # HACK: Boltz1 called 'weighted_lddt' as 'lddt'.
@@ -446,24 +463,21 @@ def permute_label_coordinates(
             )  # [Nsample, Natom, 3], [Nsample, Natom]
             aligned_true_coords_list.append(true_coords_aligned)
             resolved_mask_list.append(mask)
-        aligned_coords = torch.stack(
+        true_coords = torch.stack(
             aligned_true_coords_list, dim=0
         )  # [B, Nsample, Natom, 3]
         mask = torch.stack(resolved_mask_list, dim=0)  # [B, Nsample, Natom]
 
     else:
-        """Perform weighted rigid alignment without symmetry correction."""
         true_coords = f_input.atom.label_coords  # [B, Natom, 3]
         mask = f_input.atom.resolved_mask  # [B, Natom]
 
         # Weighted rigid alignment for best permutation
-        weights = get_atom_weights(f_input)  # [B, Natom]
         true_coords = true_coords[:, None, :, :]  # [B, 1, Natom, 3]
-        weights = weights[:, None, :]  # [B, 1, Natom]
         mask = mask[:, None, :]  # [B, 1, Natom]
-        aligned_coords = weighted_rigid_align(true_coords, pred_coords, weights, mask)
 
-        # Expand mask
+        # Expand
+        true_coords = true_coords.expand(-1, Nsample, -1, -1)  # [B, Nsample, Natom, 3]
         mask = mask.expand(-1, Nsample, -1)  # [B, Nsample, Natom]
 
-    return aligned_coords, mask
+    return true_coords, mask

--- a/src/kfold/training/folding/metrics/structure.py
+++ b/src/kfold/training/folding/metrics/structure.py
@@ -21,9 +21,9 @@ def compute_pair_lddt(
     Parameters
     ----------
     d_predicted : torch.Tensor
-        Predicted distances, shape (B, Natom, Natom)
+        Predicted distances, shape (*, Natom, Natom)
     d_true : torch.Tensor
-        Ground truth distances, shape (B, Natom, Natom)
+        Ground truth distances, shape (*, Natom, Natom)
     thresholds : Sequence[float]
         Distance error thresholds for lddt calculation
     """
@@ -57,10 +57,10 @@ def compute_rmsd(
         The rmsd score between predicted and true coordinates
     """
     true_coords = rigid_align(
-        coords=true_coords,  # [B, N, L, 3]
-        target=pred_coords,  # [B, N, L, 3]
-        mask=mask,  # [B, 1, L]
-    )  # [B, N, L, 3]
+        coords=true_coords,  # [Natom, 3]
+        target=pred_coords,  # [Natom, 3]
+        mask=mask,  # [Natom]
+    )  # [Natom, 3]
 
     diff = ((pred_coords - true_coords) ** 2).sum(-1)
     masked_diff = diff * mask
@@ -100,21 +100,20 @@ def compute_weighted_rmsd(
         weights = weights * mask.float()
 
     aligned_coords_true = weighted_rigid_align(
-        coords=true_coords,  # [B, N, L, 3]
-        target=pred_coords,  # [B, N, L, 3]
-        weights=weights,  # [B, 1, L], broadcasted over N
-        mask=mask,  # [B, 1, L]
-    )  # [B, N, L, 3]
+        coords=true_coords,  # [Natom, 3]
+        target=pred_coords,  # [Natom, 3]
+        weights=weights,  # [Natom, L], broadcasted over N
+        mask=mask,  # [Natom, L]
+    )  # [Natom, 3]
 
-    d_sq = ((pred_coords - aligned_coords_true) ** 2).sum(dim=-1)  # [B, N, L]
+    d_sq = ((pred_coords - aligned_coords_true) ** 2).sum(dim=-1)  # [Natom]
     if scale:
-        weight_sum = weights.sum(-1).clamp(min=1)  # [B, 1]
-        mse_loss = (weights * d_sq).sum(-1) / weight_sum  # [B, N]
+        weight_sum = weights.sum().clamp(min=1)
+        mse_loss = (weights * d_sq).sum() / weight_sum
     else:
-        mask_sum = mask.sum(-1).clamp(min=1)  # [B, 1]
-        mse_loss = (weights * d_sq).sum(-1) / mask_sum  # [B, N]
+        mask_sum = mask.sum().clamp(min=1)
+        mse_loss = (weights * d_sq).sum() / mask_sum
     weighted_rmsd = torch.sqrt(mse_loss)
-
     return weighted_rmsd
 
 


### PR DESCRIPTION
This pull request refactors several components of the AlphaFold3 model implementation, primarily to improve consistency in tensor shapes, simplify the codebase, and remove redundant classes. The changes affect the diffusion and transformer modules, input encoder, and configuration files. Key improvements include the removal of the `AtomAttentionEncoderWithoutStructure` class, standardization of tensor broadcasting, and updates to configuration parameters for model validation and training.

### Model architecture and codebase simplification

* Removed the `AtomAttentionEncoderWithoutStructure` class and replaced its usage with `AtomAttentionEncoder` configured with `use_structure=False`, reducing code redundancy and simplifying input encoding logic. (`src/kfold/model/layers/alphafold3/input_encoder.py`) 
* Refactored tensor shape handling in the diffusion and transformer modules to consistently use broadcasting and generic batch shapes (`[*]`), improving code maintainability and reducing shape-related bugs. This affects methods such as `forward`, `add_trunk_single_conditioning`, `add_trunk_pair_embedding`, and `add_noise_position`. (`src/kfold/model/layers/alphafold3/diffusion.py`, `src/kfold/model/layers/alphafold3/transformers.py`)
* Introduced a new helper method `initialize_atom_representation` in `AtomAttentionEncoder` to encapsulate atom representation initialization logic, improving readability and separation of concerns. (`src/kfold/model/layers/alphafold3/transformers.py`)

### Configuration and training setup

* Updated model and training configuration files to adjust hyperparameters (`noise_scale`, `step_scale`), remove weight freezing, and correct dataset paths, ensuring proper model validation and training with the latest data. (`configs/model/module/structure_module/boltz1.yaml`, `configs/validate-boltz1-pretrained.yaml`)