### PR TITLE
pass model config only for inference mode

### DIFF
--- a/configs/train-esmc-ddbm-mini.yaml
+++ b/configs/train-esmc-ddbm-mini.yaml
@@ -36,7 +36,7 @@ train:
     lmdb_path: /cache/wykim_lab/kfold_data/kfold_rcsb_processed_v251120.lmdb/
     manifest_path: /cache/wykim_lab/kfold_data/manifests/af3_manifest.pkl
     symmetry_path: /cache/wykim_lab/kfold_data/symmetry.pkl
-    split_path: ./assets/splits/boltz1
+    split_path: ./assets/splits/kfold_v251213/
     num_workers: 8
 
     paths:

--- a/configs/train-esmc-edm-mini.yaml
+++ b/configs/train-esmc-edm-mini.yaml
@@ -1,8 +1,7 @@
 model:
   _yaml_: "model/kfold-edm.yaml"
   input_embedder:
-    channel_seq_encoder: 2560
-    channel_struct_encoder: 1280
+    channel_seq_encoder: 1152
   trunk:
     use_cuequiv_kernels: true
     num_blocks: 16
@@ -41,16 +40,14 @@ train:
     num_workers: 8
 
     paths:
-      seq_embedding_path: /cache/wykim_lab/kfold_data/pretrained/esm2_3b_bf16/
-      struct_embedding_path: /cache/wykim_lab/kfold_data/pretrained/saprot_650m/
+      seq_embedding_path: /cache/wykim_lab/kfold_data/pretrained/esmc_600m_bf16/
 
     featurization_args:
-      seq_embedding_dim: 2560
-      struct_embedding_dim: 1280
+      seq_embedding_dim: 1152
 
   wandb:
     use: false
     project: "KFold-Combined"
     group: "251213"
     entity: K-Fold
-    tags: ["mini", "edm", "esm2", "saprot", "rbf"]
+    tags: ["mini", "edm", "esm2", "rbf"]

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -1,57 +1,63 @@
+import dataclasses
 import time
 import warnings
 
 import torch
-from omegaconf import DictConfig
 
 import kfold.model.modules as submodules
 from kfold.data.model_input import FoldingInput
-from kfold.utils.registry import MAIN_MODULE, Registry
+from kfold.utils.registry import MAIN_MODULE, BaseConfig, Registry
+
+
+@dataclasses.dataclass(kw_only=True)
+class BaseFoldingModelConfig:
+    input_embedder: BaseConfig
+    trunk: BaseConfig
+    score_model: BaseConfig
+    structure_module: BaseConfig
+    distogram_head: BaseConfig
+    # confidence_head: Baseconfig
 
 
 @MAIN_MODULE.register()
 class BaseFoldingModel(torch.nn.Module):
-    def __init__(self, global_config: DictConfig):
+    def __init__(self, config: BaseFoldingModelConfig):
         super().__init__()
-        self.config = global_config
+        self.config: BaseFoldingModelConfig = config
 
         # Initialize sub-modules here using the config
-        model_config = global_config.model
-
         self.input_embedder: submodules.input_embedder.BaseInputEmbedder = (
-            Registry.instantiate(model_config.input_embedder)
+            Registry.instantiate(config.input_embedder)
         )
 
-        self.trunk: submodules.trunk.BaseTrunk = Registry.instantiate(model_config.trunk)
+        self.trunk: submodules.trunk.BaseTrunk = Registry.instantiate(config.trunk)
 
         self.score_model: submodules.score_model.BaseScoreModel = Registry.instantiate(
-            model_config.score_model
+            config.score_model
         )
 
         # NOTE: structure module is not a torch.nn.Module
         # This handles diffusion sampling as well
         self.structure_module: submodules.structure_module.BaseStructureModule = (
-            Registry.instantiate(
-                model_config.structure_module, score_model=self.score_model
-            )
+            Registry.instantiate(config.structure_module, score_model=self.score_model)
         )
 
         # Heads
         self.distogram_head: submodules.distogram_head.BaseDistogramHead = (
-            Registry.instantiate(model_config.distogram_head)
+            Registry.instantiate(config.distogram_head)
         )
 
         # self.confidence_head: submodules.confidence_head.BaseConfidenceHead = (
-        #     Registry.instantiate(model_config.confidence_head)
+        #     Registry.instantiate(config.confidence_head)
         # )
 
         # Compile submodules
         # NOTE: (SeonghwanSeo) This is very slow... Right now, just disable them.
-        if getattr(model_config, "compile_trunk", False):
-            self.trunk.compile(getattr(model_config, "compile_trunk", False))
-        if getattr(model_config, "compile_score_model", False):
-            self.score_model.compile(getattr(model_config, "compile_score_model", False))
-        # if getattr(model_config, "compile_confidence_head", False):
+        if getattr(config, "compile_trunk", False):
+            self.trunk.compile(getattr(config, "compile_trunk", False))
+        if getattr(config, "compile_score_model", False):
+            self.score_model.compile(getattr(config, "compile_score_model", False))
+        # if getattr(config, "compile_confidence_head", False):
         #     self.confidence_head.compile()
 
     def forward(

--- a/src/kfold/model/models/boltz1.py
+++ b/src/kfold/model/models/boltz1.py
@@ -1,8 +1,8 @@
+import dataclasses
 import urllib.request
 from pathlib import Path
 
 import torch
-from omegaconf import DictConfig
 
 from kfold.model.modules.distogram_head.boltz1 import Boltz1DistogramHead
 from kfold.model.modules.input_embedder.boltz1_embedder import Boltz1InputEmbedder
@@ -11,7 +11,12 @@ from kfold.model.modules.structure_module.boltz1_edm import Boltz1SampleDiffusio
 from kfold.model.modules.trunk.boltz1_trunk import Boltz1PairformerTrunk
 from kfold.utils.registry import MAIN_MODULE
 
-from .base import BaseFoldingModel
+from .base import BaseFoldingModel, BaseFoldingModelConfig
+
+
+@dataclasses.dataclass(kw_only=True)
+class Boltz1Config(BaseFoldingModelConfig):
+    load_weight: bool = True
 
 
 @MAIN_MODULE.register()
@@ -22,10 +27,8 @@ class Boltz1(BaseFoldingModel):
     score_model: Boltz1DiffusionModule  # type: ignore
     structure_module: Boltz1SampleDiffusion  # type: ignore
 
-    def __init__(self, global_config: DictConfig):
-        super().__init__(global_config)
-        self.config = global_config
-        model_config = global_config.model
+    def __init__(self, config: Boltz1Config):
+        super().__init__(config)
 
         # === Boltz-1 pretrained modules === #
         assert isinstance(self.input_embedder, Boltz1InputEmbedder)
@@ -35,7 +38,7 @@ class Boltz1(BaseFoldingModel):
         assert isinstance(self.structure_module, Boltz1SampleDiffusion)
 
         # Load Boltz-1 pretrained weights
-        if model_config.load_weight:
+        if config.load_weight:
             self.load_boltz_weights()
 
     def load_boltz_weights(self):

--- a/src/kfold/model/models/boltz1_pretrained.py
+++ b/src/kfold/model/models/boltz1_pretrained.py
@@ -1,9 +1,9 @@
+import dataclasses
 import time
 import urllib.request
 from pathlib import Path
 
 import torch
-from omegaconf import DictConfig
 
 import kfold.model.modules as submodules
 from kfold.data.model_input import FoldingInput
@@ -12,7 +12,12 @@ from kfold.model.modules.input_embedder.boltz1_embedder import Boltz1InputEmbedd
 from kfold.model.modules.trunk.boltz1_trunk import Boltz1PairformerTrunk
 from kfold.utils.registry import MAIN_MODULE, Registry
 
-from .base import BaseFoldingModel
+from .base import BaseFoldingModel, BaseFoldingModelConfig
+
+
+@dataclasses.dataclass(kw_only=True)
+class Boltz1PretrainedConfig(BaseFoldingModelConfig):
+    proj_s_inputs: bool = False
 
 
 @MAIN_MODULE.register()
@@ -21,37 +26,25 @@ class Boltz1Pretrained(BaseFoldingModel):
     trunk: Boltz1PairformerTrunk  # type: ignore
     distogram_head: Boltz1DistogramHead  # type: ignore
 
-    def __init__(self, global_config: DictConfig):
-        super().__init__(global_config)
-        self.config = global_config
-        model_config = global_config.model
+    def __init__(self, config: Boltz1PretrainedConfig):
+        super().__init__(config)
 
         # === Boltz-1 pretrained modules === #
         assert isinstance(self.input_embedder, Boltz1InputEmbedder)
         assert isinstance(self.trunk, Boltz1PairformerTrunk)
         assert isinstance(self.distogram_head, Boltz1DistogramHead)
 
-        # === For custom diffusion structure module === #
-        self.score_model: submodules.score_model.BaseScoreModel = Registry.instantiate(
-            model_config.score_model
-        )
-        self.structure_module: submodules.structure_module.BaseStructureModule = (
-            Registry.instantiate(
-                model_config.structure_module, score_model=self.score_model
-            )
-        )
-
         # Load Boltz-1 pretrained weights
         self.load_boltz_weights()
 
         # NOTE: additional projection layers for compatibility with KFold
         self.proj_s_inputs = None
-        need_projection: bool = model_config.get("proj_s_inputs", False)
+        need_projection: bool = config.proj_s_inputs
         if need_projection:
             c_input_boltz = 384 + 33 * 2 + 1 + 4  # 459
             self.proj_s_inputs = torch.nn.Linear(
                 c_input_boltz,
-                model_config.score_model.channel_s,
+                config.score_model.channel_s,
                 bias=False,
             )
 

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -1,14 +1,19 @@
-from omegaconf import DictConfig
-
 from kfold.utils.registry import MAIN_MODULE
 
-from .base import BaseFoldingModel
+from .base import BaseFoldingModel, BaseFoldingModelConfig
+
+
+class KFoldConfig(BaseFoldingModelConfig):
+    pass
+    # TODO: define encoders
+    # sequence_encoder: BaseConfig
+    # structure_encoder: BaseConfig
 
 
 @MAIN_MODULE.register()
 class KFold(BaseFoldingModel):
-    def __init__(self, global_config: DictConfig):
-        super().__init__(global_config)
+    def __init__(self, config: KFoldConfig):
+        super().__init__(config)
         # self.sequence_encoder: submodules.sequence_encoder.BaseSequenceEncoder = (
         #     Registry.instantiate(model_config.sequence_encoder)
         # )

--- a/src/kfold/training/folding/training_module.py
+++ b/src/kfold/training/folding/training_module.py
@@ -103,7 +103,7 @@ class LossConfig:
 class KFoldTrainingModule(pl.LightningModule):
     def __init__(self, config: DictConfig):
         super().__init__()
-        self.global_config = config
+        self.global_config: DictConfig = config
         self.config: TrainConfig = self.global_config.train
         self.training_config: TrainingConfig = self.config.training
         self.validation_config: ValidationConfig = self.config.validation
@@ -117,9 +117,9 @@ class KFoldTrainingModule(pl.LightningModule):
         self.train_confidence_head: bool = self.training_config.train_confidence_head
 
         # Initialize model here
-        self.model: KFold
-        model_cls = MAIN_MODULE[self.global_config.model._class_]
-        self.model = model_cls(self.global_config)
+        model_config = self.global_config.model
+        model_cls = MAIN_MODULE[model_config._class_]
+        self.model: KFold = model_cls(model_config)
 
         # Freeze parts of the model if needed
         self.freeze_submodules()


### PR DESCRIPTION
This pull request refactors the configuration system for folding models by introducing dataclass-based configuration classes, replacing the previous reliance on `omegaconf.DictConfig`. This change improves type safety, clarity, and maintainability across the model codebase. The update affects base model classes, specific model implementations (`Boltz1`, `Boltz1Pretrained`, `KFold`), and the training module initialization logic.

**Configuration system refactor:**

* Introduced `BaseFoldingModelConfig` and model-specific config dataclasses (`Boltz1Config`, `Boltz1PretrainedConfig`, `KFoldConfig`) to replace `DictConfig` for model configuration, improving type safety and structure.
* Updated constructors of `BaseFoldingModel`, `Boltz1`, `Boltz1Pretrained`, and `KFold` to accept their respective config dataclasses instead of a generic `DictConfig`.
* Refactored model initialization logic to use attributes from the config dataclasses, including handling of custom options like `load_weight` and `proj_s_inputs`. 

**Training module integration:**

* Modified `KFoldTrainingModule` to instantiate models using the new config dataclasses, ensuring compatibility with the refactored model constructors. 

**Code cleanup:**

* Removed unused imports of `omegaconf.DictConfig` from affected files. 