### PR TITLE
Minor updates (sampling/cropping fix & config updates)

### DIFF
--- a/configs/train-esmc-apoemb-edm-mini.yaml
+++ b/configs/train-esmc-apoemb-edm-mini.yaml
@@ -20,9 +20,9 @@ train:
 
   global_hparams:
     max_chains: 20
-    max_tokens: 512
+    max_tokens: 384
     batch_size: 4
-    diffusion_batch_size: 32
+    diffusion_batch_size: 48
     global_batch_size: 128
     num_global_steps_per_epoch: 500
 

--- a/configs/train-esmc-ddbm-mini.yaml
+++ b/configs/train-esmc-ddbm-mini.yaml
@@ -19,9 +19,9 @@ train:
 
   global_hparams:
     max_chains: 20
-    max_tokens: 512
+    max_tokens: 384
     batch_size: 4
-    diffusion_batch_size: 32
+    diffusion_batch_size: 48
     global_batch_size: 128
     num_global_steps_per_epoch: 500
 

--- a/configs/train-esmc-edm-mini.yaml
+++ b/configs/train-esmc-edm-mini.yaml
@@ -19,9 +19,9 @@ train:
 
   global_hparams:
     max_chains: 20
-    max_tokens: 512
+    max_tokens: 384
     batch_size: 4
-    diffusion_batch_size: 32
+    diffusion_batch_size: 48
     global_batch_size: 128
     num_global_steps_per_epoch: 500
 

--- a/configs/train-esmc-edm.yaml
+++ b/configs/train-esmc-edm.yaml
@@ -14,9 +14,9 @@ train:
 
   global_hparams:
     max_chains: 20
-    max_tokens: 512
+    max_tokens: 384
     batch_size: 2
-    diffusion_batch_size: 32
+    diffusion_batch_size: 48
     global_batch_size: 128
     num_global_steps_per_epoch: 250
 

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -10,7 +10,7 @@ synchronize_seed: true # Use the same seed across DDP processes
 # Training parameters for multi-gpu setup.
 global_hparams:
   max_chains: 20
-  max_tokens: 512
+  max_tokens: 384
   batch_size: 1
   diffusion_batch_size: 48
   global_batch_size: 256
@@ -66,7 +66,7 @@ data:
     _class_: ClusterSampler
     beta_chain: 0.5
     beta_interface: 1.0
-    allow_redundant: True # Same to Boltz1
+    allow_redundant: False # Different to Boltz1
 
   # Featurizer configurations:
   featurization_args:

--- a/src/kfold/training/folding/dataset/cropper/pre_crop.py
+++ b/src/kfold/training/folding/dataset/cropper/pre_crop.py
@@ -19,6 +19,10 @@ class PreCropper(BaseCropper):
     NOTE: Unlike the original AF3 description, this cropper is polymer-centric.
     Small molecules (<6 atoms) do not count toward the chain limit. For example,
     20 polymer chains + 3 small molecules/metals are counted as 20 chains, not 23.
+
+    NOTE: Unlike the original AF3 description which always samples the anchor token
+    from an interface, this cropper falls back to sampling any resolved token
+    from the specified chain (=bias) if no valid interfaces are found.
     """
 
     class Config(BaseCropper.Config):
@@ -97,7 +101,7 @@ class PreCropper(BaseCropper):
     def sample_chains(
         self,
         struct: TokenizedStructure,
-        bias_asym_id: int | tuple[int, int] | None = None,
+        bias_asym_id: int | tuple[int, int] | None,
         rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         rng = rng or np.random.default_rng()
@@ -118,21 +122,30 @@ class PreCropper(BaseCropper):
         else:
             if bias_asym_id is None:
                 interface_id = utils.random_choice(valid_interfaces, rng=rng)
+                anchor = utils.pick_interface_token(
+                    struct, interface_id, resolved_mask, rng=rng
+                )
             elif isinstance(bias_asym_id, int):
                 candidate_interfaces = [
                     iface for iface in valid_interfaces if bias_asym_id in iface
                 ]
-                # Fallback if bias chain is not in any valid interface
-                if not candidate_interfaces:
-                    candidate_interfaces = valid_interfaces
-                interface_id = utils.random_choice(candidate_interfaces, rng=rng)
+                if len(candidate_interfaces) == 0:
+                    # Fallback to pick random token from the specified chain
+                    anchor = utils.pick_token(
+                        struct, bias_asym_id, resolved_mask, rng=rng
+                    )
+                else:
+                    # Pick random interface involving the specified chain
+                    interface_id = utils.random_choice(candidate_interfaces, rng=rng)
+                    anchor = utils.pick_interface_token(
+                        struct, interface_id, resolved_mask, rng=rng
+                    )
             else:
                 # Handle tuple case (specific interface request)
                 interface_id = bias_asym_id
-
-            anchor = utils.pick_interface_token(
-                struct, interface_id, resolved_mask, rng=rng
-            )
+                anchor = utils.pick_interface_token(
+                    struct, interface_id, resolved_mask, rng=rng
+                )
 
         # 2. Compute distances from anchor to all other tokens
         # SI: "based on minimum distance between any tokens centre atom"
@@ -161,7 +174,7 @@ class PreCropper(BaseCropper):
             asym_id = all_asym_ids[idx]
             if asym_id in selected_asym_ids:
                 continue
-            selected_asym_ids.append(asym_id)
+            selected_asym_ids.append(int(asym_id))
             chain_idx = np.where(struct.chain.asym_id == asym_id)[0][0]
             if self.min_chain_atom_count <= struct.chain.num_atoms[chain_idx]:
                 # Only count chains with sufficient atoms

--- a/src/kfold/training/folding/dataset/sampler/cluster.py
+++ b/src/kfold/training/folding/dataset/sampler/cluster.py
@@ -11,17 +11,17 @@ from .base import BaseSampler, Sample
 
 
 # === Helpers to compute weights === #
-def get_chain_cluster(chain: ChainInfo) -> str:
+def get_chain_cluster_id(chain: ChainInfo) -> str:
     """Get the cluster ID of a chain."""
     return chain.cluster_id
 
 
-def get_interface_cluster(
+def get_interface_cluster_id(
     interface: InterfaceInfo, chain_dict: dict[int, ChainInfo]
 ) -> str:
     """Get the cluster ID of an interface."""
     chains = [chain_dict[asym_id] for asym_id in interface.asym_ids]
-    cluster_ids = [get_chain_cluster(chain) for chain in chains]
+    cluster_ids = [get_chain_cluster_id(chain) for chain in chains]
     return ":".join(sorted(cluster_ids))
 
 
@@ -63,7 +63,7 @@ def get_chain_weight(
     else:
         n_ligand += 1
 
-    cluster_id = get_chain_cluster(chain)
+    cluster_id = get_chain_cluster_id(chain)
     n_cluster = cluster_sizes[cluster_id]
 
     # See Section 2.5.1 Equation 1
@@ -118,7 +118,7 @@ def get_interface_weight(
         else:
             n_ligand += 1
 
-    cluster_id = get_interface_cluster(interface, chain_dict)
+    cluster_id = get_interface_cluster_id(interface, chain_dict)
     n_cluster = cluster_sizes[cluster_id]
 
     # See Section 2.5.1 Equation 1
@@ -141,13 +141,15 @@ class ClusterSampler(BaseSampler):
     w ∝ (β_r / N_clust) * (α_prot * n_prot + α_nuc * n_nuc + α_ligand * n_ligand),
     where β_r is the beta value for the chain / interface.
 
-    NOTE: (SeonghwanSeo) Compare to Boltz, I changed a logic of cluster size estimation.
-
-    In Boltz, all valid chains / interfaces in the record are considered when
-    estimating the cluster sizes.
-    However, I introduced `allow_redundant` parameter to control whether to allow
-    redundant chains / interfaces when estimating cluster sizes.
-
+    NOTE: (SeonghwanSeo) Compare to Boltz1/AlphaFold3, I changed a logic of cluster
+    size estimation. (`allow_redundant=False`) This is because Boltz1's data processing
+    pipeline includes all chains in a complex while AF3's pipeline crops the complex up
+    to 20 chains, which may lead to overestimation of cluster sizes and underestimation
+    the chains/interfaces of small complexes. When `allow_redundant` is False, the
+    cluster size is estimated by counting unique clusters in a complex, rather than
+    counting all chains/interfaces. This way, small complexes are less penalized during
+    sampling. For example, consider a complex with 3 chains, all belonging to the same
+    cluster.
     e.g.)
     If a record has 3 chains, all of which belong to the same cluster,
     Boltz will estimate the cluster size as 3, while this will estimate it as 1
@@ -196,6 +198,7 @@ class ClusterSampler(BaseSampler):
         # Cluster sizes
         self.chain_cluster_sizes: dict[str, int] = defaultdict(int)
         self.interface_cluster_sizes: dict[str, int] = defaultdict(int)
+        self.num_clusters_in_complex: dict[str, dict[str, int]] = {}
 
     def get_samples(self, records: list[Metadata]) -> tuple[list[Sample], np.ndarray]:
         # Estimate cluster sizes
@@ -209,6 +212,7 @@ class ClusterSampler(BaseSampler):
             chain_dict: dict[int, ChainInfo] = {
                 chain.asym_id: chain for chain in record.chains
             }
+            num_clusters_in_complex = self.num_clusters_in_complex.get(record.id, {})
             for chain in record.chains:
                 if not chain.valid:
                     continue
@@ -220,6 +224,9 @@ class ClusterSampler(BaseSampler):
                     self.alpha_nuc,
                     self.alpha_ligand,
                 )
+                if not self.allow_redundant:
+                    # Adjust weight by number of clusters in the record
+                    weight /= num_clusters_in_complex.get(get_chain_cluster_id(chain), 1)
                 samples.append(Sample(record, chain.asym_id))
                 weights.append(weight)
 
@@ -235,6 +242,11 @@ class ClusterSampler(BaseSampler):
                     self.alpha_nuc,
                     self.alpha_ligand,
                 )
+                if not self.allow_redundant:
+                    # Adjust weight by number of clusters in the record
+                    weight /= num_clusters_in_complex.get(
+                        get_interface_cluster_id(interface, chain_dict), 1
+                    )
                 samples.append(Sample(record, interface.asym_ids))
                 weights.append(weight)
 
@@ -249,19 +261,32 @@ class ClusterSampler(BaseSampler):
             chain_dict: dict[int, ChainInfo] = {
                 chain.asym_id: chain for chain in record.chains
             }
-            chain_clusters_in_record = [
-                get_chain_cluster(chain) for chain in record.chains if chain.valid
+            chain_clusters_in_record: list[str] = [
+                get_chain_cluster_id(chain) for chain in record.chains if chain.valid
             ]
-            interface_clusters_in_record = [
-                get_interface_cluster(interface, chain_dict)
+            interface_clusters_in_record: list[str] = [
+                get_interface_cluster_id(interface, chain_dict)
                 for interface in record.interfaces
                 if interface.valid
             ]
 
             if not self.allow_redundant:
+                # Store number of each cluster for each entry
+                num_clusters = defaultdict(int)
+                for cluster_id in chain_clusters_in_record:
+                    num_clusters[cluster_id] += 1
+                for cluster_id in interface_clusters_in_record:
+                    num_clusters[cluster_id] += 1
+                # Remove the count <= 1 to save memory
+                for cluster_id in list(num_clusters.keys()):
+                    if num_clusters[cluster_id] <= 1:
+                        del num_clusters[cluster_id]
+                if len(num_clusters) > 0:
+                    self.num_clusters_in_complex[record.id] = dict(num_clusters)
+
                 # Remove redundant clusters in the record
-                chain_clusters_in_record = set(chain_clusters_in_record)
-                interface_clusters_in_record = set(interface_clusters_in_record)
+                chain_clusters_in_record = list(set(chain_clusters_in_record))
+                interface_clusters_in_record = list(set(interface_clusters_in_record))
 
             for cluster_id in chain_clusters_in_record:
                 self.chain_cluster_sizes[cluster_id] += 1


### PR DESCRIPTION
This pull request makes several adjustments to training configuration files and sampling logic to improve data handling and sampling accuracy in the folding dataset pipeline. The most significant changes include reducing the maximum number of tokens per sample, increasing diffusion batch size, refining cluster-based sampling to penalize redundant clusters less, and clarifying/fixing behavior in the cropping logic.

**Training configuration changes:**

* Reduced `max_tokens` from 512 to 384 in multiple config files to lower memory usage per sample. 
* Increased `diffusion_batch_size` from 32 to 48 in several configs to allow larger diffusion batches.
* Changed `allow_redundant` to `False` in `structure_only.yaml`, altering how redundant clusters are handled during sampling.

**Sampler and cluster logic improvements:**

* Refined cluster size estimation in `ClusterSampler` to count unique clusters instead of all chains/interfaces when `allow_redundant` is `False`, reducing penalization of small complexes. This includes tracking the number of clusters per complex and using this to adjust sampling weights. 
* Renamed helper functions for clarity (e.g., `get_chain_cluster` → `get_chain_cluster_id`) and applied these changes throughout the sampler code. 

**Cropping and dataset logic:**
* Clarified and improved the fallback behavior in `PreCropper` when no valid interfaces are found: now samples any resolved token from the specified chain, aligning behavior with the intended design.