### PR TITLE
add no-tri-attn option

### DIFF
--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -50,28 +50,22 @@ class InterformerStack(nn.Module):
         num_heads_tri_attn: int = 4,
         num_blocks: int = 48,
         dropout: float = 0.25,
+        skip_tri_attn: bool = False,
         blocks_per_ckpt: int | None = None,
     ) -> None:
         """Initialize the Interformer module."""
         super().__init__()
-        self.channel_s: int = channel_s
-        self.channel_z: int = channel_z
-        self.num_heads_attn: int = num_heads_attn
-        self.num_heads_tri_attn: int = num_heads_tri_attn
-        self.dropout: float = dropout
-        self.num_blocks: int = num_blocks
-
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
-
         self.blocks = nn.ModuleList()
         for _ in range(num_blocks):
             self.blocks.append(
                 InterformerBlock(
-                    self.channel_s,
-                    self.channel_z,
-                    self.num_heads_attn,
-                    self.num_heads_tri_attn,
-                    self.dropout,
+                    channel_s,
+                    channel_z,
+                    num_heads_attn,
+                    num_heads_tri_attn,
+                    skip_tri_attn,
+                    dropout,
                 )
             )
 
@@ -194,6 +188,7 @@ class InterformerBlock(nn.Module):
         channel_z: int = 128,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
+        skip_tri_attn: bool = False,
         dropout: float = 0.25,
     ) -> None:
         """Initialize the Interformer module.
@@ -208,12 +203,17 @@ class InterformerBlock(nn.Module):
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
             The number of triangle attention heads, by default 4
+        skip_tri_attn : bool, optional
+            Whether to skip triangle attention, by default False
         dropout : float, optional
             The dropout rate, by default 0.25
         """
         super().__init__()
         self.channel_s: int = channel_s
         self.channel_z: int = channel_z
+        self.num_heads_attn: int = num_heads_attn
+        self.num_heads_tri_attn: int = num_heads_tri_attn
+        self.skip_tri_attn: bool = skip_tri_attn
         self.dropout: float = dropout
 
         self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
@@ -221,12 +221,13 @@ class InterformerBlock(nn.Module):
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
 
-        self.tri_att_start = TriangleAttentionStartingNode(
-            channel_z, num_heads_tri_attn, inf=1e9
-        )
-        self.tri_att_end = TriangleAttentionEndingNode(
-            channel_z, num_heads_tri_attn, inf=1e9
-        )
+        if not self.skip_tri_attn:
+            self.tri_att_start = TriangleAttentionStartingNode(
+                channel_z, num_heads_tri_attn, inf=1e9
+            )
+            self.tri_att_end = TriangleAttentionEndingNode(
+                channel_z, num_heads_tri_attn, inf=1e9
+            )
 
         self.attention = AttentionPairBias(
             channel_a=channel_s,
@@ -254,10 +255,10 @@ class InterformerBlock(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
 
-        # Single to pair update
+        # Information flow from single (s) to pairwise (z)
         z = z + self.pairwise_proj(s)
 
-        # Triangle attention and multiplication on z
+        # Triangle multiplicative update
         z = z + self.dropout_rowwise(
             self.tri_mul_out(
                 z,
@@ -272,26 +273,30 @@ class InterformerBlock(nn.Module):
                 use_kernels=use_cuequiv_mul,
             )
         )
-        z = z + self.dropout_rowwise(
-            self.tri_att_start(
-                z,
-                mask=pair_mask,
-                chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
-            )
-        )
-        z = z + self.dropout_columnwise(
-            self.tri_att_end(
-                z,
-                mask=pair_mask,
-                chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
-            )
-        )
 
+        if not self.skip_tri_attn:
+            # Triangle attention update
+            z = z + self.dropout_rowwise(
+                self.tri_att_start(
+                    z,
+                    mask=pair_mask,
+                    chunk_size=chunk_size_tri_attn,
+                    use_kernels=use_cuequiv_attn,
+                )
+            )
+            z = z + self.dropout_columnwise(
+                self.tri_att_end(
+                    z,
+                    mask=pair_mask,
+                    chunk_size=chunk_size_tri_attn,
+                    use_kernels=use_cuequiv_attn,
+                )
+            )
+
+        # Transition for pairwise representation
         z = z + self.transition_z(z)
 
-        # Attention from z to s
+        # Information flow from pairwise (z) to single (s)
         s = s + self.attention(
             s,  # [B, L, C_s]
             None,

--- a/src/kfold/model/layers/primitives/triangle_attention.py
+++ b/src/kfold/model/layers/primitives/triangle_attention.py
@@ -369,9 +369,9 @@ class TriangleAttention(nn.Module):
         # [*, I, 1, 1, J]
         mask = mask[..., :, None, None, :]
         if mask.dtype == torch.bool:
-            mask_bias = -self.inf * (~mask).to(x.dtype)
+            mask_bias = -self.inf * (~mask).to(torch.float32)
         else:
-            mask_bias = self.inf * (mask - 1)
+            mask_bias = self.inf * (mask - 1).to(torch.float32)
 
         # [*, H, I, J]
         triangle_bias = permute_final_dims(self.linear(x), (2, 0, 1))

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -58,6 +58,7 @@ class InterformerConfig:
     num_heads_tri_attn: int = 4
     num_blocks: int = 48
     dropout: float = 0.25
+    skip_tri_attn: bool = False
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -160,6 +161,7 @@ class KFoldTrunk(BaseTrunk):
             num_heads_tri_attn=cfg.interformer.num_heads_tri_attn,
             num_blocks=cfg.interformer.num_blocks,
             dropout=cfg.interformer.dropout,
+            skip_tri_attn=cfg.interformer.skip_tri_attn,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 


### PR DESCRIPTION
This pull request adds an option to skip the triangle attention mechanism in the Interformer model, making the architecture more flexible for experimentation and potential efficiency improvements. The change is implemented consistently across the configuration, model initialization, and forward pass logic. Additionally, there are minor improvements to code clarity and numerical precision handling.

**Interformer model enhancements:**

* Added a `skip_tri_attn` boolean parameter to the `Interformer` and `InterformerBlock` classes, allowing users to enable or disable the triangle attention mechanism. This parameter is now passed through the configuration and model initialization.
* Updated the forward pass in `InterformerBlock` to conditionally apply the triangle attention layers only if `skip_tri_attn` is `False`. 

**Documentation and code clarity:**

* Improved docstrings and inline comments to clarify the purpose and flow of information in the forward pass, especially regarding the new `skip_tri_attn` option and the roles of various update steps. (F3710de5L203, F3710de5L255, F3710de5L293)

**Numerical precision fix:**

* Ensured that mask biases in `TriangleAttentionStartingNode` are always cast to `torch.float32`, improving numerical stability and consistency.