### PR TITLE
update cueq version to 0.6.0 for attention_pair_bias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
   "modelcif==1.2", # to write cif file
 
   # cuequivariance
-  "cuequivariance_ops_cu12>=0.5.0",
-  "cuequivariance_ops_torch_cu12>=0.5.0",
-  "cuequivariance_torch>=0.5.0",
+  "cuequivariance_torch>=0.6.0",
+  "cuequivariance_ops_cu12>=0.6.0",
+  "cuequivariance_ops_torch_cu12>=0.6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
AttentionPairBias kernel is supported from 0.6.0
https://docs.nvidia.com/cuda/cuequivariance/changelog.html