### PR TITLE
Implement multi anchor cropping

### DIFF
--- a/src/kfold/data/metadata.py
+++ b/src/kfold/data/metadata.py
@@ -71,15 +71,13 @@ class ChainInfo(JsonSerializable):
 
 @dataclass(frozen=True, slots=True)
 class InterfaceInfo(JsonSerializable):
-    # NOTE(seonghwanseo): I change (asym_id1, asym_id2) to {asym_id} to
-    # support multi-chain interaces (e.g., Protac)
-    asym_ids: tuple[int, ...]
+    asym_ids: tuple[int, int]
     # covalent bond interface. If True, the chains must be sampled together.
     is_bonded: bool = False
     valid: bool = True
 
     def __post_init__(self):
-        assert len(self.asym_ids) >= 2, "Interface must involve at least two chains."
+        assert len(self.asym_ids) == 2, "Interface must involve exactly two chains."
 
 
 @dataclass

--- a/src/kfold/training/folding/dataset/cropper/alphafold.py
+++ b/src/kfold/training/folding/dataset/cropper/alphafold.py
@@ -3,27 +3,7 @@
 Implements three kinds of cropping strategies:
 - Contiguous: crops a contiguous regions of tokens from a single chain.
 - Spatial: crops a region of tokens centered on a random token.
-- Spatial-interface: crops a region of tokens centered on a random interface between
-    two chains.
-
-NOTE: (pminha01) I understood the cropping logic as follows:
-Input: a TokenizedStructure object, max_tokens, asym_ids
-    (None for random, length 1 for single chain, length 2 for interface)
-Output: a numpy array of token indices to include in the crop.
- 1. Randomly select a cropping strategy (based on the weights created in the Config)
- 2. If the strategy is contiguous, then crop a contiguous region of tokens from a single
-    chain. Repeat for all chains until max_tokens is reached.
- 3. If the strategy is spatial, then crop a region of tokens centered on a token.
-    If asym_ids is provided, then the crop is centered on the specified chain. Else, a
-    random token is selected from a random chain.
- 4. If the strategy is spatial-interface, then crop a region of tokens centered on
-    an interface-representing token between two chains. If asym_ids is provided,
-    then the crop is centered on the specified interface or specified chain. Else, a
-    random interface is selected from a random interface between two chains.
-
-NOTE: (pminha01) This relies heavily on the fact that the TokenizedStructure object
-contains a valid metadata object. If such an object does not exist, then any crop
-involving a random interface (spatial-interface cropping) will default to a random center.
+- Spatial-interface: crops a region of tokens centered on a random interface.
 """
 
 import numpy as np
@@ -31,47 +11,8 @@ import numpy as np
 from kfold.data.structure import TokenizedStructure
 from kfold.utils.registry import DATA_CROPPER
 
+from . import utils
 from .base import BaseCropper
-from .boltz import pick_chain_token, pick_interface_token
-
-
-def get_random_interface(
-    structure: TokenizedStructure, chain_id: int | None
-) -> tuple[int, int] | None:
-    """Get a random interface from the metadata.
-
-    Parameters
-    ----------
-    structure: TokenizedStructure
-        The tokenized structure.
-    chain_id: int | None
-        The chain ID to center the crop on. If None, a random interface is selected.
-
-    Returns
-    ----------
-    interface_asym_ids: tuple[int, int] | None
-        The asymmetric unit IDs of the interface or None if no valid interface is found.
-    """
-    if structure.metadata is None:
-        return None
-    if structure.metadata.interfaces is None or len(structure.metadata.interfaces) == 0:
-        return None
-
-    # any random interface
-    if chain_id is None:
-        interface = np.random.choice(structure.metadata.interfaces)
-        return interface.asym_ids
-
-    # random interface that includes chain_id
-    valid_interfaces = [
-        i for i in structure.metadata.interfaces if chain_id in i.asym_ids
-    ]
-    if valid_interfaces:
-        interface = np.random.choice(valid_interfaces)
-        return interface.asym_ids
-
-    # should never reach here
-    return None
 
 
 @DATA_CROPPER.register()
@@ -95,58 +36,64 @@ class AlphaFold3Cropper(BaseCropper):
             The maximum number of chains to consider during contiguous cropping.
         """
 
-        contiguous: float = 0.2
-        spatial: float = 0.4
-        spatial_interface: float = 0.4
-        max_chains: int = 20
+        w_contiguous: float = 0.2
+        w_spatial: float = 0.4
+        w_spatial_interface: float = 0.4
 
     def __init__(self, config: Config):
-        self.contiguous: float = config.contiguous
-        self.spatial: float = config.spatial
-        self.spatial_interface: float = config.spatial_interface
-        self.max_chains: int = config.max_chains
-        if self.contiguous + self.spatial + self.spatial_interface != 1.0:
+        self.w_contiguous: float = config.w_contiguous
+        self.w_spatial: float = config.w_spatial
+        self.w_spatial_interface: float = config.w_spatial_interface
+        if self.w_contiguous + self.w_spatial + self.w_spatial_interface != 1.0:
             raise ValueError("Cropping strategy weights must sum to 1.0")
 
     def get_token_indices(  # noqa: PLR0915
         self,
-        structure: TokenizedStructure,
+        struct: TokenizedStructure,
         max_tokens: int,
-        asym_ids: tuple[int, ...] | None,
+        bias_asym_id: int | tuple[int, int] | None = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """Get the token indices to include in the crop.
 
         Parameters
         ----------
-        structure: TokenizedStructure
+        struct: TokenizedStructure
             The tokenized structure.
         max_tokens: int
             The maximum number of tokens to crop.
-        asym_ids: tuple[int, ...] | None
-            The chain IDs to center the crop on.
+        bias_asym_id: tuple[int, ...] | None
+            The chain IDs to center the crop on. If None, a random chain or interface
+        rng: np.random.Generator | None, optional
+            The random number generator. If None, use np.random.
 
         Returns
         ----------
         token_indices: np.ndarray
             The selected token indices.
         """
-        # random choice on cropping strategy
-        strategy = np.random.choice(
-            ["contiguous", "spatial", "spatial_interface"],
-            p=[self.contiguous, self.spatial, self.spatial_interface],
-        )
-        if strategy == "contiguous":
-            return self.get_contiguous_token_indices(structure, max_tokens)
-        if strategy == "spatial":
-            query = self.pick_spatial_crop_query(structure, asym_ids)
-        else:
-            query = self.pick_spatial_interface_crop_query(structure, asym_ids)
-        return self.get_closest_tokens(structure, max_tokens, query)
+        rng = rng or np.random.default_rng()
 
-    def get_contiguous_token_indices(
+        # random choice on cropping strategy
+        strategy = utils.random_choice(
+            ["contiguous", "spatial", "spatial_interface"],
+            p=[self.w_contiguous, self.w_spatial, self.w_spatial_interface],
+        )
+        match strategy:
+            case "contiguous":
+                return self.crop_contiguous(struct, max_tokens, rng)
+            case "spatial":
+                return self.crop_spatial(struct, bias_asym_id, rng)
+            case "spatial_interface":
+                return self.crop_spatial_interface(struct, bias_asym_id, rng)
+            case _:
+                raise ValueError(f"Unknown cropping strategy: {strategy}")
+
+    def crop_contiguous(
         self,
-        structure: TokenizedStructure,
+        struct: TokenizedStructure,
         max_tokens: int,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Get the token indices to include in the contiguous crop.
 
@@ -156,10 +103,12 @@ class AlphaFold3Cropper(BaseCropper):
 
         Parameters
         ----------
-        structure: TokenizedStructure
+        struct: TokenizedStructure
             The tokenized structure.
         max_tokens: int
             The maximum number of tokens to crop.
+        rng: np.random.Generator
+            The random number generator.
 
         Returns
         ----------
@@ -167,20 +116,20 @@ class AlphaFold3Cropper(BaseCropper):
             The selected token indices.
         """
 
-        all_tokens = structure.token.token_index  # =np.arange(num_tokens)
+        all_tokens = struct.token.token_index  # =np.arange(num_tokens)
 
         # randomly shuffle chains
-        chain_ids = np.random.permutation(structure.chain.asym_id)
+        chain_ids = rng.permutation(struct.chain.asym_id)
 
         # Initialize counters; n_remaining is the sum of all tokens
         n_added = 0
-        n_remaining = np.sum(np.isin(structure.token.asym_id, chain_ids))
+        n_remaining = np.sum(np.isin(struct.token.asym_id, chain_ids))
         cropped: set[int] = set()
 
         # iterate over chains
         for chain_id in chain_ids:
             # get chain length as number of tokens
-            chain_mask = structure.token.asym_id == chain_id
+            chain_mask = struct.token.asym_id == chain_id
             chain_tokens = all_tokens[chain_mask]
             chain_length = len(chain_tokens)
             n_remaining -= chain_length
@@ -188,8 +137,8 @@ class AlphaFold3Cropper(BaseCropper):
             # sample crop length and start
             crop_size_max = min(max_tokens - n_added, chain_length)
             crop_size_min = min(chain_length, max(0, max_tokens - n_added - n_remaining))
-            crop_size = np.random.randint(crop_size_min, crop_size_max + 1)
-            crop_start = np.random.randint(0, chain_length - crop_size + 1)
+            crop_size = rng.integers(crop_size_min, crop_size_max + 1, dtype=int)
+            crop_start = rng.integers(0, chain_length - crop_size + 1, dtype=int)
             n_added += crop_size
 
             # get token indices in crop
@@ -200,28 +149,99 @@ class AlphaFold3Cropper(BaseCropper):
 
         return np.array(sorted(cropped))
 
-    def pick_spatial_crop_query(
+    def crop_spatial(
         self,
         struct: TokenizedStructure,
-        asym_ids: tuple[int, ...] | None,
-    ) -> int:
-        """Pick a random token, chain, or interface to crop around.
-        If no preferred chain or interface is provided, then a random
-        chain is selected.
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Crop a spatial region around a random token.
 
         Parameters
         ----------
         struct: TokenizedStructure
             The tokenized structure.
-        asym_ids: tuple[int, ...] | None
-            The chain IDs to center the crop on.
+        bias_asym_id: tuple[int, ...] | None
+            The chain IDs to center the crop on. If None, a random chain or interface
+        rng: np.random.Generator
+            The random number generator.
 
         Returns
         ----------
-        query: int
-            The selected token index to crop around.
+        token_indices: np.ndarray
+            The selected token indices.
         """
+        # get the tokens with valid center atom
+        resolved_mask = struct.atom.resolved_mask[
+            struct.token.token_index, struct.token.center_index
+        ]
+        if not resolved_mask.any():
+            raise ValueError("No valid tokens in structure")
 
+        # pick a random token from a chain or interface if specified
+        anchor = utils.pick_token(struct, bias_asym_id, mask=resolved_mask, rng=rng)
+        return self.get_closest_tokens(struct, struct.num_tokens, anchor)
+
+    def crop_spatial_interface(
+        self,
+        struct: TokenizedStructure,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Crop a spatial region around a random interface tokens
+
+        If no bias interface is provided, then a random interface is selected.
+        If a bais interface is provided, then select a random token from that interface.
+        If a bais chain is provided, then select a random interface involving that chain.
+
+        Parameters
+        ----------
+        struct: TokenizedStructure
+            The tokenized structure.
+        bias_asym_id: tuple[int, ...] | None
+            The chain IDs to center the crop on. If None, a random chain or interface
+        rng: np.random.Generator
+            The random number generator.
+
+        Returns
+        ----------
+        token_indices: np.ndarray
+            The selected token indices.
+        """
+        # get valid interfaces
+        all_interfaces: list[tuple[int, int]] = self.get_valid_interfaces(struct)
+        if len(all_interfaces) == 0:
+            # no valid interfaces found; default to a random center
+            return self.crop_spatial(struct, bias_asym_id, rng)
+
+        # pick a random token from an interface
+        if bias_asym_id is None:
+            # pick a random token from any random interface
+            interface_id = utils.random_choice(all_interfaces, rng=rng)
+        elif isinstance(bias_asym_id, int):
+            # pick a random token from a random interface in the preferred chain
+            candidate_interfaces = [v for v in all_interfaces if bias_asym_id in v]
+            if len(candidate_interfaces) == 0:
+                # no valid interfaces found; default to a random center
+                candidate_interfaces = all_interfaces
+            interface_id = utils.random_choice(candidate_interfaces, rng=rng)
+        else:
+            # pick a random token from the preferred interface
+            if bias_asym_id in all_interfaces:
+                interface_id = bias_asym_id
+            else:
+                # no valid interfaces found; default to a random interface
+                interface_id = utils.random_choice(all_interfaces, rng=rng)
+        anchor = utils.pick_interface_token(struct, interface_id, rng=rng)
+        return self.get_closest_tokens(struct, struct.num_tokens, anchor)
+
+    def get_closest_tokens(
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        query: int,
+    ) -> np.ndarray:
+        """Get the closest tokens to the query token."""
         # check inputs
         resolved_mask = struct.token.resolved_mask
         if not resolved_mask.any():
@@ -230,130 +250,42 @@ class AlphaFold3Cropper(BaseCropper):
         # frequently used variables
         token_data = struct.token  # features: [L, ...]
         atom_data = struct.atom  # features: [L, 24, ...]
-
-        all_tokens = token_data.token_index
-        valid_tokens = all_tokens[resolved_mask]
-        all_asym_ids = token_data.asym_id
-
-        # use the first bioassembly
-        holo_coords = atom_data.coords[..., 0, :]  # (num_tokens, 24, 3)
-        # coordinates.
-        all_token_centers = holo_coords[
-            token_data.token_index, token_data.center_index, :
-        ]  # (num_tokens, 3)
-
-        # pick a random token, chain, or interface
-        if asym_ids is None:
-            # pick a random token from a random chain
-            valid_chain_asym_ids = np.unique(all_asym_ids[valid_tokens])
-            asym_id = np.random.choice(valid_chain_asym_ids)
-            return pick_chain_token(struct, asym_id)
-        elif len(asym_ids) == 1:
-            # pick a random token from the preferred chain
-            return pick_chain_token(struct, asym_ids[0])
-        elif len(asym_ids) == 2:
-            # pick a random token from the preferred interface
-            return pick_interface_token(struct, asym_ids, all_token_centers)
-        else:
-            raise ValueError("asym_ids must be None, length 1, or length 2")
-
-    def pick_spatial_interface_crop_query(
-        self,
-        structure: TokenizedStructure,
-        asym_ids: tuple[int, ...] | None,
-    ) -> int:
-        """Pick a random token from an interface to crop around.
-        If no bias interface is provided, then a random interface is selected.
-        If a bais interface is provided, then select a random token from that interface.
-        If a bais chain is provided, then select a random interface involving that chain.
-
-        Parameters
-        ----------
-        structure: TokenizedStructure
-            The tokenized structure.
-        asym_ids: tuple[int, ...] | None
-            The chain IDs to center the crop on.
-
-        Returns
-        ----------
-        query: int
-            The selected token index to crop around.
-        """
-
-        # check inputs
-        resolved_mask = structure.token.resolved_mask
-        if not resolved_mask.any():
-            raise ValueError("No valid tokens in structure")
-
-        # frequently used variables
-        token_data = structure.token  # features: [L, ...]
-        atom_data = structure.atom  # features: [L, 24, ...]
-
-        # get the first bioassembly
-        holo_coords = atom_data.coords[..., 0, :]  # (num_tokens, 24, 3)
-        all_token_centers = holo_coords[
-            token_data.token_index, token_data.center_index, :
-        ]  # (num_tokens, 3)
-
-        # pick a random token from an interface
-        if asym_ids is None:
-            # pick a random token from any random interface
-            interface_asym_ids = get_random_interface(structure, None)
-            if interface_asym_ids is None:
-                # no valid interface found; default to a random center
-                return self.pick_spatial_crop_query(structure, None)
-            else:
-                return pick_interface_token(
-                    structure, interface_asym_ids, all_token_centers
-                )
-        elif len(asym_ids) == 1:
-            # pick a random token from a random interface in the preferred chain
-            interface_asym_ids = get_random_interface(structure, asym_ids[0])
-            if interface_asym_ids is None:
-                # no valid interface found; default to a random center
-                return self.pick_spatial_crop_query(structure, asym_ids)
-            else:
-                return pick_interface_token(
-                    structure, interface_asym_ids, all_token_centers
-                )
-        elif len(asym_ids) == 2:
-            # pick a random token from the preferred interface
-            return pick_interface_token(structure, asym_ids, all_token_centers)
-        else:
-            raise ValueError("asym_ids must be None, length 1, or length 2")
-
-    def get_closest_tokens(
-        self,
-        structure: TokenizedStructure,
-        max_tokens: int,
-        query: int,
-    ) -> np.ndarray:
-        """Get the closest tokens to the query token."""
-        # check inputs
-        resolved_mask = structure.token.resolved_mask
-        if not resolved_mask.any():
-            raise ValueError("No valid tokens in structure")
-
-        # frequently used variables
-        token_data = structure.token  # features: [L, ...]
-        atom_data = structure.atom  # features: [L, 24, ...]
         all_tokens = token_data.token_index
         valid_tokens = all_tokens[resolved_mask]
 
         # get the first bioassembly
-        holo_coords = atom_data.coords[..., 0, :]  # (num_tokens, 24, 3)
+        holo_coords = atom_data.coords[..., 0, :]  # (n-tokens, 24, 3)
         all_token_centers = holo_coords[
             token_data.token_index, token_data.center_index, :
         ]  # (num_tokens, 3)
 
         query_coords = all_token_centers[query]  # [3,]
-        valid_coords = all_token_centers[valid_tokens]  # [num_valid_tokens, 3]
+        valid_coords = all_token_centers[valid_tokens]  # [n_tokens, 3]
 
         # sort all tokens by distance to query_coords
-        dists = valid_coords - query_coords  # [num_valid_tokens, 3]
-        indices = np.argsort(np.linalg.norm(dists, axis=1))
-        neighbor_indices = valid_tokens[indices]
+        dists = np.linalg.norm(valid_coords - query_coords, axis=1)  # [n_tokens, 1]
+        indices = np.argpartition(dists, max_tokens - 1)[:max_tokens]
+        return valid_tokens[indices]
 
-        # select cropped indices
-        cropped: set[int] = set(neighbor_indices[:max_tokens])
-        return np.array(sorted(cropped))
+    @staticmethod
+    def get_valid_interfaces(struct: TokenizedStructure) -> list[tuple[int, int]]:
+        """Get all valid interfaces in the structure.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+
+        Returns
+        -------
+        interface_ids : list[tuple[int, int]]
+            The valid interfaces in the structure.
+        """
+        record = struct.metadata
+        assert record is not None, "Structure metadata is required"
+        all_chains: set[int] = set(struct.chain.asym_id.tolist())
+        all_interfaces: list[tuple[int, int]] = [
+            interface.asym_ids for interface in record.interfaces if interface.valid
+        ]
+        all_interfaces = [v for v in all_interfaces if set(v).issubset(all_chains)]
+        return sorted(set(all_interfaces))

--- a/src/kfold/training/folding/dataset/cropper/alphafold.py
+++ b/src/kfold/training/folding/dataset/cropper/alphafold.py
@@ -83,9 +83,9 @@ class AlphaFold3Cropper(BaseCropper):
             case "contiguous":
                 return self.crop_contiguous(struct, max_tokens, rng)
             case "spatial":
-                return self.crop_spatial(struct, bias_asym_id, rng)
+                return self.crop_spatial(struct, max_tokens, bias_asym_id, rng)
             case "spatial_interface":
-                return self.crop_spatial_interface(struct, bias_asym_id, rng)
+                return self.crop_spatial_interface(struct, max_tokens, bias_asym_id, rng)
             case _:
                 raise ValueError(f"Unknown cropping strategy: {strategy}")
 
@@ -152,6 +152,7 @@ class AlphaFold3Cropper(BaseCropper):
     def crop_spatial(
         self,
         struct: TokenizedStructure,
+        max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
         rng: np.random.Generator,
     ) -> np.ndarray:
@@ -161,6 +162,8 @@ class AlphaFold3Cropper(BaseCropper):
         ----------
         struct: TokenizedStructure
             The tokenized structure.
+        max_tokens: int
+            The maximum number of tokens to crop.
         bias_asym_id: tuple[int, ...] | None
             The chain IDs to center the crop on. If None, a random chain or interface
         rng: np.random.Generator
@@ -180,24 +183,27 @@ class AlphaFold3Cropper(BaseCropper):
 
         # pick a random token from a chain or interface if specified
         anchor = utils.pick_token(struct, bias_asym_id, mask=resolved_mask, rng=rng)
-        return self.get_closest_tokens(struct, struct.num_tokens, anchor)
+        return self.get_closest_tokens(struct, max_tokens, anchor)
 
     def crop_spatial_interface(
         self,
         struct: TokenizedStructure,
+        max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
         rng: np.random.Generator,
     ) -> np.ndarray:
         """Crop a spatial region around a random interface tokens
 
         If no bias interface is provided, then a random interface is selected.
-        If a bais interface is provided, then select a random token from that interface.
-        If a bais chain is provided, then select a random interface involving that chain.
+        If a bias interface is provided, then select a random token from that interface.
+        If a bias chain is provided, then select a random interface involving that chain.
 
         Parameters
         ----------
         struct: TokenizedStructure
             The tokenized structure.
+        max_tokens: int
+            The maximum number of tokens to crop.
         bias_asym_id: tuple[int, ...] | None
             The chain IDs to center the crop on. If None, a random chain or interface
         rng: np.random.Generator
@@ -212,7 +218,7 @@ class AlphaFold3Cropper(BaseCropper):
         all_interfaces: list[tuple[int, int]] = self.get_valid_interfaces(struct)
         if len(all_interfaces) == 0:
             # no valid interfaces found; default to a random center
-            return self.crop_spatial(struct, bias_asym_id, rng)
+            return self.crop_spatial(struct, max_tokens, bias_asym_id, rng)
 
         # pick a random token from an interface
         if bias_asym_id is None:
@@ -233,7 +239,7 @@ class AlphaFold3Cropper(BaseCropper):
                 # no valid interfaces found; default to a random interface
                 interface_id = utils.random_choice(all_interfaces, rng=rng)
         anchor = utils.pick_interface_token(struct, interface_id, rng=rng)
-        return self.get_closest_tokens(struct, struct.num_tokens, anchor)
+        return self.get_closest_tokens(struct, max_tokens, anchor)
 
     def get_closest_tokens(
         self,
@@ -248,24 +254,26 @@ class AlphaFold3Cropper(BaseCropper):
             raise ValueError("No valid tokens in structure")
 
         # frequently used variables
-        token_data = struct.token  # features: [L, ...]
-        atom_data = struct.atom  # features: [L, 24, ...]
+        token_data = struct.token  # [n_tokens, ...]
+        atom_data = struct.atom  # [n_tokens, 24, ...]
         all_tokens = token_data.token_index
         valid_tokens = all_tokens[resolved_mask]
 
         # get the first bioassembly
-        holo_coords = atom_data.coords[..., 0, :]  # (n-tokens, 24, 3)
+        holo_coords = atom_data.coords[..., 0, :]  # [n_tokens, 24, 3]
         all_token_centers = holo_coords[
             token_data.token_index, token_data.center_index, :
         ]  # (num_tokens, 3)
 
         query_coords = all_token_centers[query]  # [3,]
-        valid_coords = all_token_centers[valid_tokens]  # [n_tokens, 3]
+        valid_coords = all_token_centers[valid_tokens]  # [n_val_tokens, 3]
 
         # sort all tokens by distance to query_coords
-        dists = np.linalg.norm(valid_coords - query_coords, axis=1)  # [n_tokens, 1]
+        dists = np.linalg.norm(valid_coords - query_coords, axis=1)  # [n_val_tokens]
         indices = np.argpartition(dists, max_tokens - 1)[:max_tokens]
-        return valid_tokens[indices]
+        neighbor_indices = valid_tokens[indices]
+        neighbor_indices.sort()
+        return neighbor_indices
 
     @staticmethod
     def get_valid_interfaces(struct: TokenizedStructure) -> list[tuple[int, int]]:

--- a/src/kfold/training/folding/dataset/cropper/alphafold.py
+++ b/src/kfold/training/folding/dataset/cropper/alphafold.py
@@ -62,8 +62,9 @@ class AlphaFold3Cropper(BaseCropper):
             The tokenized structure.
         max_tokens: int
             The maximum number of tokens to crop.
-        bias_asym_id: tuple[int, ...] | None
-            The chain IDs to center the crop on. If None, a random chain or interface
+        bias_asym_id: int | tuple[int, ...] | None
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
         rng: np.random.Generator | None, optional
             The random number generator. If None, use np.random.
 
@@ -78,6 +79,7 @@ class AlphaFold3Cropper(BaseCropper):
         strategy = utils.random_choice(
             ["contiguous", "spatial", "spatial_interface"],
             p=[self.w_contiguous, self.w_spatial, self.w_spatial_interface],
+            rng=rng,
         )
         match strategy:
             case "contiguous":
@@ -164,8 +166,9 @@ class AlphaFold3Cropper(BaseCropper):
             The tokenized structure.
         max_tokens: int
             The maximum number of tokens to crop.
-        bias_asym_id: tuple[int, ...] | None
-            The chain IDs to center the crop on. If None, a random chain or interface
+        bias_asym_id: int | tuple[int, ...] | None
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
         rng: np.random.Generator
             The random number generator.
 
@@ -204,8 +207,9 @@ class AlphaFold3Cropper(BaseCropper):
             The tokenized structure.
         max_tokens: int
             The maximum number of tokens to crop.
-        bias_asym_id: tuple[int, ...] | None
-            The chain IDs to center the crop on. If None, a random chain or interface
+        bias_asym_id: int | tuple[int, ...] | None
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
         rng: np.random.Generator
             The random number generator.
 
@@ -252,6 +256,10 @@ class AlphaFold3Cropper(BaseCropper):
         resolved_mask = struct.token.resolved_mask
         if not resolved_mask.any():
             raise ValueError("No valid tokens in structure")
+
+        if resolved_mask.sum() <= max_tokens:
+            # all valid tokens fit in the crop
+            return struct.token.token_index[resolved_mask]
 
         # frequently used variables
         token_data = struct.token  # [n_tokens, ...]

--- a/src/kfold/training/folding/dataset/cropper/base.py
+++ b/src/kfold/training/folding/dataset/cropper/base.py
@@ -30,6 +30,7 @@ class BaseCropper(ABC):
             The maximum number of tokens to crop.
         bias_asym_id : int | tuple[int, int] | None, optional
             The chain IDs to center the crop on. If None, a random chain or interface
+            will be selected.
 
         Returns
         -------
@@ -69,7 +70,8 @@ class BaseCropper(ABC):
         max_tokens : int
             The maximum number of tokens to crop.
         bias_asym_id : int | tuple[int, int] | None
-            The chain ID(s) to center the crop on. If None, a random chain
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
         rng : np.random.Generator | None, optional
             The random number generator. If None, use np.random.
 

--- a/src/kfold/training/folding/dataset/cropper/base.py
+++ b/src/kfold/training/folding/dataset/cropper/base.py
@@ -17,7 +17,8 @@ class BaseCropper(ABC):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        asym_ids: tuple[int, ...] | None,
+        bias_asym_id: int | tuple[int, int] | None = None,
+        rng: np.random.Generator | None = None,
     ) -> TokenizedStructure:
         """Crop the data to a maximum number of tokens.
 
@@ -27,14 +28,15 @@ class BaseCropper(ABC):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        asym_ids : tuple[int, ...] | None, optional
-            The chain IDs to center the crop on. If None, a random chain
+        bias_asym_id : int | tuple[int, int] | None, optional
+            The chain IDs to center the crop on. If None, a random chain or interface
 
         Returns
         -------
         cropped_struct: TokenizedStructure
             The cropped data.
         """
+        rng = rng or np.random.default_rng()
 
         # Check if structure have any valid tokens
         if struct.num_tokens == 0:
@@ -45,7 +47,9 @@ class BaseCropper(ABC):
             return struct
 
         # Get the token indices to include in the crop
-        selected_token_indices = self.get_token_indices(struct, max_tokens, asym_ids)
+        selected_token_indices = self.get_token_indices(
+            struct, max_tokens, bias_asym_id, rng=rng
+        )
         return struct.crop(selected_token_indices)
 
     @abstractmethod
@@ -53,7 +57,8 @@ class BaseCropper(ABC):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        asym_ids: tuple[int, ...] | None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """Get the indices of the tokens to include in the crop.
 
@@ -63,8 +68,10 @@ class BaseCropper(ABC):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        asym_ids : tuple[int, ...] | None, optional
-            The chain IDs to center the crop on. If None, a random chain
+        bias_asym_id : int | tuple[int, int] | None
+            The chain ID(s) to center the crop on. If None, a random chain
+        rng : np.random.Generator | None, optional
+            The random number generator. If None, use np.random.
 
         Returns
         -------

--- a/src/kfold/training/folding/dataset/cropper/boltz.py
+++ b/src/kfold/training/folding/dataset/cropper/boltz.py
@@ -4,13 +4,13 @@ import numpy as np
 from kfold.data.structure import TokenizedStructure
 from kfold.utils.registry import DATA_CROPPER
 
+from . import utils
 from .base import BaseCropper
-from .utils import pick_token
 
 
 @DATA_CROPPER.register()
 class BoltzCropper(BaseCropper):
-    """Interpolate between contiguous and spatial crops."""
+    """Unified cropper used in Boltz1"""
 
     class Config(BaseCropper.Config):
         """Configuration for the BoltzCropper.
@@ -34,13 +34,14 @@ class BoltzCropper(BaseCropper):
 
     def __init__(self, config: Config):
         sizes = list(range(config.min_neighborhood, config.max_neighborhood + 1, 2))
-        self.neighborhood_sizes = sizes
+        self.neighborhood_sizes: list[int] = sizes
 
     def get_token_indices(  # noqa: PLR0915
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        asym_ids: tuple[int, ...] | None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """Crop the data to a maximum number of tokens.
 
@@ -50,14 +51,19 @@ class BoltzCropper(BaseCropper):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        asym_ids : tuple[int, ...] | None
-            The chain IDs to center the crop on. If None, a random chain
+        asym_ids : tuple[int, ...] | None, optional
+            The chain ID(s) to center the crop on. If None, a random chain
+            or interface will be selected.
+        rng : np.random.Generator | None, optional
+            The random number generator. If None, use np.random.
 
         Returns
         -------
         token_indices: np.ndarray
             The selected token indices.
         """
+        if rng is None:
+            rng = np.random.default_rng()
 
         token_data = struct.token  # features: [L, ...]
         atom_data = struct.atom  # features: [L, 24, ...]
@@ -82,19 +88,19 @@ class BoltzCropper(BaseCropper):
         ]  # (num_tokens, 3)
 
         # Randomly select a neighborhood size
-        neighborhood_size = np.random.choice(self.neighborhood_sizes)
+        neighborhood_size = utils.random_choice(self.neighborhood_sizes, rng=rng)
 
         # Pick a random token, chain, or interface
-        if asym_ids is None:
+        if bias_asym_id is None:
             valid_chain_asym_ids = np.unique(all_asym_ids[valid_tokens])
-            asym_id = np.random.choice(valid_chain_asym_ids)
-            query = pick_token(struct, asym_id=asym_id, mask=resolved_mask)
-        elif len(asym_ids) == 1:
-            query = pick_token(struct, asym_id=asym_ids[0], mask=resolved_mask)
-        elif len(asym_ids) == 2:
-            query = pick_token(struct, asym_id=asym_ids, mask=resolved_mask)
-        else:
-            raise ValueError("asym_ids must be None, length 1, or length 2")
+            chain_id = rng.choice(valid_chain_asym_ids)
+            query = utils.pick_token(struct, chain_id, resolved_mask, rng)
+        elif isinstance(bias_asym_id, int):
+            chain_id = bias_asym_id
+            query = utils.pick_token(struct, chain_id, resolved_mask, rng)
+        else:  # tuple[int, int]
+            interface_id = bias_asym_id
+            query = utils.pick_token(struct, interface_id, resolved_mask, rng)
 
         query_coords = all_token_centers[query]  # [3,]
         valid_coords = all_token_centers[valid_tokens]  # [num_valid_tokens, 3]

--- a/src/kfold/training/folding/dataset/cropper/boltz.py
+++ b/src/kfold/training/folding/dataset/cropper/boltz.py
@@ -1,127 +1,11 @@
+# started from code from https://github.com/jwohlwend/boltz, MIT License
 import numpy as np
-from scipy.spatial.distance import cdist
 
-import kfold.constants as C
 from kfold.data.structure import TokenizedStructure
 from kfold.utils.registry import DATA_CROPPER
 
 from .base import BaseCropper
-
-
-def pick_chain_token(
-    struct: TokenizedStructure,
-    asym_id: int,
-    resolved_mask: np.ndarray | None = None,
-) -> int:
-    """Pick a random token from a chain.
-
-    Parameters
-    ----------
-    struct : TokenizedStructure
-        The tokenized structure.
-    asym_id : int
-        The chain asymmetric ID.
-    resolved_mask : np.ndarray | None, optional
-        An optional mask of valid tokens.
-
-    Returns
-    -------
-    token_index : int
-        The selected token index.
-    """
-    # Get resolved mask with valid centers
-    if resolved_mask is None:
-        token_center_mask = struct.atom.resolved_mask[
-            struct.token.token_index, struct.token.center_index
-        ]  # (num_tokens,)
-        resolved_mask = struct.token.resolved_mask & token_center_mask
-
-    chain_mask = struct.token.asym_id == asym_id
-
-    # Pick from chain, fallback to all tokens
-    token_indices = struct.token.token_index
-    chain_tokens = token_indices[chain_mask & resolved_mask]
-    if chain_tokens.size:
-        return np.random.choice(chain_tokens)
-    else:
-        valid_tokens = token_indices[resolved_mask]
-        return np.random.choice(valid_tokens)
-
-
-def pick_interface_token(
-    struct: TokenizedStructure,
-    asym_ids: tuple[int, ...],
-    center_coords: np.ndarray,
-    resolved_mask: np.ndarray | None = None,
-) -> int:
-    """Pick a random token from an interface.
-
-    Parameters
-    ----------
-    struct : TokenizedStructure
-        The tokenized data.
-    asym_ids : tuple[int, ...]
-        The chain IDs defining the interface.
-    center_coords : np.ndarray
-        The center coordinates of all tokens.
-    resolved_mask : np.ndarray | None, optional
-        An optional mask of valid tokens.
-
-    Returns
-    -------
-    token_index : int
-        The selected token index.
-    """
-
-    # Sample random interface
-    if len(asym_ids) != 2:
-        raise ValueError("asym_ids must have length 2 for interface picking")
-
-    chain_1, chain_2 = asym_ids
-
-    # Get resolved mask with valid center atoms
-    if resolved_mask is None:
-        token_center_mask = struct.atom.resolved_mask[
-            struct.token.token_index, struct.token.center_index
-        ]  # (num_tokens,)
-        resolved_mask = struct.token.resolved_mask & token_center_mask
-
-    token_indices = struct.token.token_index
-    tokens_1 = token_indices[(struct.token.asym_id == chain_1) & resolved_mask]
-    tokens_2 = token_indices[(struct.token.asym_id == chain_2) & resolved_mask]
-
-    # If no interface, pick from the chains
-    if tokens_1.size and (not tokens_2.size):
-        return np.random.choice(tokens_1)
-    elif tokens_2.size and (not tokens_1.size):
-        return np.random.choice(tokens_2)
-    elif (not tokens_1.size) and (not tokens_2.size):
-        # Fallback to all tokens
-        valid_tokens = token_indices[resolved_mask]
-        return np.random.choice(valid_tokens)
-    else:
-        # If we have tokens, compute distances to find interface tokens
-        tokens_1_coords = center_coords[tokens_1]  # (num_tokens_1, 3)
-        tokens_2_coords = center_coords[tokens_2]  # (num_tokens_2, 3)
-
-        dists = cdist(tokens_1_coords, tokens_2_coords)
-        cuttoff = dists < C.INTERFACE_CUTOFF
-
-        # In rare cases, the interface cuttoff is slightly
-        # too small, then we slightly expand it if it happens
-        if not np.any(cuttoff):
-            cuttoff = dists < (C.INTERFACE_CUTOFF + 5.0)
-
-        tokens_1 = tokens_1[np.any(cuttoff, axis=1)]
-        tokens_2 = tokens_2[np.any(cuttoff, axis=0)]
-
-        # Select random token
-        candidates = np.concatenate([tokens_1, tokens_2])
-        if candidates.size == 0:
-            # Fallback to all tokens
-            valid_tokens = token_indices[resolved_mask]
-            return np.random.choice(valid_tokens)
-        return np.random.choice(candidates)
+from .utils import pick_token
 
 
 @DATA_CROPPER.register()
@@ -204,13 +88,11 @@ class BoltzCropper(BaseCropper):
         if asym_ids is None:
             valid_chain_asym_ids = np.unique(all_asym_ids[valid_tokens])
             asym_id = np.random.choice(valid_chain_asym_ids)
-            query = pick_chain_token(struct, asym_id, resolved_mask)
+            query = pick_token(struct, asym_id=asym_id, mask=resolved_mask)
         elif len(asym_ids) == 1:
-            query = pick_chain_token(struct, asym_ids[0], resolved_mask)
+            query = pick_token(struct, asym_id=asym_ids[0], mask=resolved_mask)
         elif len(asym_ids) == 2:
-            query = pick_interface_token(
-                struct, asym_ids, all_token_centers, resolved_mask
-            )
+            query = pick_token(struct, asym_id=asym_ids, mask=resolved_mask)
         else:
             raise ValueError("asym_ids must be None, length 1, or length 2")
 

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -80,11 +80,11 @@ class MultiAnchorCropper(BaseCropper):
             Maximum distance between anchor tokens during spatial cropping.
         """
 
-        w_contiguous: float = 0.3
-        w_spatial: float = 0.2
-        w_spatial_interface: float = 0.5
+        w_contiguous: float = 0.2
+        w_spatial: float = 0.4
+        w_spatial_interface: float = 0.4
         anchor_distribution: str = "exponential"
-        max_anchors: int = 4
+        max_anchors: int = 1
         max_anchor_distance: float = 100.0
 
     def __init__(self, config: Config):

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -1,4 +1,48 @@
-import random
+"""
+Multi-Anchor Cropping Strategy for Apo-to-Holo Structure Modeling.
+
+This module implements an extended cropping strategy designed for scenarios
+where Apo structures (e.g., from AF2/ESMFold) are used as templates or inputs
+to predict Holo complexes.
+
+**Motivation**
+In Apo-to-Holo co-folding, a critical challenge is preventing the model from
+learning trivial identity mappings. Standard single-center spatial cropping
+(as used in AlphaFold-Multimer/AF3) often yields a dense, locally rigid crop.
+In such cases, the model can minimize loss simply by copying the input Apo
+structure via residual connections, failing to learn global conformational
+changes or inter-domain rearrangements.
+
+The 'Multi-Anchor' strategy mitigates this by distributing the token budget
+across multiple spatially distinct regions. This forces the model to reason
+about the geometric relationships *between* disconnected or distant regions,
+thereby encouraging the learning of global structural transitions.
+
+**Algorithm Description**
+1. Contiguous Cropping:
+    - Same as AF-M/AF3's contiguous cropping strategy.
+
+2. Spatial Cropping (Multi-Anchor):
+    - Selects N anchor tokens (default: 4) and partitions the total token budget.
+    - The first anchor is sampled based on chain bias or uniformly.
+    - Subsequent anchors are sampled from resolved tokens within a defined
+      radius (default: 100 Å) of previous anchors to ensure partial connectivity
+      while maximizing coverage.
+
+3. Spatial Interface Cropping (Multi-Anchor):
+    - Selects anchors specifically from tokens involved in chain interfaces.
+    - Unlike random sampling, this strategy traverses the 'interaction graph'.
+      Subsequent anchors are chosen from interfaces connected to already
+      selected chains, preserving the biological context of the complex assembly.
+
+**References**
+- AlphaFold-Multimer (Evans et al., 2021):
+    - Algorithm 1: Contiguous Cropping
+    - Algorithm 2: Spatial Cropping logic
+- AlphaFold 3 (Abramson et al., 2024):
+    - Section 2.7: Cropping strategies (Contiguous, Spatial, Spatial Interface)
+"""
+
 from collections import defaultdict
 
 import numpy as np
@@ -6,8 +50,8 @@ import numpy as np
 from kfold.data.structure import TokenizedStructure
 from kfold.utils.registry import DATA_CROPPER
 
+from . import utils
 from .base import BaseCropper
-from .utils import pick_token
 
 
 @DATA_CROPPER.register()
@@ -27,8 +71,6 @@ class MultiAnchorCropper(BaseCropper):
             Weight for spatial cropping.
         w_spatial_interface : float
             Weight for spatial interface cropping.
-        max_chains : int
-            Maximum number of chains to consider for contiguous cropping.
         anchor_distribution : str
             Distribution to sample number of anchors from.
             Choices: 'uniform', 'linear', 'squared', 'exponential'.
@@ -41,7 +83,6 @@ class MultiAnchorCropper(BaseCropper):
         w_contiguous: float = 0.3
         w_spatial: float = 0.2
         w_spatial_interface: float = 0.5
-        max_chains: int = 20
         anchor_distribution: str = "exponential"
         max_anchors: int = 4
         max_anchor_distance: float = 100.0
@@ -59,7 +100,6 @@ class MultiAnchorCropper(BaseCropper):
         self.w_contiguous: float = config.w_contiguous
         self.w_spatial: float = config.w_spatial
         self.w_spatial_interface: float = config.w_spatial_interface
-        self.max_chains: int = config.max_chains
         self.anchor_distribution: str = config.anchor_distribution
         self.min_anchors: int = 1
         self.max_anchors: int = config.max_anchors
@@ -69,7 +109,8 @@ class MultiAnchorCropper(BaseCropper):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        asym_ids: tuple[int, ...] | None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """Crop the data to a maximum number of tokens.
 
@@ -79,23 +120,28 @@ class MultiAnchorCropper(BaseCropper):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        asym_ids : tuple[int, ...] | None
-            The chain IDs to center the crop on. If None, a random chain
+        bias_asym_id : int | tuple[int, int] | None
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
 
         Returns
         -------
         token_indices: np.ndarray
             The selected token indices.
         """
-        v = np.random.rand()
+        rng = rng or np.random.default_rng()
+
+        v = rng.random()
         if v < self.w_contiguous:
             # Contiguous cropping
-            crop_indices = self.crop_contiguous(struct, max_tokens)
+            crop_indices = self.crop_contiguous(struct, max_tokens, rng=rng)
         elif v < self.w_contiguous + self.w_spatial:
             # Spatial cropping
-            crop_indices = self.crop_spatial(struct, max_tokens, asym_ids)
+            crop_indices = self.crop_spatial(struct, max_tokens, bias_asym_id, rng=rng)
         else:  # Spatial interface cropping
-            crop_indices = self.crop_spatial_interface(struct, max_tokens, asym_ids)
+            crop_indices = self.crop_spatial_interface(
+                struct, max_tokens, bias_asym_id, rng=rng
+            )
 
         # Ensure sorted order and limit to max_tokens
         crop_indices.sort()
@@ -108,6 +154,7 @@ class MultiAnchorCropper(BaseCropper):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Select an anchor token using contiguous cropping.
         See Algorithm 1 in the AlphaFold Multimer paper.
@@ -118,6 +165,8 @@ class MultiAnchorCropper(BaseCropper):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
+        rng : np.random.Generator
+            The random number generator.
 
         Returns
         -------
@@ -131,11 +180,9 @@ class MultiAnchorCropper(BaseCropper):
             for i in range(struct.num_chains)
         }
 
-        # Sample chains up to max_chains
+        # Randomly permute the chain order
         asym_ids = struct.chain.asym_id
-        selected_asym_ids = np.random.permutation(asym_ids)[: self.max_chains]
-
-        is_selected = np.zeros(struct.num_tokens, dtype=bool)
+        selected_asym_ids = rng.permutation(asym_ids)
 
         # Line 1
         n_added: int = 0
@@ -143,8 +190,13 @@ class MultiAnchorCropper(BaseCropper):
         # NOTE: This differs from the original algorithm which uses max_tokens.
         n_remaining: int = sum(chain_sizes[asym_id] for asym_id in selected_asym_ids)
 
+        is_selected = np.zeros(struct.num_tokens, dtype=bool)
+
         # Line 3-13
         for asym_id in selected_asym_ids:
+            if n_added >= max_tokens:
+                break
+
             n_k = chain_sizes[asym_id]
             # Line 4
             n_remaining -= n_k
@@ -155,19 +207,24 @@ class MultiAnchorCropper(BaseCropper):
             # Line 6
             min_crop = min(n_k, max(0, max_tokens - n_added - n_remaining))
             # Line 7
-            crop_size = np.random.randint(min_crop, max_crop + 1)
+            crop_size = int(rng.integers(min_crop, max_crop + 1))
             # Line 8
             n_added += crop_size
 
-            # Line 9-12
-            if crop_size > 0:
-                selected_tokens = self.do_crop_chain_contiguously(
-                    struct, asym_id, crop_size
-                )
-                is_selected[selected_tokens] = True
+            if crop_size == 0:
+                continue
 
-            if n_added >= max_tokens:
-                break
+            # Line 9
+            crop_start = int(rng.integers(0, n_k - crop_size + 1))
+
+            # Line 11
+            chain_idx = np.where(struct.chain.asym_id == asym_id)[0][0]
+            chain_st = int(struct.chain.token_starts[chain_idx])
+            crop_start += chain_st
+            selected_tokens = np.arange(crop_start, crop_start + crop_size)
+
+            # Line 12
+            is_selected[selected_tokens] = True
 
         return np.where(is_selected)[0]
 
@@ -175,7 +232,8 @@ class MultiAnchorCropper(BaseCropper):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        bias_asym_ids: tuple[int, ...] | None = None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Select anchor tokens using spatial cropping.
 
@@ -185,13 +243,15 @@ class MultiAnchorCropper(BaseCropper):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        asym_ids : tuple[int, ...] | None
+        bias_asym_id : int | tuple[int, int] | None
             The chain IDs to bias the anchor selection towards.
+        rng : np.random.Generator
+            The random number generator.
 
         Returns
         -------
-        token_index : np.ndarray
-            The selected token index.
+        token_indices : np.ndarray
+            The selected token indices.
         """
         # For spatial cropping, get the token center coordinates
         tokens = struct.token.token_index  # =np.arange(n_tokens)
@@ -206,37 +266,37 @@ class MultiAnchorCropper(BaseCropper):
             return np.where(resolved_mask)[0]
 
         # Sample number of anchors and their budgets
-        num_anchors: int = self.sample_num_anchors()
-        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens)
+        num_anchors: int = self.sample_num_anchors(rng)
+        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens, rng)
 
         anchor_tokens: list[int] = []
         is_selected = np.zeros(struct.num_tokens, dtype=bool)
         is_remaining = resolved_mask.copy()
         for i in range(num_anchors):
-            # === Select anchor token === #
-            asym_id: int | None = None  # No bias by default
-            anchor_mask = resolved_mask
-            if i == 0 and bias_asym_ids is not None:
-                # If bias is given, sample the first anchor from the biased chains
-                asym_id = random.choice(bias_asym_ids)
-            elif len(anchor_tokens) > 0:
+            # Select anchor token
+            if i == 0:
+                # Pick first anchor randomly or from biased chain(s)
+                anchor = utils.pick_token(struct, bias_asym_id, is_remaining, rng)
+            else:
                 # Pick anchor token not to far from previous anchor
                 prev_anchor = anchor_tokens[-1]
                 prev_anchor_coords = center_coords[prev_anchor]  # (3,)
                 dists = np.linalg.norm(center_coords - prev_anchor_coords, axis=1)
-                # Anchor already selected is allowed
-                anchor_mask = anchor_mask & (dists < self.max_anchor_distance)
+                cutoff_mask = dists < self.max_anchor_distance
+                anchor_mask = is_remaining & cutoff_mask
+                if not np.any(anchor_mask):
+                    # Fallback to allow picking from all remaining tokens
+                    anchor_mask = resolved_mask & cutoff_mask
+                anchor = utils.pick_token(struct, None, anchor_mask, rng)
+            anchor_tokens.append(anchor)
 
-            anchor = pick_token(struct, asym_id=asym_id, mask=anchor_mask)
-
-            # === Crop spatially around the anchor token === #
+            # Crop spatially around the anchor token
             crop_size = budgets[i]
-            neighbor_indices = self.do_crop_complex_spatially(
-                struct, anchor, crop_size, center_coords, resolved_mask=is_remaining
+            neighbor_indices = self.get_closest_tokens(
+                struct, anchor, crop_size, center_coords, mask=is_remaining
             )
             is_selected[neighbor_indices] = True
             is_remaining[neighbor_indices] = False
-            anchor_tokens.append(anchor)
 
         return np.where(is_selected)[0]
 
@@ -244,7 +304,8 @@ class MultiAnchorCropper(BaseCropper):
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        bias_asym_ids: tuple[int, ...] | None = None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Select anchor tokens using spatial cropping.
 
@@ -254,13 +315,13 @@ class MultiAnchorCropper(BaseCropper):
             The tokenized structure.
         max_tokens : int
             The maximum number of tokens to crop.
-        bias_asym_ids : tuple[int, ...] | None
-            The chain IDs to bias the anchor selection towards.
+        bias_asym_id : int | tuple[int, int] | None
+            The chain ID(s) to bias the anchor selection towards.
 
         Returns
         -------
-        token_index : np.ndarray
-            The selected token index.
+        token_indices : np.ndarray
+            The selected token indices.
         """
         # For spatial cropping, get the token center coordinates
         tokens = struct.token.token_index  # =np.arange(n_tokens)
@@ -275,23 +336,11 @@ class MultiAnchorCropper(BaseCropper):
             return np.where(resolved_mask)[0]
 
         # Get all valid interfaces
-        record = struct.metadata
-        assert record is not None, "Metadata is required for interface cropping."
+        all_interfaces = self.get_valid_interfaces(struct)
 
-        all_chains: set[int] = set(struct.chain.asym_id.tolist())
-        all_interfaces: list[tuple[int, int]] = [
-            interface.asym_ids for interface in record.interfaces if interface.valid
-        ]
-        all_interfaces = [v for v in all_interfaces if set(v).issubset(all_chains)]
-        if bias_asym_ids is not None and len(bias_asym_ids) == 2:
-            # Ensure the biased interface is included
-            all_interfaces.append(bias_asym_ids)
-        all_interfaces = sorted(set(all_interfaces))
-        num_interfaces = len(all_interfaces)
-
-        if num_interfaces == 0:
+        if len(all_interfaces) == 0:
             # No valid interfaces, fall back to regular spatial cropping
-            return self.crop_spatial(struct, max_tokens, bias_asym_ids)
+            return self.crop_spatial(struct, max_tokens, bias_asym_id, rng=rng)
 
         # Collect neighboring chains for each chain
         chain_to_neighbors: dict[int, list[int]] = defaultdict(list)
@@ -301,73 +350,65 @@ class MultiAnchorCropper(BaseCropper):
             chain_to_neighbors[i2].append(i1)
 
         # Sample number of anchors and their budgets
-        num_anchors: int = self.sample_num_anchors()
-        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens)
+        num_anchors: int = self.sample_num_anchors(rng)
+        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens, rng)
 
         is_selected = np.zeros(struct.num_tokens, dtype=bool)
         is_remaining = resolved_mask.copy()
         visited_chains: set[int] = set()
         for i in range(num_anchors):
-            # === Select interface to sample from === #
-            if i == 0 and bias_asym_ids is not None:
-                # Pick first interface randomly or from biased chains
-                if len(bias_asym_ids) == 1:
-                    asym_id = bias_asym_ids[0]
+            # Select an interface to sample anchor from
+            if i == 0:
+                if bias_asym_id is None:
+                    # Pick a random interface
+                    interface_id = utils.random_choice(all_interfaces, rng=rng)
+                elif isinstance(bias_asym_id, int):
                     # Find an interface containing the biased chain
+                    chain_id = bias_asym_id
                     candidate_interfaces = [
-                        interface for interface in all_interfaces if asym_id in interface
+                        iface for iface in all_interfaces if chain_id in iface
                     ]
-                    interface = random.choice(candidate_interfaces)
+                    if not candidate_interfaces:
+                        # Fallback to random interface
+                        candidate_interfaces = all_interfaces
+                    interface_id = utils.random_choice(candidate_interfaces, rng=rng)
                 else:
-                    assert len(bias_asym_ids) == 2
-                    interface = bias_asym_ids
-            elif len(visited_chains) > 0:
-                # Pick an interface connected to visited chains
-                i1 = random.choice(list(visited_chains))
-                i2 = random.choice(chain_to_neighbors[i1])
-                interface = (min(i1, i2), max(i1, i2))
+                    # Pick the biased interface
+                    if bias_asym_id not in all_interfaces:
+                        interface_id = bias_asym_id
+                    else:
+                        # Fallback to random interface
+                        interface_id = utils.random_choice(all_interfaces, rng=rng)
             else:
-                # Pick a random interface
-                interface = random.choice(all_interfaces)
+                # Pick an interface connected to visited chains
+                assert len(visited_chains) > 0, "No visited chains"
+                i1 = utils.random_choice(list(visited_chains), rng=rng)
+                i2 = utils.random_choice(chain_to_neighbors[i1], rng=rng)
+                interface_id = (min(i1, i2), max(i1, i2))
+            visited_chains.update(interface_id)
 
-            # === Select anchor token in the interface === #
-            crop_size = budgets[i]
-            # Anchor already selected is allowed
-            anchor = pick_token(struct, asym_id=interface, mask=resolved_mask)
+            # Select anchor token from the interface
+            # NOTE: Since re-sample from visited interfaces, we allow picking from
+            # all resolved tokens even if already selected.
+            anchor = utils.pick_interface_token(struct, interface_id, resolved_mask, rng)
 
             # Crop spatially around the anchor token
             crop_size = budgets[i]
-            neighbor_indices = self.do_crop_complex_spatially(
-                struct, anchor, crop_size, center_coords, resolved_mask=is_remaining
+            neighbor_indices = self.get_closest_tokens(
+                struct, anchor, crop_size, center_coords, mask=is_remaining
             )
             is_selected[neighbor_indices] = True
             is_remaining[neighbor_indices] = False
-            visited_chains.update(interface)
 
         return np.where(is_selected)[0]
 
-    def do_crop_chain_contiguously(
-        self, struct: TokenizedStructure, asym_id: int, crop_size: int
-    ) -> np.ndarray:
-        """Crop a contiguous segment from a specific chain."""
-        chain_i = np.where(struct.chain.asym_id == asym_id)[0]
-        assert chain_i.size == 1, f"Chain {asym_id} not found."
-        chain_i = chain_i[0]
-
-        chain_size = int(struct.chain.num_tokens[chain_i])
-        crop_start = np.random.randint(0, chain_size - crop_size + 1, 1).item()
-
-        chain_start = int(struct.chain.token_starts[chain_i])
-        global_start = chain_start + crop_start
-        return np.arange(global_start, global_start + crop_size)
-
-    def do_crop_complex_spatially(
+    def get_closest_tokens(
         self,
         struct: TokenizedStructure,
         anchor_token: int,
         crop_size: int,
         center_coords: np.ndarray | None = None,
-        resolved_mask: np.ndarray | None = None,
+        mask: np.ndarray | None = None,
     ) -> np.ndarray:
         """Crop tokens spatially around an anchor token.
 
@@ -381,7 +422,7 @@ class MultiAnchorCropper(BaseCropper):
             The number of tokens to crop.
         center_coords : np.ndarray | None, optional
             Precomputed center coordinates of tokens.
-        resolved_mask : np.ndarray | None, optional
+        mask : np.ndarray | None, optional
             Precomputed resolved mask of tokens.
 
         Returns
@@ -393,21 +434,23 @@ class MultiAnchorCropper(BaseCropper):
         center_idx = struct.token.center_index  # (num_tokens, 3)
         if center_coords is None:
             center_coords = struct.atom.coords[tokens, center_idx]  # (num_tokens, 3)
-        if resolved_mask is None:
-            resolved_mask = struct.atom.resolved_mask[tokens, center_idx]  # (num_tokens,)
+        if mask is None:
+            mask = struct.atom.resolved_mask[tokens, center_idx]  # (num_tokens,)
 
-        crop_size = min(crop_size, resolved_mask.sum())
+        if mask.sum() <= crop_size:
+            # If all resolved tokens fit in the budget, return all
+            return np.where(mask)[0]
 
         # Compute distances to all tokens
         anchor_coord = center_coords[anchor_token]  # (3,)
         dists = np.linalg.norm(center_coords - anchor_coord, axis=1)  # (num_tokens,)
-        dists[~resolved_mask] = np.inf
+        dists[~mask] = np.inf
         # Get tokens within budget (this includes the anchor token itself)
-        neighbor_indices = np.argsort(dists)[:crop_size]
+        neighbor_indices = np.argpartition(dists, crop_size)[:crop_size]
         return neighbor_indices
 
     # === Helper functions === #
-    def sample_num_anchors(self) -> int:
+    def sample_num_anchors(self, rng: np.random.Generator) -> int:
         """Sample the number of anchor tokens."""
         distribution = self.anchor_distribution
         min_anchors = self.min_anchors
@@ -420,19 +463,19 @@ class MultiAnchorCropper(BaseCropper):
             case "linear":
                 w = np.linspace(1.0, 0.0, n_candidates + 1)[:-1]
             case "squared":
-                w = np.linspace(1.0, 0.0, n_candidates + 1)[:-1]
-                w = w**2
+                w = np.linspace(1.0, 0.0, n_candidates + 1)[:-1] ** 2
             case "exponential":
                 w = np.exp(-candidates)
             case _:
                 raise ValueError(f"Unknown anchor distribution: {distribution}")
         w /= w.sum()
-        return np.random.choice(candidates, p=w)
+        return int(rng.choice(candidates, p=w))
 
     def sample_budgets_per_anchor(
         self,
         num_anchors: int,
         total_budget: int,
+        rng: np.random.Generator,
         min_per_anchor: int | None = None,
     ) -> list[int]:
         """Sample the token budgets for each anchor token.
@@ -443,6 +486,8 @@ class MultiAnchorCropper(BaseCropper):
             The number of anchor tokens.
         total_budget : int
             The total token budget.
+        rng : np.random.Generator
+            The random number generator.
         min_per_anchor : int (optional)
             The minimum number of tokens per anchor.
             Default: set to total_budget // num_anchors // 4
@@ -465,10 +510,10 @@ class MultiAnchorCropper(BaseCropper):
                 "Minimum per anchor too high for total budget and number of anchors."
             )
 
-        budgets = [min_per_anchor] * num_anchors
+        budgets: list[int] = [min_per_anchor] * num_anchors
         remaining_budget = total_budget - sum(budgets)
 
-        splits = np.random.randint(0, remaining_budget + 1, size=num_anchors - 1)
+        splits = rng.integers(0, remaining_budget + 1, size=num_anchors - 1)
         splits = np.concatenate(([0], np.sort(splits), [remaining_budget]))
         allocation = splits[1:] - splits[:-1]
         for i in range(num_anchors):
@@ -478,3 +523,26 @@ class MultiAnchorCropper(BaseCropper):
         budgets.sort(reverse=True)
 
         return budgets
+
+    @staticmethod
+    def get_valid_interfaces(struct: TokenizedStructure) -> list[tuple[int, int]]:
+        """Get all valid interfaces in the structure.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+
+        Returns
+        -------
+        interface_ids : list[tuple[int, int]]
+            The valid interfaces in the structure.
+        """
+        record = struct.metadata
+        assert record is not None, "Structure metadata is required"
+        all_chains: set[int] = set(struct.chain.asym_id.tolist())
+        all_interfaces: list[tuple[int, int]] = [
+            interface.asym_ids for interface in record.interfaces if interface.valid
+        ]
+        all_interfaces = [v for v in all_interfaces if set(v).issubset(all_chains)]
+        return sorted(set(all_interfaces))

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -278,7 +278,7 @@ class MultiAnchorCropper(BaseCropper):
                 # Pick first anchor randomly or from biased chain(s)
                 anchor = utils.pick_token(struct, bias_asym_id, is_remaining, rng)
             else:
-                # Pick anchor token not to far from previous anchor
+                # Pick anchor token not too far from previous anchor
                 prev_anchor = anchor_tokens[-1]
                 prev_anchor_coords = center_coords[prev_anchor]  # (3,)
                 dists = np.linalg.norm(center_coords - prev_anchor_coords, axis=1)
@@ -374,7 +374,7 @@ class MultiAnchorCropper(BaseCropper):
                     interface_id = utils.random_choice(candidate_interfaces, rng=rng)
                 else:
                     # Pick the biased interface
-                    if bias_asym_id not in all_interfaces:
+                    if bias_asym_id in all_interfaces:
                         interface_id = bias_asym_id
                     else:
                         # Fallback to random interface
@@ -446,7 +446,8 @@ class MultiAnchorCropper(BaseCropper):
         dists = np.linalg.norm(center_coords - anchor_coord, axis=1)  # (num_tokens,)
         dists[~mask] = np.inf
         # Get tokens within budget (this includes the anchor token itself)
-        neighbor_indices = np.argpartition(dists, crop_size)[:crop_size]
+        neighbor_indices = np.argpartition(dists, crop_size - 1)[:crop_size]
+        neighbor_indices.sort()
         return neighbor_indices
 
     # === Helper functions === #

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -1,0 +1,480 @@
+import random
+from collections import defaultdict
+
+import numpy as np
+
+from kfold.data.structure import TokenizedStructure
+from kfold.utils.registry import DATA_CROPPER
+
+from .base import BaseCropper
+from .utils import pick_token
+
+
+@DATA_CROPPER.register()
+class MultiAnchorCropper(BaseCropper):
+    """Cropper that selects tokens based on multiple anchor tokens.
+    When the number of anchor tokens is 1, this is equivalent to AF3's cropping strategy.
+    """
+
+    class Config(BaseCropper.Config):
+        """Configuration for the MultiAnchorCropper.
+
+        Parameters
+        ----------
+        w_contiguous : float
+            Weight for contiguous cropping.
+        w_spatial : float
+            Weight for spatial cropping.
+        w_spatial_interface : float
+            Weight for spatial interface cropping.
+        max_chains : int
+            Maximum number of chains to consider for contiguous cropping.
+        anchor_distribution : str
+            Distribution to sample number of anchors from.
+            Choices: 'uniform', 'linear', 'squared', 'exponential'.
+        max_anchors : int
+            Maximum number of anchor tokens.
+        max_anchor_distance : float
+            Maximum distance between anchor tokens during spatial cropping.
+        """
+
+        w_contiguous: float = 0.3
+        w_spatial: float = 0.2
+        w_spatial_interface: float = 0.5
+        max_chains: int = 20
+        anchor_distribution: str = "exponential"
+        max_anchors: int = 4
+        max_anchor_distance: float = 100.0
+
+    def __init__(self, config: Config):
+        self.config = config
+
+        assert (
+            self.config.w_contiguous
+            + self.config.w_spatial
+            + self.config.w_spatial_interface
+            == 1.0
+        ), "Weights must sum to 1."
+
+        self.w_contiguous: float = config.w_contiguous
+        self.w_spatial: float = config.w_spatial
+        self.w_spatial_interface: float = config.w_spatial_interface
+        self.max_chains: int = config.max_chains
+        self.anchor_distribution: str = config.anchor_distribution
+        self.min_anchors: int = 1
+        self.max_anchors: int = config.max_anchors
+        self.max_anchor_distance: float = config.max_anchor_distance
+
+    def get_token_indices(  # noqa: PLR0915
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        asym_ids: tuple[int, ...] | None,
+    ) -> np.ndarray:
+        """Crop the data to a maximum number of tokens.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        max_tokens : int
+            The maximum number of tokens to crop.
+        asym_ids : tuple[int, ...] | None
+            The chain IDs to center the crop on. If None, a random chain
+
+        Returns
+        -------
+        token_indices: np.ndarray
+            The selected token indices.
+        """
+        v = np.random.rand()
+        if v < self.w_contiguous:
+            # Contiguous cropping
+            crop_indices = self.crop_contiguous(struct, max_tokens)
+        elif v < self.w_contiguous + self.w_spatial:
+            # Spatial cropping
+            crop_indices = self.crop_spatial(struct, max_tokens, asym_ids)
+        else:  # Spatial interface cropping
+            crop_indices = self.crop_spatial_interface(struct, max_tokens, asym_ids)
+
+        # Ensure sorted order and limit to max_tokens
+        crop_indices.sort()
+        if len(crop_indices) > max_tokens:
+            crop_indices = crop_indices[:max_tokens]
+
+        return crop_indices
+
+    def crop_contiguous(
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+    ) -> np.ndarray:
+        """Select an anchor token using contiguous cropping.
+        See Algorithm 1 in the AlphaFold Multimer paper.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        max_tokens : int
+            The maximum number of tokens to crop.
+
+        Returns
+        -------
+        token_index : np.ndarray
+            The selected token index.
+        """
+
+        # Compute the number of tokens and start indices per chain
+        chain_sizes: dict[int, int] = {
+            int(struct.chain.asym_id[i]): int(struct.chain.num_tokens[i])
+            for i in range(struct.num_chains)
+        }
+
+        # Sample chains up to max_chains
+        asym_ids = struct.chain.asym_id
+        selected_asym_ids = np.random.permutation(asym_ids)[: self.max_chains]
+
+        is_selected = np.zeros(struct.num_tokens, dtype=bool)
+
+        # Line 1
+        n_added: int = 0
+        # Line 2
+        # NOTE: This differs from the original algorithm which uses max_tokens.
+        n_remaining: int = sum(chain_sizes[asym_id] for asym_id in selected_asym_ids)
+
+        # Line 3-13
+        for asym_id in selected_asym_ids:
+            n_k = chain_sizes[asym_id]
+            # Line 4
+            n_remaining -= n_k
+
+            # Sample length of crop for current chain
+            # Line 5
+            max_crop = min(max_tokens - n_added, n_k)
+            # Line 6
+            min_crop = min(n_k, max(0, max_tokens - n_added - n_remaining))
+            # Line 7
+            crop_size = np.random.randint(min_crop, max_crop + 1)
+            # Line 8
+            n_added += crop_size
+
+            # Line 9-12
+            if crop_size > 0:
+                selected_tokens = self.do_crop_chain_contiguously(
+                    struct, asym_id, crop_size
+                )
+                is_selected[selected_tokens] = True
+
+            if n_added >= max_tokens:
+                break
+
+        return np.where(is_selected)[0]
+
+    def crop_spatial(
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        bias_asym_ids: tuple[int, ...] | None = None,
+    ) -> np.ndarray:
+        """Select anchor tokens using spatial cropping.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        max_tokens : int
+            The maximum number of tokens to crop.
+        asym_ids : tuple[int, ...] | None
+            The chain IDs to bias the anchor selection towards.
+
+        Returns
+        -------
+        token_index : np.ndarray
+            The selected token index.
+        """
+        # For spatial cropping, get the token center coordinates
+        tokens = struct.token.token_index  # =np.arange(n_tokens)
+        center_idx = struct.token.center_index  # (n_tokens, 3)
+
+        holo_coords = struct.atom.coords[..., 0, :]  # (n_tokens, 24, 3)
+        center_coords = holo_coords[tokens, center_idx, :]  # (n_tokens, 3)
+        resolved_mask = struct.atom.resolved_mask[tokens, center_idx]  # (n_tokens,)
+
+        if resolved_mask.sum() <= max_tokens:
+            # If all resolved tokens fit in the budget, return all
+            return np.where(resolved_mask)[0]
+
+        # Sample number of anchors and their budgets
+        num_anchors: int = self.sample_num_anchors()
+        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens)
+
+        anchor_tokens: list[int] = []
+        is_selected = np.zeros(struct.num_tokens, dtype=bool)
+        is_remaining = resolved_mask.copy()
+        for i in range(num_anchors):
+            # === Select anchor token === #
+            asym_id: int | None = None  # No bias by default
+            anchor_mask = resolved_mask
+            if i == 0 and bias_asym_ids is not None:
+                # If bias is given, sample the first anchor from the biased chains
+                asym_id = random.choice(bias_asym_ids)
+            elif len(anchor_tokens) > 0:
+                # Pick anchor token not to far from previous anchor
+                prev_anchor = anchor_tokens[-1]
+                prev_anchor_coords = center_coords[prev_anchor]  # (3,)
+                dists = np.linalg.norm(center_coords - prev_anchor_coords, axis=1)
+                # Anchor already selected is allowed
+                anchor_mask = anchor_mask & (dists < self.max_anchor_distance)
+
+            anchor = pick_token(struct, asym_id=asym_id, mask=anchor_mask)
+
+            # === Crop spatially around the anchor token === #
+            crop_size = budgets[i]
+            neighbor_indices = self.do_crop_complex_spatially(
+                struct, anchor, crop_size, center_coords, resolved_mask=is_remaining
+            )
+            is_selected[neighbor_indices] = True
+            is_remaining[neighbor_indices] = False
+            anchor_tokens.append(anchor)
+
+        return np.where(is_selected)[0]
+
+    def crop_spatial_interface(
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        bias_asym_ids: tuple[int, ...] | None = None,
+    ) -> np.ndarray:
+        """Select anchor tokens using spatial cropping.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        max_tokens : int
+            The maximum number of tokens to crop.
+        bias_asym_ids : tuple[int, ...] | None
+            The chain IDs to bias the anchor selection towards.
+
+        Returns
+        -------
+        token_index : np.ndarray
+            The selected token index.
+        """
+        # For spatial cropping, get the token center coordinates
+        tokens = struct.token.token_index  # =np.arange(n_tokens)
+        center_idx = struct.token.center_index  # (n_tokens, 3)
+
+        holo_coords = struct.atom.coords[..., 0, :]  # (n_tokens, 24, 3)
+        center_coords = holo_coords[tokens, center_idx, :]  # (n_tokens, 3)
+        resolved_mask = struct.atom.resolved_mask[tokens, center_idx]  # (n_tokens,)
+
+        if resolved_mask.sum() <= max_tokens:
+            # If all resolved tokens fit in the budget, return all
+            return np.where(resolved_mask)[0]
+
+        # Get all valid interfaces
+        record = struct.metadata
+        assert record is not None, "Metadata is required for interface cropping."
+
+        all_chains: set[int] = set(struct.chain.asym_id.tolist())
+        all_interfaces: list[tuple[int, int]] = [
+            interface.asym_ids for interface in record.interfaces if interface.valid
+        ]
+        all_interfaces = [v for v in all_interfaces if set(v).issubset(all_chains)]
+        if bias_asym_ids is not None and len(bias_asym_ids) == 2:
+            # Ensure the biased interface is included
+            all_interfaces.append(bias_asym_ids)
+        all_interfaces = sorted(set(all_interfaces))
+        num_interfaces = len(all_interfaces)
+
+        if num_interfaces == 0:
+            # No valid interfaces, fall back to regular spatial cropping
+            return self.crop_spatial(struct, max_tokens, bias_asym_ids)
+
+        # Collect neighboring chains for each chain
+        chain_to_neighbors: dict[int, list[int]] = defaultdict(list)
+        for interface in set(all_interfaces):
+            i1, i2 = interface
+            chain_to_neighbors[i1].append(i2)
+            chain_to_neighbors[i2].append(i1)
+
+        # Sample number of anchors and their budgets
+        num_anchors: int = self.sample_num_anchors()
+        budgets: list[int] = self.sample_budgets_per_anchor(num_anchors, max_tokens)
+
+        is_selected = np.zeros(struct.num_tokens, dtype=bool)
+        is_remaining = resolved_mask.copy()
+        visited_chains: set[int] = set()
+        for i in range(num_anchors):
+            # === Select interface to sample from === #
+            if i == 0 and bias_asym_ids is not None:
+                # Pick first interface randomly or from biased chains
+                if len(bias_asym_ids) == 1:
+                    asym_id = bias_asym_ids[0]
+                    # Find an interface containing the biased chain
+                    candidate_interfaces = [
+                        interface for interface in all_interfaces if asym_id in interface
+                    ]
+                    interface = random.choice(candidate_interfaces)
+                else:
+                    assert len(bias_asym_ids) == 2
+                    interface = bias_asym_ids
+            elif len(visited_chains) > 0:
+                # Pick an interface connected to visited chains
+                i1 = random.choice(list(visited_chains))
+                i2 = random.choice(chain_to_neighbors[i1])
+                interface = (min(i1, i2), max(i1, i2))
+            else:
+                # Pick a random interface
+                interface = random.choice(all_interfaces)
+
+            # === Select anchor token in the interface === #
+            crop_size = budgets[i]
+            # Anchor already selected is allowed
+            anchor = pick_token(struct, asym_id=interface, mask=resolved_mask)
+
+            # Crop spatially around the anchor token
+            crop_size = budgets[i]
+            neighbor_indices = self.do_crop_complex_spatially(
+                struct, anchor, crop_size, center_coords, resolved_mask=is_remaining
+            )
+            is_selected[neighbor_indices] = True
+            is_remaining[neighbor_indices] = False
+            visited_chains.update(interface)
+
+        return np.where(is_selected)[0]
+
+    def do_crop_chain_contiguously(
+        self, struct: TokenizedStructure, asym_id: int, crop_size: int
+    ) -> np.ndarray:
+        """Crop a contiguous segment from a specific chain."""
+        chain_i = np.where(struct.chain.asym_id == asym_id)[0]
+        assert chain_i.size == 1, f"Chain {asym_id} not found."
+        chain_i = chain_i[0]
+
+        chain_size = int(struct.chain.num_tokens[chain_i])
+        crop_start = np.random.randint(0, chain_size - crop_size + 1, 1).item()
+
+        chain_start = int(struct.chain.token_starts[chain_i])
+        global_start = chain_start + crop_start
+        return np.arange(global_start, global_start + crop_size)
+
+    def do_crop_complex_spatially(
+        self,
+        struct: TokenizedStructure,
+        anchor_token: int,
+        crop_size: int,
+        center_coords: np.ndarray | None = None,
+        resolved_mask: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Crop tokens spatially around an anchor token.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        anchor_token : int
+            The anchor token index.
+        crop_size : int
+            The number of tokens to crop.
+        center_coords : np.ndarray | None, optional
+            Precomputed center coordinates of tokens.
+        resolved_mask : np.ndarray | None, optional
+            Precomputed resolved mask of tokens.
+
+        Returns
+        -------
+        token_indices : np.ndarray
+            The selected token indices.
+        """
+        tokens = struct.token.token_index  # =np.arange(num_tokens)
+        center_idx = struct.token.center_index  # (num_tokens, 3)
+        if center_coords is None:
+            center_coords = struct.atom.coords[tokens, center_idx]  # (num_tokens, 3)
+        if resolved_mask is None:
+            resolved_mask = struct.atom.resolved_mask[tokens, center_idx]  # (num_tokens,)
+
+        crop_size = min(crop_size, resolved_mask.sum())
+
+        # Compute distances to all tokens
+        anchor_coord = center_coords[anchor_token]  # (3,)
+        dists = np.linalg.norm(center_coords - anchor_coord, axis=1)  # (num_tokens,)
+        dists[~resolved_mask] = np.inf
+        # Get tokens within budget (this includes the anchor token itself)
+        neighbor_indices = np.argsort(dists)[:crop_size]
+        return neighbor_indices
+
+    # === Helper functions === #
+    def sample_num_anchors(self) -> int:
+        """Sample the number of anchor tokens."""
+        distribution = self.anchor_distribution
+        min_anchors = self.min_anchors
+        max_anchors = self.max_anchors
+        candidates = np.arange(min_anchors, max_anchors + 1)
+        n_candidates = len(candidates)
+        match distribution:
+            case "uniform":
+                w = np.ones(n_candidates)
+            case "linear":
+                w = np.linspace(1.0, 0.0, n_candidates + 1)[:-1]
+            case "squared":
+                w = np.linspace(1.0, 0.0, n_candidates + 1)[:-1]
+                w = w**2
+            case "exponential":
+                w = np.exp(-candidates)
+            case _:
+                raise ValueError(f"Unknown anchor distribution: {distribution}")
+        w /= w.sum()
+        return np.random.choice(candidates, p=w)
+
+    def sample_budgets_per_anchor(
+        self,
+        num_anchors: int,
+        total_budget: int,
+        min_per_anchor: int | None = None,
+    ) -> list[int]:
+        """Sample the token budgets for each anchor token.
+
+        Parameters
+        ----------
+        num_anchors : int
+            The number of anchor tokens.
+        total_budget : int
+            The total token budget.
+        min_per_anchor : int (optional)
+            The minimum number of tokens per anchor.
+            Default: set to total_budget // num_anchors // 4
+
+        Returns
+        -------
+        budgets : list[int]
+            The token budgets for each anchor token.
+            The budgets are sorted in descending order.
+        """
+        if num_anchors == 1:
+            return [total_budget]
+
+        if min_per_anchor is None:
+            # Set default minimum per anchor (25% of average)
+            min_per_anchor = total_budget // num_anchors // 4
+
+        if min_per_anchor * num_anchors >= total_budget:
+            raise ValueError(
+                "Minimum per anchor too high for total budget and number of anchors."
+            )
+
+        budgets = [min_per_anchor] * num_anchors
+        remaining_budget = total_budget - sum(budgets)
+
+        splits = np.random.randint(0, remaining_budget + 1, size=num_anchors - 1)
+        splits = np.concatenate(([0], np.sort(splits), [remaining_budget]))
+        allocation = splits[1:] - splits[:-1]
+        for i in range(num_anchors):
+            budgets[i] += allocation[i].item()
+
+        # sort budgets in descending order
+        budgets.sort(reverse=True)
+
+        return budgets

--- a/src/kfold/training/folding/dataset/cropper/utils.py
+++ b/src/kfold/training/folding/dataset/cropper/utils.py
@@ -142,7 +142,7 @@ def pick_chain_token(
         The tokenized structure.
     asym_id : int
         The chain asymmetric ID.
-    resolved_mask : np.ndarray | None, optional
+    mask : np.ndarray | None, optional
         An optional mask of valid tokens.
     rng : np.random.Generator | None, optional
         The random number generator. If None, use np.random.
@@ -236,7 +236,7 @@ def pick_interface_token(
     dists = cdist(tokens_1_coords, tokens_2_coords)
     cutoff = dists < C.INTERFACE_CUTOFF
 
-    # In rare cases, the interface cuttoff is slightly to small,
+    # In rare cases, the interface cutoff is slightly too small,
     # then we slightly expand it if it happens
     if not np.any(cutoff):
         cutoff = dists < (C.INTERFACE_CUTOFF + 5.0)

--- a/src/kfold/training/folding/dataset/cropper/utils.py
+++ b/src/kfold/training/folding/dataset/cropper/utils.py
@@ -1,0 +1,182 @@
+# started from code from https://github.com/jwohlwend/boltz, MIT License
+import numbers
+
+import numpy as np
+from scipy.spatial.distance import cdist
+
+import kfold.constants as C
+from kfold.data.structure import TokenizedStructure
+
+
+def pick_token(
+    struct: TokenizedStructure,
+    asym_id: int | tuple[int, int] | None = None,
+    mask: np.ndarray | None = None,
+) -> int:
+    """Pick a random token from a chain.
+
+    Parameters
+    ----------
+    struct : TokenizedStructure
+        The tokenized structure.
+    asym_id : int | tuple[int, int] | None, optional
+        The chain asymmetric ID or interface chain IDs.
+        If None, pick from all tokens.
+    mask : np.ndarray | None, optional
+        An optional mask of valid tokens.
+
+    Returns
+    -------
+    token_index : int
+        The selected token index.
+    """
+    if asym_id is None:
+        # Pick from entire complex
+        return pick_complex_token(struct, mask)
+    if isinstance(asym_id, int | numbers.Integral):
+        # Pick from specific chain
+        return pick_chain_token(struct, asym_id, mask)
+    else:
+        # Pick from interface
+        assert len(asym_id) == 2, "asym_id tuple must have length 2"
+        return pick_interface_token(struct, asym_id, mask)
+
+
+def pick_complex_token(
+    struct: TokenizedStructure,
+    mask: np.ndarray | None = None,
+) -> int:
+    """Pick a random token from the entire complex.
+
+    Parameters
+    ----------
+    struct : TokenizedStructure
+        The tokenized structure.
+    mask : np.ndarray | None, optional
+        An optional mask of valid tokens.
+
+    Returns
+    -------
+    token_index : int
+        The selected token index.
+    """
+    token_indices = struct.token.token_index
+    if mask is not None:
+        token_indices = token_indices[mask]
+    return np.random.choice(token_indices)
+
+
+def pick_chain_token(
+    struct: TokenizedStructure,
+    asym_id: int,
+    mask: np.ndarray | None = None,
+) -> int:
+    """Pick a random token from a chain.
+
+    Parameters
+    ----------
+    struct : TokenizedStructure
+        The tokenized structure.
+    asym_id : int
+        The chain asymmetric ID.
+    resolved_mask : np.ndarray | None, optional
+        An optional mask of valid tokens.
+
+    Returns
+    -------
+    token_index : int
+        The selected token index.
+    """
+    # Get chain mask
+    chain_mask = struct.token.asym_id == asym_id
+    if mask is not None:
+        chain_mask &= mask
+
+    if not np.any(chain_mask):
+        # Fallback to all tokens
+        return pick_token(struct, asym_id=None, mask=mask)
+
+    # Pick from chain, fallback to all tokens
+    token_indices = struct.token.token_index  # =np.arange(num_tokens)
+    chain_tokens = token_indices[chain_mask]
+    return np.random.choice(chain_tokens)
+
+
+def pick_interface_token(
+    struct: TokenizedStructure,
+    asym_ids: tuple[int, int],
+    mask: np.ndarray | None = None,
+) -> int:
+    """Pick a random token from an interface.
+
+    Parameters
+    ----------
+    struct : TokenizedStructure
+        The tokenized data.
+    asym_ids : tuple[int, int]
+        The chain IDs defining the interface.
+    mask : np.ndarray | None, optional
+        An optional mask of valid tokens.
+
+    Returns
+    -------
+    token_index : int
+        The selected token index.
+    """
+    assert len(asym_ids) == 2, "asym_ids must be a tuple of length 2"
+
+    if mask is None:
+        # Interface can be determined only on resolved residues
+        mask = struct.atom.resolved_mask[
+            struct.token.token_index, struct.token.center_index
+        ]  # (num_tokens,)
+
+    # Get chain masks
+    chain_1, chain_2 = asym_ids
+    chain_mask_1 = (struct.token.asym_id == chain_1) & mask
+    chain_mask_2 = (struct.token.asym_id == chain_2) & mask
+    is_empty_1 = not np.any(chain_mask_1)
+    is_empty_2 = not np.any(chain_mask_2)
+
+    if is_empty_1 and is_empty_2:
+        # Fallback to all tokens with resolved residues
+        return pick_complex_token(struct, mask)
+
+    if (not is_empty_1) and is_empty_2:
+        # Fallback to chain 1 with resolved residues
+        return pick_chain_token(struct, chain_1, mask)
+
+    if is_empty_1 and (not is_empty_2):
+        # Fallback to chain 2 with resolved residues
+        return pick_chain_token(struct, chain_2, mask)
+
+    # Get interface tokens
+    tokens = struct.token.token_index  # =np.arange(num_tokens)
+    center_index = struct.token.center_index
+    tokens_1 = tokens[chain_mask_1]
+    tokens_2 = tokens[chain_mask_2]
+
+    # Compute distances between tokens in the two chains to determine interface
+    holo_coords = struct.atom.coords[..., 0, :]  # (num_tokens, 24, 3)
+    tokens_1_coords = holo_coords[tokens_1, center_index[tokens_1]]
+    tokens_2_coords = holo_coords[tokens_2, center_index[tokens_2]]
+
+    dists = cdist(tokens_1_coords, tokens_2_coords)
+    cutoff = dists < C.INTERFACE_CUTOFF
+
+    # In rare cases, the interface cuttoff is slightly to small,
+    # then we slightly expand it if it happens
+    if not np.any(cutoff):
+        cutoff = dists < (C.INTERFACE_CUTOFF + 5.0)
+
+    if not np.any(cutoff):
+        # Fallback to all tokens with resolved residues
+        return pick_complex_token(struct, mask)
+
+    tokens_1 = tokens_1[cutoff.any(axis=1)]
+    tokens_2 = tokens_2[cutoff.any(axis=0)]
+
+    # Select random token
+    candidates = np.concatenate([tokens_1, tokens_2])
+
+    return np.random.choice(candidates)

--- a/src/kfold/training/folding/dataset/cropper/utils.py
+++ b/src/kfold/training/folding/dataset/cropper/utils.py
@@ -1,5 +1,7 @@
 # started from code from https://github.com/jwohlwend/boltz, MIT License
 import numbers
+from collections.abc import Sequence
+from typing import TypeVar, overload
 
 import numpy as np
 from scipy.spatial.distance import cdist
@@ -7,11 +9,64 @@ from scipy.spatial.distance import cdist
 import kfold.constants as C
 from kfold.data.structure import TokenizedStructure
 
+AnyT = TypeVar("AnyT")
+
+
+@overload
+def random_choice(
+    samples: int,
+    p: Sequence[float] | np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
+) -> int: ...
+
+
+@overload
+def random_choice(
+    samples: Sequence[AnyT],
+    p: Sequence[float] | np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
+) -> AnyT: ...
+
+
+def random_choice(
+    samples: int | Sequence[AnyT],
+    p: Sequence[float] | np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
+) -> AnyT | int:
+    """Randomly choose an element or multiple elements from a sequence.
+
+    Parameters
+    ----------
+    samples : Sequence[AnyT]
+        The sequence to choose from.
+    p : Sequence[float] | np.ndarray | None, optional
+        The probabilities associated with each entry in `samples`.
+    rng : np.random.Generator | None
+        The random number generator. If None, use np.random.
+
+    Returns
+    -------
+    choice: AnyT
+        The randomly chosen element(s).
+    """
+    assert rng is not None, "rng must be provided"  # avoid accidental use of global RNG
+    rng = rng or np.random.default_rng()
+    if p is not None:
+        p = np.array(p, dtype=np.float64)
+        p /= p.sum()
+
+    if isinstance(samples, int):
+        return rng.choice(samples, p=p)
+    else:
+        index = rng.choice(len(samples), p=p)
+        return samples[index]
+
 
 def pick_token(
     struct: TokenizedStructure,
     asym_id: int | tuple[int, int] | None = None,
     mask: np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
 ) -> int:
     """Pick a random token from a chain.
 
@@ -24,27 +79,32 @@ def pick_token(
         If None, pick from all tokens.
     mask : np.ndarray | None, optional
         An optional mask of valid tokens.
+    rng : np.random.Generator | None, optional
+        The random number generator. If None, use np.random.
 
     Returns
     -------
     token_index : int
         The selected token index.
     """
+    assert rng is not None, "rng must be provided"  # avoid accidental use of global RNG
+    rng = rng or np.random.default_rng()
     if asym_id is None:
         # Pick from entire complex
-        return pick_complex_token(struct, mask)
+        return pick_complex_token(struct, mask, rng)
     if isinstance(asym_id, int | numbers.Integral):
         # Pick from specific chain
-        return pick_chain_token(struct, asym_id, mask)
+        return pick_chain_token(struct, int(asym_id), mask, rng)
     else:
         # Pick from interface
         assert len(asym_id) == 2, "asym_id tuple must have length 2"
-        return pick_interface_token(struct, asym_id, mask)
+        return pick_interface_token(struct, asym_id, mask, rng)
 
 
 def pick_complex_token(
     struct: TokenizedStructure,
     mask: np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
 ) -> int:
     """Pick a random token from the entire complex.
 
@@ -60,16 +120,19 @@ def pick_complex_token(
     token_index : int
         The selected token index.
     """
+    rng = rng or np.random.default_rng()
+
     token_indices = struct.token.token_index
     if mask is not None:
         token_indices = token_indices[mask]
-    return np.random.choice(token_indices)
+    return rng.choice(token_indices)
 
 
 def pick_chain_token(
     struct: TokenizedStructure,
     asym_id: int,
     mask: np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
 ) -> int:
     """Pick a random token from a chain.
 
@@ -81,12 +144,16 @@ def pick_chain_token(
         The chain asymmetric ID.
     resolved_mask : np.ndarray | None, optional
         An optional mask of valid tokens.
+    rng : np.random.Generator | None, optional
+        The random number generator. If None, use np.random.
 
     Returns
     -------
     token_index : int
         The selected token index.
     """
+    rng = rng or np.random.default_rng()
+
     # Get chain mask
     chain_mask = struct.token.asym_id == asym_id
     if mask is not None:
@@ -94,18 +161,19 @@ def pick_chain_token(
 
     if not np.any(chain_mask):
         # Fallback to all tokens
-        return pick_token(struct, asym_id=None, mask=mask)
+        return pick_token(struct, asym_id=None, mask=mask, rng=rng)
 
     # Pick from chain, fallback to all tokens
     token_indices = struct.token.token_index  # =np.arange(num_tokens)
     chain_tokens = token_indices[chain_mask]
-    return np.random.choice(chain_tokens)
+    return rng.choice(chain_tokens)
 
 
 def pick_interface_token(
     struct: TokenizedStructure,
     asym_ids: tuple[int, int],
     mask: np.ndarray | None = None,
+    rng: np.random.Generator | None = None,
 ) -> int:
     """Pick a random token from an interface.
 
@@ -117,6 +185,8 @@ def pick_interface_token(
         The chain IDs defining the interface.
     mask : np.ndarray | None, optional
         An optional mask of valid tokens.
+    rng : np.random.Generator | None, optional
+        The random number generator. If None, use np.random.
 
     Returns
     -------
@@ -124,6 +194,8 @@ def pick_interface_token(
         The selected token index.
     """
     assert len(asym_ids) == 2, "asym_ids must be a tuple of length 2"
+
+    rng = rng or np.random.default_rng()
 
     if mask is None:
         # Interface can be determined only on resolved residues
@@ -140,21 +212,21 @@ def pick_interface_token(
 
     if is_empty_1 and is_empty_2:
         # Fallback to all tokens with resolved residues
-        return pick_complex_token(struct, mask)
+        return pick_complex_token(struct, mask, rng)
 
     if (not is_empty_1) and is_empty_2:
         # Fallback to chain 1 with resolved residues
-        return pick_chain_token(struct, chain_1, mask)
+        return pick_chain_token(struct, chain_1, mask, rng)
 
     if is_empty_1 and (not is_empty_2):
         # Fallback to chain 2 with resolved residues
-        return pick_chain_token(struct, chain_2, mask)
+        return pick_chain_token(struct, chain_2, mask, rng)
 
     # Get interface tokens
-    tokens = struct.token.token_index  # =np.arange(num_tokens)
+    all_tokens = struct.token.token_index  # =np.arange(num_tokens)
     center_index = struct.token.center_index
-    tokens_1 = tokens[chain_mask_1]
-    tokens_2 = tokens[chain_mask_2]
+    tokens_1 = all_tokens[chain_mask_1]
+    tokens_2 = all_tokens[chain_mask_2]
 
     # Compute distances between tokens in the two chains to determine interface
     holo_coords = struct.atom.coords[..., 0, :]  # (num_tokens, 24, 3)
@@ -171,7 +243,7 @@ def pick_interface_token(
 
     if not np.any(cutoff):
         # Fallback to all tokens with resolved residues
-        return pick_complex_token(struct, mask)
+        return pick_complex_token(struct, mask, rng)
 
     tokens_1 = tokens_1[cutoff.any(axis=1)]
     tokens_2 = tokens_2[cutoff.any(axis=0)]
@@ -179,4 +251,4 @@ def pick_interface_token(
     # Select random token
     candidates = np.concatenate([tokens_1, tokens_2])
 
-    return np.random.choice(candidates)
+    return rng.choice(candidates)

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -301,7 +301,7 @@ class TrainingDataset(SafeLoadingDataset):
         for _ in range(num_trials):
             sample = self.samples[index]
             try:
-                return self.get_item(sample.metadata, asym_ids=sample.asym_ids)
+                return self.get_item(sample.metadata, asym_ids=sample.asym_id)
             except (KeyboardInterrupt, SystemExit) as e:
                 raise e
             except Exception as e:

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -378,8 +378,9 @@ class LMDBDatabase:
 
         # Use io.BytesIO to wrap the raw bytes
         with io.BytesIO(value_bytes) as byte_stream:
-            tokenized_structure = structure.TokenizedStructure.load_npz(byte_stream)
-        return tokenized_structure
+            struct = structure.TokenizedStructure.load_npz(byte_stream)
+        struct = struct.copy_with(metadata=record)
+        return struct
 
     def __del__(self):
         if hasattr(self, "_lmdb_env"):

--- a/src/kfold/training/folding/dataset/dl_sampler.py
+++ b/src/kfold/training/folding/dataset/dl_sampler.py
@@ -72,7 +72,8 @@ class DistributedWeightedSampler(Sampler[int]):
 
     def __iter__(self) -> Iterator[int]:
         # deterministically shuffle based on epoch and seed
-        rng = np.random.RandomState(self.seed + self.epoch)
+        seed = self.seed + self.epoch
+        rng = np.random.default_rng(seed)
 
         indices = rng.choice(
             self.dataset_size,

--- a/src/kfold/training/folding/dataset/sampler/base.py
+++ b/src/kfold/training/folding/dataset/sampler/base.py
@@ -14,13 +14,13 @@ class Sample(NamedTuple):
     ----------
     metadata : Metadata
         The metadata record of the sampled item.
-    asym_ids : tuple[int, ...] or None
-        The cropping constraint; asym_ids of chains / interfaces to include.
+    asym_id : int | tuple[int, int] | None
+        The cropping constraint; asym_id(s) of chain / interface to include.
         If None, no constraint is applied.
     """
 
     metadata: Metadata
-    asym_ids: tuple[int, ...] | None = None
+    asym_id: int | tuple[int, int] | None
 
 
 @DATA_SAMPLER.register()

--- a/src/kfold/training/folding/dataset/sampler/cluster.py
+++ b/src/kfold/training/folding/dataset/sampler/cluster.py
@@ -220,7 +220,7 @@ class ClusterSampler(BaseSampler):
                     self.alpha_nuc,
                     self.alpha_ligand,
                 )
-                samples.append(Sample(record, (chain.asym_id,)))
+                samples.append(Sample(record, chain.asym_id))
                 weights.append(weight)
 
             for interface in record.interfaces:

--- a/src/kfold/training/folding/dataset/sampler/uniform.py
+++ b/src/kfold/training/folding/dataset/sampler/uniform.py
@@ -38,7 +38,7 @@ class UniformSampler(BaseSampler):
                 for chain in m.chains:
                     if not chain.valid:
                         continue
-                    samples.append(Sample(m, (chain.asym_id,)))
+                    samples.append(Sample(m, chain.asym_id))
 
         weights = None  # Uniform sampling
         return samples, weights

--- a/tests/test_crop.py
+++ b/tests/test_crop.py
@@ -1,45 +1,65 @@
-import json
+import io
 import random
 from pathlib import Path
 
+import lmdb
+import numpy as np
 from tqdm import tqdm
 
-from kfold.training.folding.dataset.cropper.boltz import BoltzCropper
-from kfold.utils.boltz.process import parse_record, tokenize_structure
-from kfold.utils.boltz.structure import BoltzStructure
+from kfold.data.metadata import Metadata
+from kfold.data.structure import TokenizedStructure
+from kfold.training.folding.dataset.cropper.multi_anchor import MultiAnchorCropper
+from kfold.training.folding.dataset.datamodule import load_manifest
 
-BOLTZ_PATH = Path("/cache/wykim_lab/rcsb_processed_targets/")
-BOLTZ_MANIFEST_PATH = BOLTZ_PATH / "manifest.json"
-BOLTZ_STRUCTURE_DIR = BOLTZ_PATH / "structures"
+LMDB_PATH = Path("/cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/")
+MANIFEST_PATH = Path("/cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl")
+SAVE_PATH = Path("./tmp/pdb-crop/")
 
 
 if __name__ == "__main__":
-    with open(BOLTZ_MANIFEST_PATH) as f:
-        manifest = json.load(f)
+    all_records: list[Metadata] = load_manifest(MANIFEST_PATH)
 
-    manifest = {v["id"]: v for v in manifest}
-    keys = sorted(list(manifest.keys()))
-    random.seed(42)
-    random.shuffle(keys)
+    env = lmdb.open(str(LMDB_PATH), readonly=True, lock=False, readahead=False)
 
     # data cropping
-    cropper = BoltzCropper(BoltzCropper.Config())
+    cropper = MultiAnchorCropper(
+        MultiAnchorCropper.Config(
+            w_contiguous=0.3,
+            w_spatial=0.2,
+            w_spatial_interface=0.5,
+        )
+    )
 
-    keys = keys[:20]
-    for key in tqdm(keys):
-        record = parse_record(manifest[key])
-        if record.num_chains > 20:
-            # Skip large structures for testing
-            continue
+    SAVE_PATH.mkdir(parents=True, exist_ok=True)
 
-        # Set random seed for reproducibility
-        random.seed(key)
-        path = BOLTZ_STRUCTURE_DIR / f"{key}.npz"
-        boltz_structure = BoltzStructure.load(path)
-        tokenized = tokenize_structure(boltz_structure)
-        # Crop structure
-        cropped_tokenized = cropper.crop(tokenized, 384, None)
+    with env.begin(write=False) as txn:
+        for i, record in enumerate(tqdm(all_records[:100])):
+            # Set random seed for reproducibility
+            random.seed(i)
+            np.random.seed(i)
 
-        # Save full and cropped structures
-        tokenized.to_pdb(f"./tmp/pdb-crop/{key}-full.pdb")
-        cropped_tokenized.to_pdb(f"./tmp/pdb-crop/{key}-crop.pdb")
+            key = record.id
+
+            if record.num_chains > 52:
+                continue
+
+            byte_data = txn.get(key.encode("utf-8"))
+
+            with io.BytesIO(byte_data) as byte_stream:
+                struct = TokenizedStructure.load_npz(byte_stream)
+            struct = struct.copy_with(metadata=record)
+
+            if struct.num_tokens < 768:
+                # Skip small structures for testing
+                continue
+
+            cropped_struct = cropper.crop(struct, 384, None)
+
+            # Save full and cropped structures
+            try:
+                struct.to_pdb(SAVE_PATH / f"{key}-full.pdb", is_predicted=False)
+                cropped_struct.to_pdb(
+                    SAVE_PATH / f"{key}-cropped.pdb", is_predicted=False
+                )
+            except Exception as e:
+                print(f"Failed to save {key}: {e}")


### PR DESCRIPTION
This pull request refactors and improves the cropping logic for protein structures in the `kfold` codebase, focusing on the cropping strategies in the `alphafold.py` cropper. The main changes include standardizing interface definitions, updating method signatures to support more flexible cropping, improving reproducibility by introducing random number generators, and cleaning up legacy code. These updates make the cropping logic clearer, more robust, and easier to extend.

### Cropping logic and API improvements

* Standardized the definition of `asym_ids` in `InterfaceInfo` to always require exactly two chain IDs, simplifying interface handling and validation.
* Updated cropper method signatures to use `bias_asym_id` (an int or tuple of ints) and an optional `rng` parameter for reproducible random choices, replacing the previous `asym_ids` argument. This change is reflected in both the base cropper and the `alphafold.py` cropper. 
* Refactored cropping functions to use a consistent random generator (`rng`) for all random operations, improving reproducibility and testability.

### Cropping strategy and code cleanup

* Simplified and clarified the cropping strategies, including contiguous, spatial, and spatial-interface cropping, and removed legacy helper functions in favor of a more modular approach using utility functions.
* Replaced legacy code for picking interface tokens and queries with new utility-based logic, and added more robust handling for cases where no valid interfaces are found.

### Configuration and parameter handling

* Renamed cropping strategy weights to `w_contiguous`, `w_spatial`, and `w_spatial_interface` for clarity, and removed unused configuration parameters such as `max_chains`.

These changes collectively improve the maintainability, clarity, and reliability of the cropping logic for protein structure datasets.