### PR TITLE
Fix inference pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 experiments/
 wandb/
 benchmark/
+inference_results/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -185,6 +185,13 @@ def main():
         with open(save_dir / "query.yaml", "w") as f:
             f.write(query.yaml)
 
+        # Save apo structure
+        apo_save_path = save_dir / "apo.cif"
+        try:
+            struct.write(apo_save_path, save_apo=True)
+        except Exception as e:
+            print(f"Warning: Failed to save apo structure for {name}: {e}")
+
         # Save sampled structures
         new_struct: structure.TokenizedStructure = struct.replace_atom_coords(
             model_out["sample_coordinates"].cpu().numpy()

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -188,7 +188,7 @@ def main():
         # Save apo structure
         apo_save_path = save_dir / "apo.cif"
         try:
-            struct.write(apo_save_path, save_apo=True)
+            struct.write(apo_save_path, conformer_id=0, save_apo=True)
         except Exception as e:
             print(f"Warning: Failed to save apo structure for {name}: {e}")
 

--- a/src/kfold/data/processing/component.py
+++ b/src/kfold/data/processing/component.py
@@ -161,6 +161,11 @@ class Component:
     symmetries: tuple[list[int], ...] = ()  # Permutational symmetries
     properties: dict = dataclasses.field(default_factory=dict)  # Additional properties
 
+    @property
+    def num_atoms(self) -> int:
+        """Get the number of atoms in the component."""
+        return len(self.atom_names)
+
     def to_dict(self) -> dict:
         """Convert the Component instance to a dictionary without deepcopy"""
         fields = dataclasses.fields(self)
@@ -205,6 +210,10 @@ class Component:
                 f"Invalid conformer_type: {conformer_type}. "
                 f"Available options are: {available_types}"
             )
+
+        # If there is only one heavy atom, return zero coordinates
+        if self.num_atoms == 1:
+            return np.zeros((1, 3), dtype=np.float32)
 
         rng = rng or np.random.default_rng()
 

--- a/src/kfold/inference/data_pipeline.py
+++ b/src/kfold/inference/data_pipeline.py
@@ -595,6 +595,11 @@ def parse_polymer_sequence(
         k: np.array(bond_dict[k], dtype=bond_dtypes[k]) for k in bond_dict
     }
 
+    # Fill nans in atom coordinates with zeros
+    # TODO: Remove these lines and handle nans properly in future steps (apo perturbation)
+    atom_arr["apo_coords"] = np.nan_to_num(atom_arr["apo_coords"], nan=0.0)
+    atom_arr["ref_pos"] = np.nan_to_num(atom_arr["ref_pos"], nan=0.0)
+
     # Add Napo/Nholo dimension (N, 24, 1, 3) / (N, 24, 1)
     atom_arr["coords"] = np.expand_dims(atom_arr["coords"], axis=-2)
     atom_arr["apo_coords"] = np.expand_dims(atom_arr["apo_coords"], axis=-2)

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -118,16 +118,16 @@ class KFoldInferenceClient(pl.LightningModule):
         with open(save_dir / "query.yaml", "w") as f:
             f.write(query.yaml)
 
+        try:
+            apo_save_path = save_dir / "apo.cif"
+            struct.write(apo_save_path, conformer_id=0, save_apo=True)
+        except Exception as e:
+            logger.error(f"Error saving apo structure for {name}: {e}")
+
         # Save predictions
         sample_coords: torch.Tensor = model_out["sample_coordinates"]
         sample_coords_arr = sample_coords.cpu().numpy()
         new_struct = struct.replace_atom_coords(sample_coords_arr)
-
-        try:
-            save_path = save_dir / "apo.cif"
-            new_struct.write(save_path, 0, save_apo=True)
-        except Exception as e:
-            logger.error(f"Error saving apo structure for {name}: {e}")
 
         try:
             for i in range(num_diffusion_samples):

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -122,6 +122,13 @@ class KFoldInferenceClient(pl.LightningModule):
         sample_coords: torch.Tensor = model_out["sample_coordinates"]
         sample_coords_arr = sample_coords.cpu().numpy()
         new_struct = struct.replace_atom_coords(sample_coords_arr)
+
+        try:
+            save_path = save_dir / "apo.cif"
+            new_struct.write(save_path, 0, save_apo=True)
+        except Exception as e:
+            logger.error(f"Error saving apo structure for {name}: {e}")
+
         try:
             for i in range(num_diffusion_samples):
                 save_path = save_dir / f"sample-{i}.cif"


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to handling and saving "apo" (unbound) structures, as well as robustness improvements in data processing and structure handling. The most important changes are grouped below by their themes.

**Apo Structure Handling and Saving:**

* Added logic to save the apo structure (`apo.cif`) in both the main inference script (`scripts/inference.py`) and the PyTorch Lightning client (`src/kfold/inference/pl_client.py`), including error handling to log or print warnings if saving fails.

**Robustness in Structure and Data Processing:**

* In the `Component` class, added a `num_atoms` property to easily access the number of atoms, and updated `get_conformer` to return zero coordinates if there is only one atom, preventing downstream errors.
* In the data pipeline, filled NaNs in atom coordinate arrays (`apo_coords` and `ref_pos`) with zeros to avoid issues in later processing steps, with a note to improve this handling in the future.