### PR TITLE
Fix/dataloader error

### DIFF
--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -21,13 +21,13 @@ data:
   _class_: TrainingDataModule
 
   # DataLoader
-  train_batch_size: ??? # set by global_hparam
+  train_batch_size: 1 # NOTE: overriden by global_hparam
   val_batch_size: 1
   num_workers: 8
-  max_chains: ??? # set by global_hparam
-  max_tokens: ??? # set by global_hparam
+  max_chains: 300 # NOTE: overriden by global_hparam
+  max_tokens: 384 # NOTE: overriden by global_hparam
   pin_memory: true
-  safe_load: true
+  safe_load: false
 
   # Data paths
   lmdb_path: <LMDB_PATH_PLACEHOLDER>
@@ -98,11 +98,11 @@ trainer:
   num_nodes: "auto"
   precision: bf16-mixed
   max_epochs: -1
-  limit_train_batches: ??? # set by global_hparam
+  limit_train_batches: 1 # NOTE: overriden by global_hparam
   limit_val_batches: null
   log_every_n_steps: 1
   enable_checkpointing: true
-  accumulate_grad_batches: ??? # set by global_hparam
+  accumulate_grad_batches: 1 # NOTE: overriden by global_hparam
   gradient_clip_val: 10.0
 
 # Exponential Moving Average (EMA)
@@ -116,7 +116,7 @@ training:
   num_cycles: 4
 
   # For structure module training
-  diffusion_batch_size: ??? # set by global_hparam
+  diffusion_batch_size: 48 # NOTE: overriden by global_hparam
 
   # For confidence module training
   num_steps: 20 # Mini-diffusion rollout

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -21,11 +21,11 @@ data:
   _class_: TrainingDataModule
 
   # DataLoader
-  train_batch_size: 1 # NOTE: overriden by global_hparam
+  train_batch_size: 1 # NOTE: overridden by global_hparam
   val_batch_size: 1
   num_workers: 8
-  max_chains: 20 # NOTE: overriden by global_hparam
-  max_tokens: 384 # NOTE: overriden by global_hparam
+  max_chains: 20 # NOTE: overridden by global_hparam
+  max_tokens: 384 # NOTE: overridden by global_hparam
   pin_memory: true
   safe_load: false
 
@@ -98,11 +98,11 @@ trainer:
   num_nodes: "auto"
   precision: bf16-mixed
   max_epochs: -1
-  limit_train_batches: 1 # NOTE: overriden by global_hparam
+  limit_train_batches: 1 # NOTE: overridden by global_hparam
   limit_val_batches: null
   log_every_n_steps: 1
   enable_checkpointing: true
-  accumulate_grad_batches: 1 # NOTE: overriden by global_hparam
+  accumulate_grad_batches: 1 # NOTE: overridden by global_hparam
   gradient_clip_val: 10.0
 
 # Exponential Moving Average (EMA)
@@ -116,7 +116,7 @@ training:
   num_cycles: 4
 
   # For structure module training
-  diffusion_batch_size: 48 # NOTE: overriden by global_hparam
+  diffusion_batch_size: 48 # NOTE: overridden by global_hparam
 
   # For confidence module training
   num_steps: 20 # Mini-diffusion rollout

--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -24,7 +24,7 @@ data:
   train_batch_size: 1 # NOTE: overriden by global_hparam
   val_batch_size: 1
   num_workers: 8
-  max_chains: 300 # NOTE: overriden by global_hparam
+  max_chains: 20 # NOTE: overriden by global_hparam
   max_tokens: 384 # NOTE: overriden by global_hparam
   pin_memory: true
   safe_load: false

--- a/scripts/process/structure_embedding/b_match_dimension.py
+++ b/scripts/process/structure_embedding/b_match_dimension.py
@@ -27,13 +27,13 @@ def parse_args():
         "--embedding_path",
         type=Path,
         help="Directory containing the structure embeddings.",
-        default="/cache/wykim_lab/kfold_data/pretrained/saprot_650m_raw/",
+        required=True,
     )
     parser.add_argument(
         "--output_path",
         type=Path,
-        help="Path of directory to save the matched embeddings.",
-        default="/cache/wykim_lab/kfold_data/pretrained/saprot_650m_matched/",
+        help="Path of directory to save the length-matched embeddings.",
+        required=True,
     )
     parser.add_argument(
         "--num_workers",

--- a/src/kfold/training/folding/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/folding/dataset/cropper/multi_anchor.py
@@ -388,16 +388,23 @@ class MultiAnchorCropper(BaseCropper):
             else:
                 # Pick an interface connected to visited chains
                 assert len(visited_chains) > 0, "No visited chains"
-                i1 = utils.random_choice(visited_chains, rng=rng)
-                i2 = utils.random_choice(chain_to_neighbors[i1], rng=rng)
-                interface_id = (min(i1, i2), max(i1, i2))
+                candidates: set[tuple[int, int]] = set()
+                for asym_id1 in visited_chains:
+                    neighbors = chain_to_neighbors[asym_id1]
+                    for asym_id2 in neighbors:
+                        interface_id = (min(asym_id1, asym_id2), max(asym_id1, asym_id2))
+                        candidates.add(interface_id)
+                if len(candidates) == 0:
+                    # No connected interfaces, fallback to all interfaces
+                    candidates = set(all_interfaces)
+                interface_id = utils.random_choice(sorted(candidates), rng=rng)
 
             # Select anchor token from the interface
             # NOTE: Since re-sample from visited interfaces, we allow picking from
             # all resolved tokens even if already selected.
             anchor = utils.pick_interface_token(struct, interface_id, resolved_mask, rng)
 
-            # Crop spatially around the anchor token
+            # Collect spatial neighbors around the anchor token among remaining tokens
             crop_size = budgets[i]
             neighbor_indices = self.get_closest_tokens(
                 struct, anchor, crop_size, center_coords, mask=is_remaining

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     global_config.train.data.safe_load = False
     global_config.train.data.num_workers = 64
 
-    # Load validation loader
+    # Load training loader
     data_module = TrainingDataModule(global_config.train.data)
     data_module.setup("fit")
     dataloader = data_module.train_dataloader()

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import lightning.pytorch as pl
+import torch
+from tqdm import tqdm
+
+from kfold.config import load_config
+from kfold.training.folding.dataset.datamodule import TrainingDataModule
+
+TEST_CONFIG_PATH = Path("./configs/train-af3-tiny.yaml")
+
+
+if __name__ == "__main__":
+    pl.seed_everything(42)
+
+    # Validation settings
+    num_samples = 5
+
+    global_config = load_config(TEST_CONFIG_PATH)
+    global_config.train.data.train_batch_size = 32
+    global_config.train.data.safe_load = False
+    global_config.train.data.num_workers = 64
+
+    # Load validation loader
+    data_module = TrainingDataModule(global_config.train.data)
+    data_module.setup("fit")
+    dataloader = data_module.train_dataloader()
+
+    # Turn off gradient
+    torch.set_grad_enabled(False)
+
+    for f_input, _ in tqdm(dataloader):
+        batch_size = f_input.batch_size
+        num_tokens = f_input.num_tokens
+        pass


### PR DESCRIPTION
This pull request includes several configuration updates and code improvements aimed at making the training and data processing pipeline more robust, explicit, and testable. The main changes involve setting explicit default values in configuration files, improving the logic for selecting interfaces in the cropping algorithm, requiring explicit command-line arguments in a script, and adding a new dataloader test script.

**Configuration updates for clarity and reproducibility:**

* Set explicit default values for `train_batch_size`, `max_chains`, `max_tokens`, `safe_load`, `limit_train_batches`, `accumulate_grad_batches`, and `diffusion_batch_size` in `configs/train/structure_only.yaml`, overriding previous placeholder values (`???`)

**Improvements to data processing scripts:**

* Updated argument parsing in `b_match_dimension.py` to require explicit `--embedding_path` and `--output_path` arguments, removing default paths and reducing the risk of accidental overwrites or misconfiguration.

**Enhancements to dataset cropping logic:**

* Improved the interface selection logic in `crop_spatial_interface` to consider all possible candidate interfaces connected to visited chains, with a fallback to all interfaces if none are connected. This makes the cropping process more robust and avoids assertion errors.

**Testing and validation:**

* Added a new script `tests/test_dataloader.py` to test the `TrainingDataModule` with configurable settings, ensuring the dataloader works as expected with different batch sizes and worker counts.