### PR TITLE
hotfix

### DIFF
--- a/configs/train/structure_only.yaml
+++ b/configs/train/structure_only.yaml
@@ -27,7 +27,7 @@ data:
   max_chains: 20 # NOTE: overridden by global_hparam
   max_tokens: 384 # NOTE: overridden by global_hparam
   pin_memory: true
-  safe_load: false
+  safe_load: true
 
   # Data paths
   lmdb_path: <LMDB_PATH_PLACEHOLDER>

--- a/src/kfold/training/folding/dataset/datamodule.py
+++ b/src/kfold/training/folding/dataset/datamodule.py
@@ -119,6 +119,11 @@ class TrainingDataModule(pl.LightningDataModule):
         if not self.lmdb_path.exists():
             raise FileNotFoundError(f"LMDB path not found: {self.lmdb_path}")
 
+        for path in self.paths.values():
+            if path is not None:
+                assert path.exists(), f"Path not found: {path}"
+                self.print_rank_zero(f"Path found: {path}")
+
     def setup(self, stage: str | None = None) -> None:
         if stage == "fit":
             self._train_ds = self.construct_train_dataset()

--- a/src/kfold/training/folding/dataset/dataset.py
+++ b/src/kfold/training/folding/dataset/dataset.py
@@ -134,7 +134,7 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
 
     def __getitem__(self, index: int) -> tuple[model_input.FoldingInput, SymmetryInfo]:
         """Get the folding input for the given index, with retry on failure."""
-        return self.get_item_safe(index, num_trials=10)
+        return self.get_item_safe(index, num_trials=100)
 
     def get_item_safe(
         self,


### PR DESCRIPTION
- turn on safe-load (accidentally turned off)
- print whether the pertained embedding paths exist.