### PR TITLE
add on-the-fly chain subsampling(pre-crop) before cropping

### DIFF
--- a/configs/train-af3-tiny.yaml
+++ b/configs/train-af3-tiny.yaml
@@ -16,11 +16,12 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 384
     batch_size: 4
     diffusion_batch_size: 48
     global_batch_size: 256
-    num_global_steps_per_epoch: 250
+    num_global_steps_per_epoch: 500
 
   # pytorch lightning trainer hparams
   trainer:

--- a/configs/train-af3.yaml
+++ b/configs/train-af3.yaml
@@ -11,6 +11,7 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 384
     batch_size: 2
     diffusion_batch_size: 48

--- a/configs/train-esmc-apoemb-edm-mini.yaml
+++ b/configs/train-esmc-apoemb-edm-mini.yaml
@@ -19,11 +19,12 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 512
     batch_size: 4
     diffusion_batch_size: 32
     global_batch_size: 128
-    num_global_steps_per_epoch: 250
+    num_global_steps_per_epoch: 500
 
   # pytorch lightning trainer hparams
   trainer:

--- a/configs/train-esmc-ddbm-mini.yaml
+++ b/configs/train-esmc-ddbm-mini.yaml
@@ -18,11 +18,12 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 512
     batch_size: 4
     diffusion_batch_size: 32
     global_batch_size: 128
-    num_global_steps_per_epoch: 250
+    num_global_steps_per_epoch: 500
 
   # pytorch lightning trainer hparams
   trainer:

--- a/configs/train-esmc-edm-mini.yaml
+++ b/configs/train-esmc-edm-mini.yaml
@@ -18,11 +18,12 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 512
     batch_size: 4
     diffusion_batch_size: 32
     global_batch_size: 128
-    num_global_steps_per_epoch: 250
+    num_global_steps_per_epoch: 500
 
   # pytorch lightning trainer hparams
   trainer:

--- a/configs/train-esmc-edm.yaml
+++ b/configs/train-esmc-edm.yaml
@@ -13,6 +13,7 @@ train:
   seed: 42
 
   global_hparams:
+    max_chains: 20
     max_tokens: 512
     batch_size: 2
     diffusion_batch_size: 32

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -21,11 +21,11 @@ data:
   _class_: TrainingDataModule
 
   # DataLoader
-  train_batch_size: ${global_hparams.batch_size}
+  train_batch_size: ???
   val_batch_size: 1
   num_workers: 8
-  max_chains: ${global_hparams.max_chains}
-  max_tokens: ${global_hparams.max_tokens}
+  max_chains: ???
+  max_tokens: ???
   pin_memory: true
   safe_load: true
 
@@ -60,8 +60,9 @@ data:
   cropper:
     _registry_: "data_cropper"
     _class_: MultiAnchorCropper
-    w_contiguous: 0.3
-    w_spatial: 0.2
+    max_anchors: 1
+    w_contiguous: 0.25
+    w_spatial: 0.25
     w_spatial_interface: 0.5
 
   sampler:

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -21,11 +21,11 @@ data:
   _class_: TrainingDataModule
 
   # DataLoader
-  train_batch_size: ???
+  train_batch_size: ??? # set by global_hparam
   val_batch_size: 1
   num_workers: 8
-  max_chains: ???
-  max_tokens: ???
+  max_chains: ??? # set by global_hparam
+  max_tokens: ??? # set by global_hparam
   pin_memory: true
   safe_load: true
 

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -59,11 +59,7 @@ data:
 
   cropper:
     _registry_: "data_cropper"
-    _class_: MultiAnchorCropper
-    max_anchors: 4
-    w_contiguous: 0.25
-    w_spatial: 0.25
-    w_spatial_interface: 0.5
+    _class_: BoltzCropper
 
   sampler:
     _registry_: "data_sampler"

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -60,7 +60,7 @@ data:
   cropper:
     _registry_: "data_cropper"
     _class_: MultiAnchorCropper
-    max_anchors: 1
+    max_anchors: 4
     w_contiguous: 0.25
     w_spatial: 0.25
     w_spatial_interface: 0.5

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -9,6 +9,7 @@ synchronize_seed: true # Use the same seed across DDP processes
 
 # Training parameters for multi-gpu setup.
 global_hparams:
+  max_chains: 20
   max_tokens: 512
   batch_size: 1
   diffusion_batch_size: 48
@@ -20,10 +21,11 @@ data:
   _class_: TrainingDataModule
 
   # DataLoader
-  train_batch_size: ??? # set by global_hparam
+  train_batch_size: ${global_hparams.batch_size}
   val_batch_size: 1
   num_workers: 8
-  max_tokens: ??? # set by global_hparam
+  max_chains: ${global_hparams.max_chains}
+  max_tokens: ${global_hparams.max_tokens}
   pin_memory: true
   safe_load: true
 
@@ -57,9 +59,10 @@ data:
 
   cropper:
     _registry_: "data_cropper"
-    _class_: BoltzCropper
-    min_neighborhood: 0
-    max_neighborhood: 40
+    _class_: MultiAnchorCropper
+    w_contiguous: 0.3
+    w_spatial: 0.2
+    w_spatial_interface: 0.5
 
   sampler:
     _registry_: "data_sampler"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -117,6 +117,9 @@ def parse_config(args) -> DictConfig:
     train_cfg = cfg.train
     global_hparams = train_cfg.global_hparams
 
+    train_cfg.data.max_chains = global_hparams.max_chains
+    train_cfg.data.max_tokens = global_hparams.max_tokens
+    train_cfg.data.train_batch_size = global_hparams.batch_size
     train_cfg.training.diffusion_batch_size = global_hparams.diffusion_batch_size
 
     # compute accumulate_grad_batches

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -117,8 +117,6 @@ def parse_config(args) -> DictConfig:
     train_cfg = cfg.train
     global_hparams = train_cfg.global_hparams
 
-    train_cfg.data.max_tokens = global_hparams.max_tokens
-    train_cfg.data.train_batch_size = global_hparams.batch_size
     train_cfg.training.diffusion_batch_size = global_hparams.diffusion_batch_size
 
     # compute accumulate_grad_batches
@@ -155,7 +153,7 @@ def parse_config(args) -> DictConfig:
         cfg.train.trainer.accumulate_grad_batches = 1
         cfg.train.trainer.log_every_n_steps = 1
         cfg.train.trainer.limit_train_batches = 10
-        cfg.train.trainer.limit_val_batches = 50
+        cfg.train.trainer.limit_val_batches = 10
         cfg.train.data.train_batch_size = 1
         cfg.train.data.num_workers = 0
         cfg.train.data.safe_load = False

--- a/src/kfold/data/structure.py
+++ b/src/kfold/data/structure.py
@@ -725,6 +725,40 @@ class TokenizedStructure:
             metadata=self.metadata,
         )
 
+    def reassign_token_indices(self) -> Self:
+        """Reassign token indices to be consecutive from 0 to Ntoken-1.
+
+        Returns
+        -------
+        new_struct: TokenizedStructure
+            Structure with reassigned token indices.
+        """
+        Ntoken = self.num_tokens
+        old_token_indices = self.token.token_index
+        new_token_indices = np.arange(Ntoken, dtype=old_token_indices.dtype)
+
+        # Update token structure
+        new_token = self.token.copy_with(token_index=new_token_indices)
+
+        # Update token indices in bond
+        bond = self.bond
+        token_index_mapping = {
+            old_idx: new_idx for new_idx, old_idx in enumerate(old_token_indices)
+        }
+        old_bond_token_indices = bond.token_index
+        new_bond_token_indices = np.array(
+            [
+                [token_index_mapping[int(idx)] for idx in bond_pair]
+                for bond_pair in old_bond_token_indices
+            ],
+            dtype=old_bond_token_indices.dtype,
+        ).reshape(-1, 2)
+        new_bond = bond.copy_with(token_index=new_bond_token_indices)
+
+        # Create new structure
+        new_struct = self.copy_with(token=new_token, bond=new_bond)
+        return new_struct
+
     def replace_atom_coords(
         self,
         atom_coords: np.ndarray,

--- a/src/kfold/training/folding/dataset/cropper/__init__.py
+++ b/src/kfold/training/folding/dataset/cropper/__init__.py
@@ -4,6 +4,7 @@ import importlib
 from pathlib import Path
 
 from .base import BaseCropper
+from .pre_crop import PreCropper
 
 # Get all Python module names in current directory
 _package_dir = Path(__file__).parent

--- a/src/kfold/training/folding/dataset/cropper/alphafold.py
+++ b/src/kfold/training/folding/dataset/cropper/alphafold.py
@@ -47,12 +47,12 @@ class AlphaFold3Cropper(BaseCropper):
         if self.w_contiguous + self.w_spatial + self.w_spatial_interface != 1.0:
             raise ValueError("Cropping strategy weights must sum to 1.0")
 
-    def get_token_indices(  # noqa: PLR0915
+    def get_token_indices(
         self,
         struct: TokenizedStructure,
         max_tokens: int,
-        bias_asym_id: int | tuple[int, int] | None = None,
-        rng: np.random.Generator | None = None,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Get the token indices to include in the crop.
 
@@ -65,8 +65,8 @@ class AlphaFold3Cropper(BaseCropper):
         bias_asym_id: int | tuple[int, ...] | None
             The chain ID(s) to center the crop on. If None, a random chain or interface
             will be selected.
-        rng: np.random.Generator | None, optional
-            The random number generator. If None, use np.random.
+        rng: np.random.Generator
+            The random number generator.
 
         Returns
         ----------

--- a/src/kfold/training/folding/dataset/cropper/base.py
+++ b/src/kfold/training/folding/dataset/cropper/base.py
@@ -59,7 +59,7 @@ class BaseCropper(ABC):
         struct: TokenizedStructure,
         max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
-        rng: np.random.Generator | None = None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Get the indices of the tokens to include in the crop.
 
@@ -72,8 +72,8 @@ class BaseCropper(ABC):
         bias_asym_id : int | tuple[int, int] | None
             The chain ID(s) to center the crop on. If None, a random chain or interface
             will be selected.
-        rng : np.random.Generator | None, optional
-            The random number generator. If None, use np.random.
+        rng : np.random.Generator
+            The random number generator.
 
         Returns
         -------

--- a/src/kfold/training/folding/dataset/cropper/boltz.py
+++ b/src/kfold/training/folding/dataset/cropper/boltz.py
@@ -41,7 +41,7 @@ class BoltzCropper(BaseCropper):
         struct: TokenizedStructure,
         max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
-        rng: np.random.Generator | None = None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Crop the data to a maximum number of tokens.
 
@@ -54,17 +54,14 @@ class BoltzCropper(BaseCropper):
         asym_ids : tuple[int, ...] | None, optional
             The chain ID(s) to center the crop on. If None, a random chain
             or interface will be selected.
-        rng : np.random.Generator | None, optional
-            The random number generator. If None, use np.random.
+        rng : np.random.Generator
+            The random number generator
 
         Returns
         -------
         token_indices: np.ndarray
             The selected token indices.
         """
-        if rng is None:
-            rng = np.random.default_rng()
-
         token_data = struct.token  # features: [L, ...]
         atom_data = struct.atom  # features: [L, 24, ...]
 

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -110,7 +110,7 @@ class MultiAnchorCropper(BaseCropper):
         struct: TokenizedStructure,
         max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
-        rng: np.random.Generator | None = None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         """Crop the data to a maximum number of tokens.
 
@@ -123,14 +123,14 @@ class MultiAnchorCropper(BaseCropper):
         bias_asym_id : int | tuple[int, int] | None
             The chain ID(s) to center the crop on. If None, a random chain or interface
             will be selected.
+        rng : np.random.Generator
+            The random number generator
 
         Returns
         -------
         token_indices: np.ndarray
             The selected token indices.
         """
-        rng = rng or np.random.default_rng()
-
         v = rng.random()
         if v < self.w_contiguous:
             # Contiguous cropping
@@ -175,9 +175,12 @@ class MultiAnchorCropper(BaseCropper):
         """
 
         # Compute the number of tokens and start indices per chain
+        asym_id_to_chain_idx: dict[int, int] = {
+            v: i for i, v in enumerate(struct.chain.asym_id.tolist())
+        }
         chain_sizes: dict[int, int] = {
-            int(struct.chain.asym_id[i]): int(struct.chain.num_tokens[i])
-            for i in range(struct.num_chains)
+            asym_id: int(struct.chain.num_tokens[chain_idx])
+            for asym_id, chain_idx in asym_id_to_chain_idx.items()
         }
 
         # Randomly permute the chain order
@@ -218,7 +221,7 @@ class MultiAnchorCropper(BaseCropper):
             crop_start = int(rng.integers(0, n_k - crop_size + 1))
 
             # Line 11
-            chain_idx = np.where(struct.chain.asym_id == asym_id)[0][0]
+            chain_idx = asym_id_to_chain_idx[asym_id]
             chain_st = int(struct.chain.token_starts[chain_idx])
             crop_start += chain_st
             selected_tokens = np.arange(crop_start, crop_start + crop_size)

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -74,6 +74,8 @@ class MultiAnchorCropper(BaseCropper):
         anchor_distribution : str
             Distribution to sample number of anchors from.
             Choices: 'uniform', 'linear', 'squared', 'exponential'.
+        min_anchors : int
+            Minimum number of anchor tokens.
         max_anchors : int
             Maximum number of anchor tokens.
         max_anchor_distance : float
@@ -84,6 +86,7 @@ class MultiAnchorCropper(BaseCropper):
         w_spatial: float = 0.4
         w_spatial_interface: float = 0.4
         anchor_distribution: str = "exponential"
+        min_anchors: int = 1
         max_anchors: int = 1
         max_anchor_distance: float = 100.0
 
@@ -101,7 +104,7 @@ class MultiAnchorCropper(BaseCropper):
         self.w_spatial: float = config.w_spatial
         self.w_spatial_interface: float = config.w_spatial_interface
         self.anchor_distribution: str = config.anchor_distribution
-        self.min_anchors: int = 1
+        self.min_anchors: int = config.min_anchors
         self.max_anchors: int = config.max_anchors
         self.max_anchor_distance: float = config.max_anchor_distance
 
@@ -358,7 +361,7 @@ class MultiAnchorCropper(BaseCropper):
 
         is_selected = np.zeros(struct.num_tokens, dtype=bool)
         is_remaining = resolved_mask.copy()
-        visited_chains: set[int] = set()
+        visited_chains: list[int] = []
         for i in range(num_anchors):
             # Select an interface to sample anchor from
             if i == 0:
@@ -385,10 +388,9 @@ class MultiAnchorCropper(BaseCropper):
             else:
                 # Pick an interface connected to visited chains
                 assert len(visited_chains) > 0, "No visited chains"
-                i1 = utils.random_choice(list(visited_chains), rng=rng)
+                i1 = utils.random_choice(visited_chains, rng=rng)
                 i2 = utils.random_choice(chain_to_neighbors[i1], rng=rng)
                 interface_id = (min(i1, i2), max(i1, i2))
-            visited_chains.update(interface_id)
 
             # Select anchor token from the interface
             # NOTE: Since re-sample from visited interfaces, we allow picking from
@@ -402,6 +404,8 @@ class MultiAnchorCropper(BaseCropper):
             )
             is_selected[neighbor_indices] = True
             is_remaining[neighbor_indices] = False
+
+            visited_chains = np.unique(struct.token.asym_id[is_selected]).tolist()
 
         return np.where(is_selected)[0]
 

--- a/src/kfold/training/folding/dataset/cropper/pre_crop.py
+++ b/src/kfold/training/folding/dataset/cropper/pre_crop.py
@@ -1,0 +1,178 @@
+import numpy as np
+
+from kfold.data.structure import TokenizedStructure
+from kfold.utils.registry import DATA_CROPPER
+
+from . import utils
+from .base import BaseCropper
+
+
+@DATA_CROPPER.register()
+class PreCropper(BaseCropper):
+    """Pre-Cropper that selects up to max_chains chains
+    See AlphaFold3 SI Section 2.5.4
+
+    NOTE: The output of this cropper is considered as an original structure
+    instead of cropped structure for further cropping and chain permutations.
+    Actually, this cropper just sample the neighboring chains to limit the number
+    of chains.
+    """
+
+    class Config(BaseCropper.Config):
+        """Configuration for the MultiAnchorCropper.
+
+        Parameters
+        ----------
+        max_chains : int
+            Maximum number of chains to consider for contiguous cropping.
+        """
+
+        max_chains: int = 20
+
+    def __init__(self, config: Config):
+        self.max_chains: int = config.max_chains
+
+    def crop(
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        bias_asym_id: int | tuple[int, int] | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> TokenizedStructure:
+        """Crop the data to a maximum number of tokens.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+        max_tokens : int
+            The maximum number of tokens to crop.
+            NOTE: NOT USED in this cropper.
+        asym_ids : tuple[int, ...] | None, optional
+            The chain IDs to center the crop on. If None, a random chain
+            NOTE: NOT USED in this cropper.
+
+        Returns
+        -------
+        cropped_struct: TokenizedStructure
+            The partial complex structure with limited number of chains.
+        """
+        rng = rng or np.random.default_rng()
+
+        if struct.num_chains <= self.max_chains:
+            # No cropping needed
+            return struct
+
+        # Sample the chains to include in the crop
+        sampled_asym_ids = self.sample_chains(struct, bias_asym_id, rng=rng)
+        token_mask = np.isin(struct.token.asym_id, sampled_asym_ids)
+        selected_token_indices = struct.token.token_index[token_mask]
+
+        # Extract the partial structure with the selected chains
+        partial_struct = struct.crop(selected_token_indices)
+
+        # Re-assign token index to be consecutive
+        partial_struct = struct.reassign_token_indices()
+
+        return partial_struct
+
+    def get_token_indices(  # noqa: PLR0915
+        self,
+        struct: TokenizedStructure,
+        max_tokens: int,
+        bias_asym_id: int | tuple[int, int] | None,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        raise ValueError("PreCropper does not support get_token_indices")
+
+    def sample_chains(
+        self,
+        struct: TokenizedStructure,
+        bias_asym_id: int | tuple[int, int] | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        rng = rng or np.random.default_rng()
+
+        all_tokens = struct.token.token_index
+        center_idx = struct.token.center_index
+
+        # Check specific atom resolvability (center atoms only)
+        # Assuming resolved_mask is shape (N_tokens, N_atoms)
+        resolved_mask = struct.atom.resolved_mask[all_tokens, center_idx]
+
+        # 1. Select Anchor Token
+        valid_interfaces = self.get_valid_interfaces(struct)
+
+        if not valid_interfaces:
+            # Fallback if no interfaces found
+            anchor = utils.pick_token(struct, bias_asym_id, resolved_mask, rng=rng)
+        else:
+            if bias_asym_id is None:
+                interface_id = utils.random_choice(valid_interfaces, rng=rng)
+            elif isinstance(bias_asym_id, int):
+                candidate_interfaces = [
+                    iface for iface in valid_interfaces if bias_asym_id in iface
+                ]
+                # Fallback if bias chain is not in any valid interface
+                if not candidate_interfaces:
+                    candidate_interfaces = valid_interfaces
+                interface_id = utils.random_choice(candidate_interfaces, rng=rng)
+            else:
+                # Handle tuple case (specific interface request)
+                interface_id = bias_asym_id
+
+            anchor = utils.pick_interface_token(
+                struct, interface_id, resolved_mask, rng=rng
+            )
+
+        # 2. Compute distances from anchor to all other tokens
+        # SI: "based on minimum distance between any tokens centre atom"
+        holo_coords = struct.atom.coords[:, :, 0, :]  # (Ntoken, 24, 3)
+
+        # Anchor token center coordinate
+        anchor_coord = holo_coords[anchor, center_idx[anchor], :]  # (3,)
+
+        # All token centers
+        all_token_centers = holo_coords[all_tokens, center_idx, :]  # (Ntoken, 3)
+
+        dists = np.linalg.norm(all_token_centers - anchor_coord, axis=-1)
+        dists[~resolved_mask] = np.inf
+
+        # 3. Select chains based on nearest distances
+        neighbors = np.argsort(dists)
+        selected_asym_ids: list[int] = []
+
+        all_asym_ids = struct.token.asym_id
+        for idx in neighbors:
+            if np.isinf(dists[idx]):
+                break
+            asym_id = all_asym_ids[idx]
+            if asym_id not in selected_asym_ids:
+                selected_asym_ids.append(asym_id)
+            if len(selected_asym_ids) >= self.max_chains:
+                break
+
+        return np.array(selected_asym_ids)
+
+    @staticmethod
+    def get_valid_interfaces(struct: TokenizedStructure) -> list[tuple[int, int]]:
+        """Get all valid interfaces in the structure.
+
+        Parameters
+        ----------
+        struct : TokenizedStructure
+            The tokenized structure.
+
+        Returns
+        -------
+        interface_ids : list[tuple[int, int]]
+            The valid interfaces in the structure.
+        """
+        record = struct.metadata
+        assert record is not None, "Structure metadata is required"
+        all_chains: set[int] = set(struct.chain.asym_id.tolist())
+        all_interfaces: list[tuple[int, int]] = [
+            interface.asym_ids for interface in record.interfaces if interface.valid
+        ]
+        all_interfaces = [v for v in all_interfaces if set(v).issubset(all_chains)]
+        return sorted(set(all_interfaces))

--- a/src/kfold/training/folding/dataset/cropper/pre_crop.py
+++ b/src/kfold/training/folding/dataset/cropper/pre_crop.py
@@ -22,7 +22,7 @@ class PreCropper(BaseCropper):
     """
 
     class Config(BaseCropper.Config):
-        """Configuration for the MultiAnchorCropper.
+        """Configuration for the PreCropper.
 
         Parameters
         ----------
@@ -47,7 +47,7 @@ class PreCropper(BaseCropper):
         bias_asym_id: int | tuple[int, int] | None = None,
         rng: np.random.Generator | None = None,
     ) -> TokenizedStructure:
-        """Crop the data to a maximum number of tokens.
+        """Crop the data to a maximum number of chains, optionally biasing the selection.
 
         Parameters
         ----------
@@ -56,8 +56,9 @@ class PreCropper(BaseCropper):
         max_tokens : int
             The maximum number of tokens to crop.
             NOTE: NOT USED in this cropper.
-        asym_ids : tuple[int, ...] | None, optional
-            The chain IDs to center the crop on. If None, a random chain
+        bias_asym_ids : tuple[int, ...] | None, optional
+            The chain ID(s) to center the crop on. If None, a random chain or interface
+            will be selected.
             NOTE: NOT USED in this cropper.
 
         Returns
@@ -80,7 +81,7 @@ class PreCropper(BaseCropper):
         partial_struct = struct.crop(selected_token_indices)
 
         # Re-assign token index to be consecutive
-        partial_struct = struct.reassign_token_indices()
+        partial_struct = partial_struct.reassign_token_indices()
 
         return partial_struct
 

--- a/src/kfold/training/folding/dataset/cropper/pre_crop.py
+++ b/src/kfold/training/folding/dataset/cropper/pre_crop.py
@@ -9,13 +9,16 @@ from .base import BaseCropper
 
 @DATA_CROPPER.register()
 class PreCropper(BaseCropper):
-    """Pre-Cropper that selects up to max_chains chains
-    See AlphaFold3 SI Section 2.5.4
+    """Pre-Cropper that selects up to `max_chains` chains.
+    See AlphaFold 3 SI Section 2.5.4.
 
-    NOTE: The output of this cropper is considered as an original structure
-    instead of cropped structure for further cropping and chain permutations.
-    Actually, this cropper just sample the neighboring chains to limit the number
-    of chains.
+    NOTE: The output of this cropper is treated as the "original" structure
+    rather than a training crop. It effectively samples neighboring chains to
+    reduce the complex to a manageable bioassembly size before further processing.
+
+    NOTE: Unlike the original AF3 description, this cropper is polymer-centric.
+    Small molecules (<6 atoms) do not count toward the chain limit. For example,
+    20 polymer chains + 3 small molecules/metals are counted as 20 chains, not 23.
     """
 
     class Config(BaseCropper.Config):
@@ -25,12 +28,17 @@ class PreCropper(BaseCropper):
         ----------
         max_chains : int
             Maximum number of chains to consider for contiguous cropping.
+        min_chain_atom_count : int
+            The minimum number of atoms in a chain to be considered
+            for max chain counting. If 0, all chains are counted.
         """
 
         max_chains: int = 20
+        min_chain_atom_count: int = 6
 
     def __init__(self, config: Config):
         self.max_chains: int = config.max_chains
+        self.min_chain_atom_count: int = config.min_chain_atom_count
 
     def crop(
         self,
@@ -55,7 +63,7 @@ class PreCropper(BaseCropper):
         Returns
         -------
         cropped_struct: TokenizedStructure
-            The partial complex structure with limited number of chains.
+            The sub-complex structure with limited number of chains.
         """
         rng = rng or np.random.default_rng()
 
@@ -68,7 +76,7 @@ class PreCropper(BaseCropper):
         token_mask = np.isin(struct.token.asym_id, sampled_asym_ids)
         selected_token_indices = struct.token.token_index[token_mask]
 
-        # Extract the partial structure with the selected chains
+        # Extract the sub-complex structure with the selected chains
         partial_struct = struct.crop(selected_token_indices)
 
         # Re-assign token index to be consecutive
@@ -76,12 +84,12 @@ class PreCropper(BaseCropper):
 
         return partial_struct
 
-    def get_token_indices(  # noqa: PLR0915
+    def get_token_indices(
         self,
         struct: TokenizedStructure,
         max_tokens: int,
         bias_asym_id: int | tuple[int, int] | None,
-        rng: np.random.Generator | None = None,
+        rng: np.random.Generator,
     ) -> np.ndarray:
         raise ValueError("PreCropper does not support get_token_indices")
 
@@ -141,16 +149,22 @@ class PreCropper(BaseCropper):
         # 3. Select chains based on nearest distances
         neighbors = np.argsort(dists)
         selected_asym_ids: list[int] = []
+        chain_counts: int = 0
 
         all_asym_ids = struct.token.asym_id
         for idx in neighbors:
             if np.isinf(dists[idx]):
                 break
-            asym_id = all_asym_ids[idx]
-            if asym_id not in selected_asym_ids:
-                selected_asym_ids.append(asym_id)
-            if len(selected_asym_ids) >= self.max_chains:
+            if chain_counts >= self.max_chains:
                 break
+            asym_id = all_asym_ids[idx]
+            if asym_id in selected_asym_ids:
+                continue
+            selected_asym_ids.append(asym_id)
+            chain_idx = np.where(struct.chain.asym_id == asym_id)[0][0]
+            if self.min_chain_atom_count <= struct.chain.num_atoms[chain_idx]:
+                # Only count chains with sufficient atoms
+                chain_counts += 1
 
         return np.array(selected_asym_ids)
 

--- a/src/kfold/training/folding/dataset/datamodule.py
+++ b/src/kfold/training/folding/dataset/datamodule.py
@@ -73,6 +73,7 @@ class TrainingDataModuleConfig(DataModuleConfig):
     symmetry_path: str | Path | None
     return_train_symmetry: bool = False
     return_validation_symmetry: bool = True
+    max_chains: int  # Used for chain sampling
     max_tokens: int  # Used for cropping and padding
     filters: list[BaseFilter.Config] = dataclasses.field(default_factory=list)
     sampler: BaseSampler.Config = dataclasses.field(
@@ -112,6 +113,11 @@ class TrainingDataModule(pl.LightningDataModule):
         self.featurization_args = config.featurization_args
         self.return_train_symmetry: bool = config.return_train_symmetry
         self.return_validation_symmetry: bool = config.return_validation_symmetry
+        if self.return_train_symmetry or self.return_validation_symmetry:
+            assert self.ccd_symmetry_path is not None, (
+                "symmetry_path must be provided if return_train_symmetry or "
+                "return_validation_symmetry is True"
+            )
 
         self.lmdb_path: Path = Path(config.lmdb_path)
         if not self.lmdb_path.exists():
@@ -169,23 +175,24 @@ class TrainingDataModule(pl.LightningDataModule):
             "after filtering."
         )
 
+        max_chains: int = self.config.max_chains
         max_tokens: int = self.config.max_tokens
+
         # Ensure max_atoms(=max_tokens*24) is a multiple of 32 for LocalAttention
         assert max_tokens % 4 == 0, "max_tokens must be a multiple of 4."
+
         # If symmetry is to be returned, load symmetry info
+        ccd_symmetry_dict = None
         if self.return_train_symmetry:
-            assert self.ccd_symmetry_path is not None, (
-                "symmetry_path must be provided if return_true_symmetry is True"
-            )
+            assert self.ccd_symmetry_path is not None
             ccd_symmetry_dict = load_ccd_symmetry_dict(self.ccd_symmetry_path)
-        else:
-            ccd_symmetry_dict = None
 
         return LMDBTrainingDataset(
             records=train_records,
             lmdb_path=self.lmdb_path,
             paths=self.paths,
             featurization_args=self.featurization_args,
+            max_chains=max_chains,
             max_tokens=max_tokens,
             cropper=self.cropper,
             sampler_config=self.config.sampler,
@@ -215,9 +222,7 @@ class TrainingDataModule(pl.LightningDataModule):
 
         # If symmetry is to be returned, load symmetry info
         if self.return_validation_symmetry:
-            assert self.ccd_symmetry_path is not None, (
-                "symmetry_path must be provided if return_validation_symmetry is True"
-            )
+            assert self.ccd_symmetry_path is not None
             ccd_symmetry_dict = load_ccd_symmetry_dict(self.ccd_symmetry_path)
         else:
             ccd_symmetry_dict = None

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -109,7 +109,8 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         See Section 2.5.4 of AlphaFold3 SI
 
         In contrast to `crop_structure`, this method is intended for
-        chain subsampling before actual cropping.
+        sample sub-complexes from the original structure before
+        applying the main cropping strategy.
         """
         return struct
 
@@ -303,6 +304,7 @@ class TrainingDataset(SafeLoadingDataset):
         assert "asym_ids" in kwargs, "asym_ids must be provided for cropping."
         asym_ids: list[str] = kwargs["asym_ids"]
         if self.max_chains < struct.num_chains:
+            # Get sub-complex with limited number of chains
             struct = self.pre_cropper.crop(struct, self.max_tokens, asym_ids)
         return struct
 

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -109,8 +109,8 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         See Section 2.5.4 of AlphaFold3 SI
 
         In contrast to `crop_structure`, this method is intended for
-        sample sub-complexes from the original structure before
-        applying the main cropping strategy.
+        sampling sub-complexes from the original structure before applying
+        the main cropping strategy.
         """
         return struct
 
@@ -302,7 +302,7 @@ class TrainingDataset(SafeLoadingDataset):
         **kwargs,
     ) -> structure.TokenizedStructure:
         assert "asym_ids" in kwargs, "asym_ids must be provided for cropping."
-        asym_ids: list[str] = kwargs["asym_ids"]
+        asym_ids: int | tuple[int, int] | None = kwargs["asym_ids"]
         if self.max_chains < struct.num_chains:
             # Get sub-complex with limited number of chains
             struct = self.pre_cropper.crop(struct, self.max_tokens, asym_ids)
@@ -315,7 +315,7 @@ class TrainingDataset(SafeLoadingDataset):
         **kwargs,
     ) -> structure.TokenizedStructure:
         assert "asym_ids" in kwargs, "asym_ids must be provided for cropping."
-        asym_ids: list[str] = kwargs["asym_ids"]
+        asym_ids: int | tuple[int, int] | None = kwargs["asym_ids"]
         if self.max_tokens < struct.num_tokens:
             # Crop the tokenized structure
             struct = self.cropper.crop(struct, self.max_tokens, asym_ids)

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 from kfold.data import featurize, metadata, model_input, structure
 from kfold.utils.registry import Registry
 
-from .cropper import BaseCropper
+from .cropper import BaseCropper, PreCropper
 from .sampler import BaseSampler, Sample
 from .utils import symmetry
 
@@ -100,6 +100,19 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         """Get the tokenized structure for the given index."""
 
     # === Optional to-override in subclasses === #
+    def pre_crop_structure(
+        self,
+        struct: structure.TokenizedStructure,
+        **kwargs,
+    ) -> structure.TokenizedStructure:
+        """Pre-crop the folding input structure as needed.
+        See Section 2.5.4 of AlphaFold3 SI
+
+        In contrast to `crop_structure`, this method is intended for
+        chain subsampling before actual cropping.
+        """
+        return struct
+
     def crop_structure(
         self,
         struct: structure.TokenizedStructure,
@@ -153,6 +166,9 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
 
         # Tokenization
         struct = self.load_tokenized_structure(record)
+
+        # Pre-cropping (on-the-fly pipeline of AlphaFold3 SI Section 2.5.4)
+        struct = self.pre_crop_structure(struct, **kwargs)
 
         # Cropping
         cropped_struct = self.crop_structure(struct, **kwargs)
@@ -214,6 +230,7 @@ class TrainingDataset(SafeLoadingDataset):
         records: list[metadata.Metadata],
         paths: dict[str, Path | None],
         featurization_args: dict,
+        max_chains: int,
         max_tokens: int,
         cropper: BaseCropper,
         sampler_config: BaseSampler.Config | None,
@@ -226,6 +243,12 @@ class TrainingDataset(SafeLoadingDataset):
         ----------
         records : list[metadata.Metadata]
             List of samples to use in the dataset.
+        paths : dict[str, Path | None]
+            Paths for various resources.
+        featurization_args : dict
+            Arguments for featurization.
+        max_chains : int
+            Maximum number of chains per sample.
         max_tokens : int
             Maximum number of tokens per sample. Must be a multiple of 64 for
             LocalAtomAttention.
@@ -252,7 +275,11 @@ class TrainingDataset(SafeLoadingDataset):
             ccd_symmetry_dict=ccd_symmetry_dict,
         )
         self.max_tokens: int = max_tokens
+        self.max_chains: int = max_chains
+
+        self.pre_cropper = PreCropper(PreCropper.Config(max_chains=max_chains))
         self.cropper: BaseCropper = cropper
+
         assert self.max_tokens % 64 == 0, f"max_tokens must be a multiple of {64}."
 
         # AF3-style sampling (chain/interface-based)
@@ -266,6 +293,18 @@ class TrainingDataset(SafeLoadingDataset):
     @override
     def __len__(self) -> int:
         return len(self.samples)
+
+    @override
+    def pre_crop_structure(
+        self,
+        struct: structure.TokenizedStructure,
+        **kwargs,
+    ) -> structure.TokenizedStructure:
+        assert "asym_ids" in kwargs, "asym_ids must be provided for cropping."
+        asym_ids: list[str] = kwargs["asym_ids"]
+        if self.max_chains < struct.num_chains:
+            struct = self.pre_cropper.crop(struct, self.max_tokens, asym_ids)
+        return struct
 
     @override
     def crop_structure(
@@ -394,6 +433,7 @@ class LMDBTrainingDataset(TrainingDataset, LMDBDatabase):
         lmdb_path: Path,
         paths: dict[str, Path | None],
         featurization_args: dict,
+        max_chains: int,
         max_tokens: int,
         cropper: BaseCropper,
         sampler_config: BaseSampler.Config | None,
@@ -406,6 +446,7 @@ class LMDBTrainingDataset(TrainingDataset, LMDBDatabase):
             records,
             paths,
             featurization_args,
+            max_chains,
             max_tokens,
             cropper,
             sampler_config,


### PR DESCRIPTION
This pull request introduces a new chain pre-cropping step and updates configuration and cropper logic to support more flexible, polymer-centric cropping of protein complexes. The main changes include adding a `PreCropper` class for limiting the number of chains before training, updating configuration files to support the new cropping logic, and refactoring cropper interfaces to standardize random number generator (RNG) usage.

### Chain cropping and configuration improvements

* Added a new `PreCropper` class (`src/kfold/training/folding/dataset/cropper/pre_crop.py`) that samples up to `max_chains` polymer chains before further cropping, following AlphaFold 3 SI Section 2.5.4. This helps manage bioassembly size and ensures small molecules do not count toward the chain limit.
* Updated all training configuration files (e.g., `configs/train-af3-tiny.yaml`, `configs/train-af3.yaml`, `configs/train-esmc-apoemb-edm-mini.yaml`, etc.) to include the new `max_chains` parameter and increased `num_global_steps_per_epoch` for several configs to 500, supporting larger and more flexible crops. 
* Updated `configs/train/structure_only.yaml` to pass `max_chains` from `global_hparams` to `data`, and switched the cropper to `MultiAnchorCropper` with new parameters for anchor selection.

### Cropper interface and logic refactoring

* Standardized cropper interfaces to require an explicit `np.random.Generator` (RNG) parameter, removing implicit default RNG creation and updating docstrings for clarity. This affects all cropper classes (`base.py`, `boltz.py`, `alphafold.py`, `multi_anchor.py`).
* Improved logic in `MultiAnchorCropper` for mapping chain indices and selecting crop start positions, making chain selection more robust and readable. 

### Data structure utilities

* Added a new method `reassign_token_indices` to `TokenizedStructure` (`src/kfold/data/structure.py`) to ensure token indices are consecutive after cropping, supporting the new pre-cropping workflow.

### Training script updates

* Updated the training script (`scripts/train.py`) to propagate `max_chains` from global hyperparameters to the data config, and adjusted validation batch limits for debugging. 

### Module registration

* Registered the new `PreCropper` module for use in the cropper registry (`src/kfold/training/folding/dataset/cropper/__init__.py`).