### PR TITLE
Add cuequivariance kernel for attention pair bias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 experiments/
 wandb/
 benchmark/
+inference_results/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/configs/model/af3.yaml
+++ b/configs/model/af3.yaml
@@ -2,12 +2,16 @@
 _registry_: "main_module"
 _class_: AlphaFold3
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/af3.yaml"
 
 trunk:
   _yaml_: "module/trunk/af3.yaml"
-  use_cuequiv_kernels: true
 
 structure_module:
   _yaml_: "module/structure_module/af3.yaml"

--- a/configs/model/boltz1-full.yaml
+++ b/configs/model/boltz1-full.yaml
@@ -2,16 +2,21 @@
 _registry_: "main_module"
 _class_: Boltz1
 
+# Basic settings
 load_weight: false
 freeze_weight: false
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/boltz1.yaml"
 
 trunk:
   _yaml_: "module/trunk/boltz1.yaml"
   use_msa: true
-  use_cuequiv_kernels: false
 
 structure_module:
   _yaml_: "module/structure_module/boltz1.yaml"

--- a/configs/model/kfold-ddbm.yaml
+++ b/configs/model/kfold-ddbm.yaml
@@ -2,6 +2,11 @@
 _registry_: "main_module"
 _class_: KFold
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"
   channel_seq_encoder: null # Should be overriden
@@ -10,7 +15,6 @@ input_embedder:
 
 trunk:
   _yaml_: "module/trunk/af3.yaml"
-  use_cuequiv_kernels: true
 
 structure_module:
   _yaml_: "module/structure_module/ddbm.yaml"

--- a/configs/model/kfold-ecsi-pairmixer.yaml
+++ b/configs/model/kfold-ecsi-pairmixer.yaml
@@ -2,6 +2,11 @@
 _registry_: "main_module"
 _class_: KFold
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"
   channel_seq_encoder: null # Should be overriden
@@ -11,7 +16,6 @@ input_embedder:
 # should be path to pairformer trunk path
 trunk:
   _yaml_: "module/trunk/pairmixer.yaml"
-  use_cuequiv_kernels: true
 
 structure_module:
   _yaml_: "module/structure_module/ecsi.yaml"

--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -2,6 +2,11 @@
 _registry_: "main_module"
 _class_: KFold
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"
   channel_seq_encoder: null # Should be overriden
@@ -10,7 +15,6 @@ input_embedder:
 
 trunk:
   _yaml_: "module/trunk/af3.yaml"
-  use_cuequiv_kernels: true
 
 structure_module:
   _yaml_: "module/structure_module/ecsi.yaml"

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -2,6 +2,11 @@
 _registry_: "main_module"
 _class_: KFold
 
+# kernel settings
+kernel:
+  cuequivariance: true
+
+# Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"
   channel_seq_encoder: null # Should be overriden
@@ -10,7 +15,6 @@ input_embedder:
 
 trunk:
   _yaml_: "module/trunk/kfold.yaml"
-  use_cuequiv_kernels: true
   use_ensemble: False
   use_multi_state: False
 

--- a/configs/model/module/trunk/af3.yaml
+++ b/configs/model/module/trunk/af3.yaml
@@ -8,5 +8,4 @@ num_blocks: 48
 dropout: 0.25
 use_msa: False
 use_template: False
-use_cuequiv_kernels: True
 blocks_per_ckpt: 1

--- a/configs/model/module/trunk/boltz1.yaml
+++ b/configs/model/module/trunk/boltz1.yaml
@@ -9,4 +9,3 @@ pairwise_head_width: 32
 pairwise_num_heads: 4
 use_msa: True
 use_template: False
-use_cuequiv_kernels: false

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -19,6 +19,4 @@ ensemble_module:
 multi_state_module: {}
 use_ensemble: False
 use_multi_state: False
-use_cuequiv_kernels: True
 blocks_per_ckpt: 1
-

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -7,6 +7,7 @@ interformer:
   num_heads_tri_attn: 4
   num_blocks: 48
   dropout: 0.25
+  skip_tri_attn: false
 ensemble_module:
   channel_struct_input: 0 # to be filled in by the ensemble config
   channel_struct: 128
@@ -17,6 +18,6 @@ ensemble_module:
   struct_dropout: 0.15
   z_dropout: 0.25
 multi_state_module: {}
-use_ensemble: False
-use_multi_state: False
+use_ensemble: false
+use_multi_state: false
 blocks_per_ckpt: 1

--- a/configs/model/module/trunk/pairmixer.yaml
+++ b/configs/model/module/trunk/pairmixer.yaml
@@ -6,5 +6,4 @@ num_blocks: 48
 dropout: 0.25
 use_msa: False
 use_template: False
-use_cuequiv_kernels: True
 blocks_per_ckpt: 1

--- a/configs/model/module/trunk/pairmixerformer.yaml
+++ b/configs/model/module/trunk/pairmixerformer.yaml
@@ -7,7 +7,6 @@ pairmixer_blocks: 42
 dropout: 0.25
 use_msa: False
 use_template: False
-use_cuequiv_kernels: True
 blocks_per_ckpt: 1
 # following 2 are parameters for pairformer
 num_heads_attn: 16

--- a/configs/train-af3-tiny.yaml
+++ b/configs/train-af3-tiny.yaml
@@ -2,7 +2,6 @@ model:
   _yaml_: "model/af3.yaml"
   trunk:
     num_blocks: 8
-    use_cuequiv_kernels: true
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8

--- a/configs/train-af3.yaml
+++ b/configs/train-af3.yaml
@@ -1,7 +1,5 @@
 model:
   _yaml_: "model/af3.yaml"
-  trunk:
-    use_cuequiv_kernels: true
 
 train:
   _yaml_: "train/structure_only.yaml"

--- a/configs/train-esm2-ddbm-mini.yaml
+++ b/configs/train-esm2-ddbm-mini.yaml
@@ -4,7 +4,6 @@ model:
     channel_seq_encoder: 2560
   trunk:
     num_blocks: 16
-    use_cuequiv_kernels: true
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8

--- a/configs/train-esm2-ecsi-mini-pairmixer.yaml
+++ b/configs/train-esm2-ecsi-mini-pairmixer.yaml
@@ -6,7 +6,6 @@ model:
     use_apo: true
   trunk:
     num_blocks: 16
-    use_cuequiv_kernels: true
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
@@ -56,4 +55,3 @@ train:
     project: "KFold-esm"
     group: esm # set your group name
     entity: K-Fold # set your entity name
-

--- a/configs/train-esm2-ecsi-mini.yaml
+++ b/configs/train-esm2-ecsi-mini.yaml
@@ -5,7 +5,6 @@ model:
     use_apo: true
   trunk:
     num_blocks: 16
-    use_cuequiv_kernels: true
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8

--- a/configs/train-esm2-edm-mini.yaml
+++ b/configs/train-esm2-edm-mini.yaml
@@ -5,7 +5,6 @@ model:
   trunk:
     interformer:
       num_blocks: 16
-    use_cuequiv_kernels: true
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8

--- a/configs/train-esm2-edm.yaml
+++ b/configs/train-esm2-edm.yaml
@@ -2,8 +2,6 @@ model:
   _yaml_: "model/kfold-edm.yaml"
   input_embedder:
     channel_seq_encoder: 2560
-  trunk:
-    use_cuequiv_kernels: true
 
 train:
   _yaml_: "train/structure_only.yaml"

--- a/configs/validate-boltz1.yaml
+++ b/configs/validate-boltz1.yaml
@@ -1,8 +1,8 @@
 model:
   _yaml_: "model/boltz1-full.yaml"
-  trunk:
-    use_cuequiv_kernels: false # true can return slightly different results.
   load_weight: true
+  kernel:
+    cuequivariance: true
 
 train:
   _yaml_: "train/structure_only.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dependencies = [
   "modelcif==1.2", # to write cif file
 
   # cuequivariance
-  "cuequivariance_ops_cu12>=0.5.0",
-  "cuequivariance_ops_torch_cu12>=0.5.0",
-  "cuequivariance_torch>=0.5.0",
+  "cuequivariance_torch>=0.6.0",
+  "cuequivariance_ops_cu12>=0.6.0",
+  "cuequivariance_ops_torch_cu12>=0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -185,6 +185,13 @@ def main():
         with open(save_dir / "query.yaml", "w") as f:
             f.write(query.yaml)
 
+        # Save apo structure
+        apo_save_path = save_dir / "apo.cif"
+        try:
+            struct.write(apo_save_path, save_apo=True)
+        except Exception as e:
+            print(f"Warning: Failed to save apo structure for {name}: {e}")
+
         # Save sampled structures
         new_struct: structure.TokenizedStructure = struct.replace_atom_coords(
             model_out["sample_coordinates"].cpu().numpy()

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -188,7 +188,7 @@ def main():
         # Save apo structure
         apo_save_path = save_dir / "apo.cif"
         try:
-            struct.write(apo_save_path, save_apo=True)
+            struct.write(apo_save_path, conformer_id=0, save_apo=True)
         except Exception as e:
             print(f"Warning: Failed to save apo structure for {name}: {e}")
 

--- a/src/kfold/data/processing/component.py
+++ b/src/kfold/data/processing/component.py
@@ -161,6 +161,11 @@ class Component:
     symmetries: tuple[list[int], ...] = ()  # Permutational symmetries
     properties: dict = dataclasses.field(default_factory=dict)  # Additional properties
 
+    @property
+    def num_atoms(self) -> int:
+        """Get the number of atoms in the component."""
+        return len(self.atom_names)
+
     def to_dict(self) -> dict:
         """Convert the Component instance to a dictionary without deepcopy"""
         fields = dataclasses.fields(self)
@@ -205,6 +210,10 @@ class Component:
                 f"Invalid conformer_type: {conformer_type}. "
                 f"Available options are: {available_types}"
             )
+
+        # If there is only one heavy atom, return zero coordinates
+        if self.num_atoms == 1:
+            return np.zeros((1, 3), dtype=np.float32)
 
         rng = rng or np.random.default_rng()
 

--- a/src/kfold/inference/data_pipeline.py
+++ b/src/kfold/inference/data_pipeline.py
@@ -595,6 +595,11 @@ def parse_polymer_sequence(
         k: np.array(bond_dict[k], dtype=bond_dtypes[k]) for k in bond_dict
     }
 
+    # Fill nans in atom coordinates with zeros
+    # TODO: Remove these lines and handle nans properly in future steps (apo perturbation)
+    atom_arr["apo_coords"] = np.nan_to_num(atom_arr["apo_coords"], nan=0.0)
+    atom_arr["ref_pos"] = np.nan_to_num(atom_arr["ref_pos"], nan=0.0)
+
     # Add Napo/Nholo dimension (N, 24, 1, 3) / (N, 24, 1)
     atom_arr["coords"] = np.expand_dims(atom_arr["coords"], axis=-2)
     atom_arr["apo_coords"] = np.expand_dims(atom_arr["apo_coords"], axis=-2)

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -118,16 +118,16 @@ class KFoldInferenceClient(pl.LightningModule):
         with open(save_dir / "query.yaml", "w") as f:
             f.write(query.yaml)
 
+        try:
+            apo_save_path = save_dir / "apo.cif"
+            struct.write(apo_save_path, conformer_id=0, save_apo=True)
+        except Exception as e:
+            logger.error(f"Error saving apo structure for {name}: {e}")
+
         # Save predictions
         sample_coords: torch.Tensor = model_out["sample_coordinates"]
         sample_coords_arr = sample_coords.cpu().numpy()
         new_struct = struct.replace_atom_coords(sample_coords_arr)
-
-        try:
-            save_path = save_dir / "apo.cif"
-            new_struct.write(save_path, 0, save_apo=True)
-        except Exception as e:
-            logger.error(f"Error saving apo structure for {name}: {e}")
 
         try:
             for i in range(num_diffusion_samples):

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -122,6 +122,13 @@ class KFoldInferenceClient(pl.LightningModule):
         sample_coords: torch.Tensor = model_out["sample_coordinates"]
         sample_coords_arr = sample_coords.cpu().numpy()
         new_struct = struct.replace_atom_coords(sample_coords_arr)
+
+        try:
+            save_path = save_dir / "apo.cif"
+            new_struct.write(save_path, 0, save_apo=True)
+        except Exception as e:
+            logger.error(f"Error saving apo structure for {name}: {e}")
+
         try:
             for i in range(num_diffusion_samples):
                 save_path = save_dir / f"sample-{i}.cif"

--- a/src/kfold/model/layers/alphafold3/diffusion.py
+++ b/src/kfold/model/layers/alphafold3/diffusion.py
@@ -194,6 +194,7 @@ class DiffusionModule(nn.Module):
         s_trunk: torch.Tensor,
         z_trunk: torch.Tensor,
         model_cache: dict | None = None,
+        use_cuequiv_kernels: bool = False,
     ) -> torch.Tensor:
         """Forward pass of the AF3 diffusion module.
         See Section 3.7 Algorithm 20: Diffusion Module in the AF3 paper.
@@ -270,6 +271,7 @@ class DiffusionModule(nn.Module):
             s=s,  # [B, N, Lt, c_s]
             z=z,  # [B, 1, Lt, Lt, c_z], broadcasted to [B, N, Lt, Lt, c_z]
             attn_mask=token_mask,  # [B, 1, Lt], broadcasted to [B, N, Lt]
+            use_cuequiv_kernels=use_cuequiv_kernels,
         )
 
         # Line 6

--- a/src/kfold/model/layers/alphafold3/pairformer.py
+++ b/src/kfold/model/layers/alphafold3/pairformer.py
@@ -65,8 +65,7 @@ class PairformerStack(nn.Module):
         z: torch.Tensor,
         mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
-        use_cuequiv_mul: bool = False,
-        use_cuequiv_attn: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
 
@@ -78,6 +77,10 @@ class PairformerStack(nn.Module):
             The pairwise embeddings
         mask : torch.Tensor
             The token mask
+        chunk_size_tri_attn : int | None, optional
+            The chunk size for triangle attention, by default None
+        use_cuequiv_kernels : bool, optional
+            Whether to use CuEQuiv kernels, by default False
 
         Returns
         -------
@@ -100,8 +103,7 @@ class PairformerStack(nn.Module):
                 single_mask=mask.float(),
                 pair_mask=pair_mask.float(),
                 chunk_size_tri_attn=chunk_size_tri_attn,
-                use_cuequiv_mul=use_cuequiv_mul,
-                use_cuequiv_attn=use_cuequiv_attn,
+                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -186,8 +188,7 @@ class PairformerBlock(nn.Module):
         single_mask: torch.Tensor,
         pair_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
-        use_cuequiv_mul: bool = False,
-        use_cuequiv_attn: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
         See Section 3.6 Algorithm 20 Pairformer Stack
@@ -198,7 +199,7 @@ class PairformerBlock(nn.Module):
             self.tri_mul_out(
                 z,
                 pair_mask,
-                use_kernels=use_cuequiv_mul,
+                use_kernels=use_cuequiv_kernels,
             )
         )
 
@@ -207,7 +208,7 @@ class PairformerBlock(nn.Module):
             self.tri_mul_in(
                 z,
                 mask=pair_mask,
-                use_kernels=use_cuequiv_mul,
+                use_kernels=use_cuequiv_kernels,
             )
         )
 
@@ -217,7 +218,7 @@ class PairformerBlock(nn.Module):
                 z,
                 mask=pair_mask,
                 chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
+                use_kernels=use_cuequiv_kernels,
             )
         )
 
@@ -227,7 +228,7 @@ class PairformerBlock(nn.Module):
                 z,
                 mask=pair_mask,
                 chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
+                use_kernels=use_cuequiv_kernels,
             )
         )
 
@@ -240,6 +241,7 @@ class PairformerBlock(nn.Module):
             None,
             z,  # [B, L, L, C_z]
             attn_mask=single_mask,  # [B, L]
+            use_kernels=use_cuequiv_kernels,
         )
 
         # Line 8

--- a/src/kfold/model/layers/alphafold3/transformers.py
+++ b/src/kfold/model/layers/alphafold3/transformers.py
@@ -538,8 +538,7 @@ class AtomTransformer(nn.Module):
         )
 
         # NOTE: mask the key positions only (masking query is not required)
-        mask = mask  # [B, La, 1]
-        attn_mask = local_attn_index.to_key(mask[..., None]).squeeze(-1)  # [B, W, Lk]
+        attn_mask = local_attn_index.to_key(mask[..., None]).squeeze(-1)  # [..., W, Lk]
 
         # main transformer
         q = self.diffusion_transformer(

--- a/src/kfold/model/layers/alphafold3/transformers.py
+++ b/src/kfold/model/layers/alphafold3/transformers.py
@@ -15,8 +15,8 @@ from kfold.model.layers.primitives import (
     Linear,
     LinearNoBias,
     SwiGLU,
-    attention,
 )
+from kfold.model.layers.primitives.attention import attention, attention_pair_bias
 from kfold.utils.checkpointing import checkpoint_blocks
 
 from .embeddings import AtomEmbedding
@@ -119,7 +119,7 @@ class AttentionPairBias(nn.Module):
         z: torch.Tensor,
         attn_mask: torch.Tensor,
         local_attn_index: LocalAttentionIndex | None = None,
-        inplace: bool = False,
+        use_kernels: bool = False,
     ) -> torch.Tensor:
         """Forward pass.
         See Section 3.7 Algorithm 24 of AlphaFold3 paper.
@@ -138,6 +138,8 @@ class AttentionPairBias(nn.Module):
             NOTE: We only mask key positions as in the official implementation.
         local_attn_index : LocalAttentionIndex | None
             The local attention indexer, by default None
+        use_kernels : bool, optional
+            Whether to use custom kernel for attention, by default False
 
         Returns
         -------
@@ -145,6 +147,11 @@ class AttentionPairBias(nn.Module):
             The output sequence tensor. (B, N, c_a)
 
         """
+        if use_kernels:
+            assert local_attn_index is None, (
+                "local_attn_index must be None when use_kernels is True"
+            )
+
         # === Input linearection === #
         if self.use_single_cond:
             # Line 1-2
@@ -169,26 +176,47 @@ class AttentionPairBias(nn.Module):
         k = self.linear_k(a_k)  # [..., H, Lk, Dh]
         v = self.linear_v(a_k)  # [..., H, Lk, Dh]
 
-        # Line 8
-        attn_bias = self.linear_z(z)  # [..., H, Lq, Lk]
-        attn_bias = attn_bias - self.inf * (1 - attn_mask.float())[..., None, None, :]
+        if use_kernels:
+            # Attention Pair Bias with cuequivariance kernels
+            a = attention_pair_bias(
+                s=a,
+                q=q,
+                k=k,
+                v=v,
+                z=z,
+                mask=attn_mask.bool(),
+                w_proj_z=self.linear_z[1].weight,
+                w_proj_g=self.linear_g.weight,
+                w_proj_o=self.linear_out.weight,
+                w_ln_z=self.linear_z[0].weight,
+                b_ln_z=self.linear_z[0].bias,
+                b_proj_z=self.linear_z[1].bias,
+                b_proj_g=self.linear_g.bias,
+                b_proj_o=self.linear_out.bias,
+                num_heads=self.num_heads,
+                inf=self.inf,
+                use_kernels=True,
+            )
+        else:
+            # Line 8
+            attn_bias = self.linear_z(z)  # [..., H, Lq, Lk]
+            attn_bias = attn_bias - self.inf * (1 - attn_mask.float())[..., None, None, :]
 
-        # Line 9
-        g = self.sigmoid(self.linear_g(a))
+            # Line 9
+            g = self.sigmoid(self.linear_g(a))
 
-        # === Attention === #
-        # Line 10-11
-        Av = attention(
-            q,
-            k,
-            v,
-            bias=attn_bias,
-            scale=math.sqrt(self.head_dim),
-            inplace=inplace,
-        )
-        Av = rearrange(Av, "... h l d -> ... l (h d)")
-        Av = Av.reshape(a.shape)
-        a = self.linear_out(g * Av)
+            # === Attention === #
+            # Line 10-11
+            Av = attention(
+                q,
+                k,
+                v,
+                bias=attn_bias,
+                scale=1.0 / math.sqrt(self.head_dim),
+            )
+            Av = rearrange(Av, "... h l d -> ... l (h d)")
+            Av = Av.reshape(a.shape)
+            a = self.linear_out(g * Av)
 
         # === Output projection === #
         # Line 12-14
@@ -250,6 +278,7 @@ class DiffusionTransformer(nn.Module):
         z: torch.Tensor,
         attn_mask: torch.Tensor,
         local_attn_index: LocalAttentionIndex | None = None,
+        use_cuequiv_kernels: bool = False,
     ):
         """See Section 3.7 Algorithm 23 Diffusion Transformer
 
@@ -264,6 +293,10 @@ class DiffusionTransformer(nn.Module):
         attn_mask : torch.Tensor
             The pairwise mask tensor (..., Lk)
             NOTE: We only mask key positions as in the official implementation.
+        local_attn_index : LocalAttentionIndex | None
+            The local attention indexer, by default None
+        use_cuequiv_kernels : bool, optional
+            Whether to use custom kernel for attention, by default False
         """
         # Line 1, 4
         blocks = [
@@ -271,6 +304,7 @@ class DiffusionTransformer(nn.Module):
                 b,
                 attn_mask=attn_mask,
                 local_attn_index=local_attn_index,
+                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -335,6 +369,7 @@ class DiffusionTransformerBlock(nn.Module):
         z: torch.Tensor,
         attn_mask: torch.Tensor,
         local_attn_index: LocalAttentionIndex | None = None,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """See Section 3.7 Algorithm 23 Diffusion Transformer
 
@@ -348,6 +383,8 @@ class DiffusionTransformerBlock(nn.Module):
             The input pair representation tensor (..., Lq, Lk, c_z)
         attn_mask : torch.Tensor
             The pairwise mask tensor (..., Lq, Lk)
+        use_cuequiv_kernels : bool, optional
+            Whether to use custom kernel for attention, by default False
 
         Returns
         -------
@@ -374,6 +411,7 @@ class DiffusionTransformerBlock(nn.Module):
             z=z,
             attn_mask=attn_mask,
             local_attn_index=local_attn_index,
+            use_kernels=use_cuequiv_kernels,
         )
         # Line 3
         a = a + self.transition(a, s)
@@ -500,7 +538,7 @@ class AtomTransformer(nn.Module):
         )
 
         # NOTE: mask the key positions only (masking query is not required)
-        mask = mask.float()  # [B, La, 1]
+        mask = mask  # [B, La, 1]
         attn_mask = local_attn_index.to_key(mask[..., None]).squeeze(-1)  # [B, W, Lk]
 
         # main transformer
@@ -510,6 +548,7 @@ class AtomTransformer(nn.Module):
             z=p,  # [B, W, Lq, Lk, c_atompair]
             attn_mask=attn_mask,  # [B, W, Lk]
             local_attn_index=local_attn_index,
+            use_cuequiv_kernels=False,  # skip cueq kernel for local attention
         )
 
         return q
@@ -572,7 +611,7 @@ class AtomAttentionEncoder(nn.Module):
         self.embed_atompair_ref_dist = LinearNoBias(1, channel_atompair, init="default")
         self.embed_atompair_mask = LinearNoBias(1, channel_atompair, init="default")
 
-        self.use_structure = use_structure
+        self.use_structure: bool = use_structure
         if use_structure:
             assert channel_z is not None, (
                 "channel_z must be provided if use_structure is True"

--- a/src/kfold/model/layers/kfold/ensemble_module.py
+++ b/src/kfold/model/layers/kfold/ensemble_module.py
@@ -5,6 +5,8 @@ import torch
 from kfold.data.model_input import FoldingInput
 from kfold.model.layers.alphafold3.transition import Transition
 from kfold.model.layers.primitives import (
+    DropoutColumnwise,
+    DropoutRowwise,
     LayerNorm,
     LinearNoBias,
     TriangleAttentionEndingNode,
@@ -12,7 +14,6 @@ from kfold.model.layers.primitives import (
     TriangleMultiplicationIncoming,
     TriangleMultiplicationOutgoing,
 )
-from kfold.model.layers.primitives.dropout import get_dropout_mask
 from kfold.model.layers.primitives.utils import permute_final_dims
 from kfold.utils.checkpointing import checkpoint_blocks
 
@@ -316,8 +317,8 @@ class EnsembleModule(torch.nn.Module):
         num_heads_pwa: int = 8,
         num_heads_tri_attn: int = 4,
         num_blocks: int = 4,
-        struct_dropout: float = 0.15,
-        z_dropout: float = 0.25,
+        dropout_struct: float = 0.15,
+        dropout_z: float = 0.25,
         blocks_per_ckpt: int | None = None,
     ) -> None:
         """Initialize the Ensemble module.
@@ -340,10 +341,10 @@ class EnsembleModule(torch.nn.Module):
             The number of heads for the triangle attention.
         num_blocks : int
             The number of Ensemble blocks.
-        struct_dropout : float
-            The Ensemble dropout.
-        z_dropout : float
-            The pairwise dropout.
+        dropout_struct : float
+            The dropout rate for the ensemble stack.
+        dropout_z : float
+            The dropout rate for the pairwise stack.
         blocks_per_ckpt : int | None
             The number of blocks per checkpoint, default None.
         """
@@ -364,8 +365,8 @@ class EnsembleModule(torch.nn.Module):
                     channel_hidden_opm=channel_hidden_opm,
                     num_heads_pwa=num_heads_pwa,
                     num_heads_tri_attn=num_heads_tri_attn,
-                    struct_dropout=struct_dropout,
-                    z_dropout=z_dropout,
+                    dropout_struct=dropout_struct,
+                    dropout_z=dropout_z,
                     is_last_block=(i == num_blocks - 1),
                 )
             )
@@ -375,10 +376,8 @@ class EnsembleModule(torch.nn.Module):
         f_input: FoldingInput,
         z: torch.Tensor,
         s_inputs: torch.Tensor,
-        chunk_size_opm: int | None = None,
         chunk_size_tri_attn: int | None = None,
-        use_cuequiv_mul: bool = True,
-        use_cuequiv_attn: bool = True,
+        use_cuequiv_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the forward pass.
 
@@ -390,6 +389,8 @@ class EnsembleModule(torch.nn.Module):
             The pairwise embeddings
         s_inputs : Tensor
             The input single embeddings
+        chunk_size_tri_attn : int | None, optional
+            The chunk size for triangle attention, by default None.
 
         Returns
         -------
@@ -397,13 +398,6 @@ class EnsembleModule(torch.nn.Module):
             The output pairwise embeddings.
 
         """
-        # Set chunk sizes
-        if self.training:
-            assert chunk_size_opm is None, "During training, chunk_size_opm must be None."
-            assert chunk_size_tri_attn is None, (
-                "During training, chunk_size_tri_attn must be None."
-            )
-
         # Compute input projections
         e: torch.Tensor = f_input.pretrained.structure_embedding  # [B, L, E, c_struct]
         # FIXME: add a better way to handle missing structure embeddings
@@ -421,9 +415,7 @@ class EnsembleModule(torch.nn.Module):
                 b,
                 token_mask=token_mask,
                 struct_mask=struct_mask,
-                use_cuequiv_mul=use_cuequiv_mul,
-                use_cuequiv_attn=use_cuequiv_attn,
-                chunk_size_opm=chunk_size_opm,
+                use_cuequiv_kernels=use_cuequiv_kernels,
                 chunk_size_tri_attn=chunk_size_tri_attn,
             )
             for b in self.blocks
@@ -453,8 +445,8 @@ class EnsembleBlock(torch.nn.Module):
         channel_hidden_opm: int = 32,
         num_heads_pwa: int = 8,
         num_heads_tri_attn: int = 4,
-        struct_dropout: float = 0.15,
-        z_dropout: float = 0.25,
+        dropout_struct: float = 0.15,
+        dropout_z: float = 0.25,
         is_last_block: bool = False,
     ) -> None:
         """Initialize the Ensemble block.
@@ -471,18 +463,15 @@ class EnsembleBlock(torch.nn.Module):
             The number of heads for the ensemble attention, by default 8.
         num_heads_tri_attn : int, optional
             The number of heads for the triangle attention, by default 4.
-        struct_dropout : float, optional
+        dropout_struct : float, optional
             The dropout rate for the ensemble stack, by default 0.15.
-        z_dropout : float, optional
+        dropout_z : float, optional
             The dropout rate for the pairwise stack, by default 0.25.
         is_last_block : bool, optional
             Whether this is the last block, by default False.
 
         """
         super().__init__()
-        self.e_dropout: float = struct_dropout
-        self.z_dropout: float = z_dropout
-
         self.outer_product_mean = OuterProductMean(
             c_in=channel_struct,
             c_hidden=channel_hidden_opm,
@@ -499,6 +488,11 @@ class EnsembleBlock(torch.nn.Module):
         )
 
         self.transition_z = Transition(channel_z, expansion_factor=4)
+
+        self.dropout_rowwise_e = DropoutRowwise(dropout_struct)
+        self.dropout_columnwise_e = DropoutColumnwise(dropout_struct)
+        self.dropout_rowwise_z = DropoutRowwise(dropout_z)
+        self.dropout_columnwise_z = DropoutColumnwise(dropout_z)
 
         self.is_last_block: bool = is_last_block
         if not self.is_last_block:
@@ -517,9 +511,7 @@ class EnsembleBlock(torch.nn.Module):
         z: torch.Tensor,
         token_mask: torch.Tensor,
         struct_mask: torch.Tensor,
-        use_cuequiv_mul: bool = True,
-        use_cuequiv_attn: bool = True,
-        chunk_size_opm: int | None = None,
+        use_cuequiv_kernels: bool = False,
         chunk_size_tri_attn: int | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
@@ -534,6 +526,10 @@ class EnsembleBlock(torch.nn.Module):
             The token mask
         struct_mask : torch.Tensor
             The structure ensemble mask
+        use_cuequiv_kernels : bool, optional
+            Whether to use cuEQUIV kernels, by default False
+        chunk_size_tri_attn : int | None, optional
+            The chunk size for triangle attention, by default None.
 
         Returns
         -------
@@ -544,39 +540,48 @@ class EnsembleBlock(torch.nn.Module):
 
         """
         # Communication
-        z = z + self.outer_product_mean(e, struct_mask, chunk_size=chunk_size_opm)
+        # NOTE: The number of ensemble members are <10, so chunking is not needed here.
+        z = z + self.outer_product_mean(e, struct_mask)
 
         # Pairwise stack
-        dropout = get_dropout_mask(z, self.z_dropout, self.training)
-        z = z + dropout * self.tri_mul_out(
-            z, mask=token_mask, use_kernels=use_cuequiv_mul
+        z = z + self.dropout_rowwise_z(
+            self.tri_mul_out(
+                z,
+                token_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
-
-        dropout = get_dropout_mask(z, self.z_dropout, self.training)
-        z = z + dropout * self.tri_mul_in(z, mask=token_mask, use_kernels=use_cuequiv_mul)
-
-        dropout = get_dropout_mask(z, self.z_dropout, self.training)
-        z = z + dropout * self.tri_att_start(
-            z,
-            mask=token_mask,
-            chunk_size=chunk_size_tri_attn,
-            use_kernels=use_cuequiv_attn,
+        z = z + self.dropout_rowwise_z(
+            self.tri_mul_in(
+                z,
+                token_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
-
-        dropout = get_dropout_mask(z, self.z_dropout, self.training, columnwise=True)
-        z = z + dropout * self.tri_att_end(
-            z,
-            mask=token_mask,
-            chunk_size=chunk_size_tri_attn,
-            use_kernels=use_cuequiv_attn,
+        z = z + self.dropout_rowwise_z(
+            self.tri_att_start(
+                z,
+                token_mask,
+                chunk_size=chunk_size_tri_attn,
+                use_kernels=use_cuequiv_kernels,
+            )
+        )
+        z = z + self.dropout_columnwise_z(
+            self.tri_att_end(
+                z,
+                token_mask,
+                chunk_size=chunk_size_tri_attn,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
 
         z = z + self.transition_z(z)
 
         if not self.is_last_block:
             # Ensemble stack
-            ensb_dropout = get_dropout_mask(e, self.e_dropout, self.training)
-            e = e + ensb_dropout * self.pair_weighted_averaging(e, z, token_mask)
+            e = e + self.dropout_rowwise_e(
+                self.pair_weighted_averaging(e, z, token_mask),
+            )
             e = e + self.transition_e(e)
 
         return e, z

--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -81,8 +81,7 @@ class InterformerStack(nn.Module):
         z: torch.Tensor,
         mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
-        use_cuequiv_mul: bool = False,
-        use_cuequiv_attn: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
 
@@ -94,6 +93,10 @@ class InterformerStack(nn.Module):
             The pairwise embeddings
         mask : torch.Tensor
             The token mask
+        chunk_size_tri_attn : int | None, optional
+            The chunk size for triangle attention, by default None
+        use_cuequiv_kernels : bool, optional
+            Whether to use CuEQuiv kernels, by default False
 
         Returns
         -------
@@ -113,11 +116,10 @@ class InterformerStack(nn.Module):
         blocks = [
             partial(
                 b,
-                single_mask=mask.float(),
-                pair_mask=pair_mask.float(),
+                single_mask=mask,
+                pair_mask=pair_mask,
                 chunk_size_tri_attn=chunk_size_tri_attn,
-                use_cuequiv_mul=use_cuequiv_mul,
-                use_cuequiv_attn=use_cuequiv_attn,
+                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -249,8 +251,7 @@ class InterformerBlock(nn.Module):
         single_mask: torch.Tensor,
         pair_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
-        use_cuequiv_mul: bool = False,
-        use_cuequiv_attn: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
 
@@ -262,14 +263,14 @@ class InterformerBlock(nn.Module):
             self.tri_mul_out(
                 z,
                 pair_mask,
-                use_kernels=use_cuequiv_mul,
+                use_kernels=use_cuequiv_kernels,
             )
         )
         z = z + self.dropout_rowwise(
             self.tri_mul_in(
                 z,
                 mask=pair_mask,
-                use_kernels=use_cuequiv_mul,
+                use_kernels=use_cuequiv_kernels,
             )
         )
         z = z + self.dropout_rowwise(
@@ -277,7 +278,7 @@ class InterformerBlock(nn.Module):
                 z,
                 mask=pair_mask,
                 chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
+                use_kernels=use_cuequiv_kernels,
             )
         )
         z = z + self.dropout_columnwise(
@@ -285,7 +286,7 @@ class InterformerBlock(nn.Module):
                 z,
                 mask=pair_mask,
                 chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
+                use_kernels=use_cuequiv_kernels,
             )
         )
 
@@ -297,6 +298,7 @@ class InterformerBlock(nn.Module):
             None,
             z,  # [B, L, L, C_z]
             attn_mask=single_mask,  # [B, L]
+            use_kernels=use_cuequiv_kernels,
         )
         s = s + self.transition_s(s)
 

--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -50,28 +50,22 @@ class InterformerStack(nn.Module):
         num_heads_tri_attn: int = 4,
         num_blocks: int = 48,
         dropout: float = 0.25,
+        skip_tri_attn: bool = False,
         blocks_per_ckpt: int | None = None,
     ) -> None:
         """Initialize the Interformer module."""
         super().__init__()
-        self.channel_s: int = channel_s
-        self.channel_z: int = channel_z
-        self.num_heads_attn: int = num_heads_attn
-        self.num_heads_tri_attn: int = num_heads_tri_attn
-        self.dropout: float = dropout
-        self.num_blocks: int = num_blocks
-
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
-
         self.blocks = nn.ModuleList()
         for _ in range(num_blocks):
             self.blocks.append(
                 InterformerBlock(
-                    self.channel_s,
-                    self.channel_z,
-                    self.num_heads_attn,
-                    self.num_heads_tri_attn,
-                    self.dropout,
+                    channel_s,
+                    channel_z,
+                    num_heads_attn,
+                    num_heads_tri_attn,
+                    skip_tri_attn,
+                    dropout,
                 )
             )
 
@@ -194,6 +188,7 @@ class InterformerBlock(nn.Module):
         channel_z: int = 128,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
+        skip_tri_attn: bool = False,
         dropout: float = 0.25,
     ) -> None:
         """Initialize the Interformer module.
@@ -208,12 +203,17 @@ class InterformerBlock(nn.Module):
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
             The number of triangle attention heads, by default 4
+        skip_tri_attn : bool, optional
+            Whether to skip triangle attention, by default False
         dropout : float, optional
             The dropout rate, by default 0.25
         """
         super().__init__()
         self.channel_s: int = channel_s
         self.channel_z: int = channel_z
+        self.num_heads_attn: int = num_heads_attn
+        self.num_heads_tri_attn: int = num_heads_tri_attn
+        self.skip_tri_attn: bool = skip_tri_attn
         self.dropout: float = dropout
 
         self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
@@ -221,12 +221,13 @@ class InterformerBlock(nn.Module):
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
 
-        self.tri_att_start = TriangleAttentionStartingNode(
-            channel_z, num_heads_tri_attn, inf=1e9
-        )
-        self.tri_att_end = TriangleAttentionEndingNode(
-            channel_z, num_heads_tri_attn, inf=1e9
-        )
+        if not self.skip_tri_attn:
+            self.tri_att_start = TriangleAttentionStartingNode(
+                channel_z, num_heads_tri_attn, inf=1e9
+            )
+            self.tri_att_end = TriangleAttentionEndingNode(
+                channel_z, num_heads_tri_attn, inf=1e9
+            )
 
         self.attention = AttentionPairBias(
             channel_a=channel_s,
@@ -254,10 +255,10 @@ class InterformerBlock(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
 
-        # Single to pair update
+        # Information flow from single (s) to pairwise (z)
         z = z + self.pairwise_proj(s)
 
-        # Triangle attention and multiplication on z
+        # Triangle multiplicative update
         z = z + self.dropout_rowwise(
             self.tri_mul_out(
                 z,
@@ -272,26 +273,30 @@ class InterformerBlock(nn.Module):
                 use_kernels=use_cuequiv_mul,
             )
         )
-        z = z + self.dropout_rowwise(
-            self.tri_att_start(
-                z,
-                mask=pair_mask,
-                chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
-            )
-        )
-        z = z + self.dropout_columnwise(
-            self.tri_att_end(
-                z,
-                mask=pair_mask,
-                chunk_size=chunk_size_tri_attn,
-                use_kernels=use_cuequiv_attn,
-            )
-        )
 
+        if not self.skip_tri_attn:
+            # Triangle attention update
+            z = z + self.dropout_rowwise(
+                self.tri_att_start(
+                    z,
+                    mask=pair_mask,
+                    chunk_size=chunk_size_tri_attn,
+                    use_kernels=use_cuequiv_attn,
+                )
+            )
+            z = z + self.dropout_columnwise(
+                self.tri_att_end(
+                    z,
+                    mask=pair_mask,
+                    chunk_size=chunk_size_tri_attn,
+                    use_kernels=use_cuequiv_attn,
+                )
+            )
+
+        # Transition for pairwise representation
         z = z + self.transition_z(z)
 
-        # Attention from z to s
+        # Information flow from pairwise (z) to single (s)
         s = s + self.attention(
             s,  # [B, L, C_s]
             None,

--- a/src/kfold/model/layers/pairmixer/pairmixer.py
+++ b/src/kfold/model/layers/pairmixer/pairmixer.py
@@ -55,7 +55,10 @@ import torch.nn as nn
 
 from kfold.model.layers.alphafold3.transformers import AttentionPairBias
 from kfold.model.layers.alphafold3.transition import Transition
-from kfold.model.layers.primitives.dropout import get_dropout_mask
+from kfold.model.layers.primitives.dropout import (
+    DropoutColumnwise,
+    DropoutRowwise,
+)
 from kfold.model.layers.primitives.triangle_multiplication import (
     TriangleMultiplicationIncoming,
     TriangleMultiplicationOutgoing,
@@ -97,7 +100,7 @@ class PairmixerStack(nn.Module):
         s: torch.Tensor,
         z: torch.Tensor,
         mask: torch.Tensor,
-        use_cuequiv_mul: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Perform the forward pass.
@@ -110,8 +113,8 @@ class PairmixerStack(nn.Module):
             The pairwise embeddings
         mask : torch.Tensor
             The token mask
-        use_cuequiv_mul : bool, optional
-            Whether to use Cuequiv multiplication, by default False
+        use_cuequiv_kernels : bool, optional
+            Whether to use cuequiv kernels in triangle multiplication,
 
         Returns
         -------
@@ -128,7 +131,7 @@ class PairmixerStack(nn.Module):
             partial(
                 b,
                 pair_mask=pair_mask.float(),
-                use_cuequiv_mul=use_cuequiv_mul,
+                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -175,31 +178,36 @@ class PairmixerBlock(nn.Module):
 
         self.transition_z = Transition(channel_z, expansion_factor=4)
 
+        self.dropout_rowwise = DropoutRowwise(dropout)
+        self.dropout_columnwise = DropoutColumnwise(dropout)
+
     def forward(
         self,
         s: torch.Tensor,
         z: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_mul: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
         See Section 3.6 Algorithm 20 Pairformer Stack
         """
 
         # Line 2
-        dropout = get_dropout_mask(z, self.dropout, self.training)
-        z = z + dropout * self.tri_mul_out(
-            z,
-            mask=pair_mask,
-            use_kernels=use_cuequiv_mul,
+        z = z + self.dropout_rowwise(
+            self.tri_mul_out(
+                z,
+                pair_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
 
         # Line 3
-        dropout = get_dropout_mask(z, self.dropout, self.training)
-        z = z + dropout * self.tri_mul_in(
-            z,
-            mask=pair_mask,
-            use_kernels=use_cuequiv_mul,
+        z = z + self.dropout_rowwise(
+            self.tri_mul_in(
+                z,
+                mask=pair_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
 
         # Line 4, 5 removed (no attention)
@@ -253,7 +261,7 @@ class PairmixerWithSeqAttnModule(nn.Module):
         s: torch.Tensor,
         z: torch.Tensor,
         mask: torch.Tensor,
-        use_cuequiv_mul: bool = False,
+        use_cuequiv_kernels: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
@@ -265,7 +273,7 @@ class PairmixerWithSeqAttnModule(nn.Module):
                 b,
                 single_mask=mask.float(),
                 pair_mask=pair_mask.float(),
-                use_cuequiv_mul=use_cuequiv_mul,
+                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -315,27 +323,31 @@ class PairmixerWithSeqAttnBlock(nn.Module):
         self.transition_s = Transition(channel_s, expansion_factor=4)
         self.transition_z = Transition(channel_z, expansion_factor=4)
 
+        self.dropout_rowwise = DropoutRowwise(dropout)
+        self.dropout_columnwise = DropoutColumnwise(dropout)
+
     def forward(
         self,
         s: torch.Tensor,
         z: torch.Tensor,
         single_mask: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_mul: bool = False,
+        use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # pairwise rep updates
-        dropout = get_dropout_mask(z, self.dropout, self.training)
-        z = z + dropout * self.tri_mul_out(
-            z,
-            mask=pair_mask,
-            use_kernels=use_cuequiv_mul,
+        z = z + self.dropout_rowwise(
+            self.tri_mul_out(
+                z,
+                pair_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
-
-        dropout = get_dropout_mask(z, self.dropout, self.training)
-        z = z + dropout * self.tri_mul_in(
-            z,
-            mask=pair_mask,
-            use_kernels=use_cuequiv_mul,
+        z = z + self.dropout_rowwise(
+            self.tri_mul_in(
+                z,
+                mask=pair_mask,
+                use_kernels=use_cuequiv_kernels,
+            )
         )
 
         z = z + self.transition_z(z)

--- a/src/kfold/model/layers/primitives/attention.py
+++ b/src/kfold/model/layers/primitives/attention.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 try:
     from cuequivariance_torch import attention_pair_bias as cueq_attention_pair_bias
 except ImportError:
-    triangle_attention = None
+    cueq_attention_pair_bias = None
 
 from .utils import add, mul, permute_final_dims
 
@@ -104,21 +104,21 @@ def attention_pair_bias(
     mask : torch.Tensor
         The attention mask tensor of shape (B, *, Lk)
     w_proj_z : torch.Tensor
-        The weight tensor for projecting z, default None
+        The weight tensor for projecting z
     w_proj_g : torch.Tensor
         The weight tensor for projecting g
     w_proj_o : torch.Tensor
         The weight tensor for projecting o
     w_ln_z : torch.Tensor
-        The weight tensor for layer norm on z, default None
+        The weight tensor for layer norm on z
     b_ln_z : Optional[torch.Tensor]
-        The bias tensor for layer norm on z, default None
+        The bias tensor for layer norm on z
     b_proj_z : torch.Tensor
-        The bias tensor for projecting z, default None
+        The bias tensor for projecting z
     b_proj_g : Optional[torch.Tensor]
-        The bias tensor for projecting g, default None
+        The bias tensor for projecting g
     b_proj_o : Optional[torch.Tensor]
-        The bias tensor for projecting o, default None
+        The bias tensor for projecting o
     num_heads : int
         The number of attention heads, default 32
     inf : float
@@ -128,7 +128,7 @@ def attention_pair_bias(
     attn_scale : Optional[float]
         The scaling factor for the query-key dot product, default None
     use_kernels : bool
-        Whether to use the custom kernel if available, default True
+        Whether to use the custom kernel if available, default False
     """
     if use_kernels:
         assert cueq_attention_pair_bias is not None, (

--- a/src/kfold/model/layers/primitives/attention.py
+++ b/src/kfold/model/layers/primitives/attention.py
@@ -1,6 +1,14 @@
-import torch
+import math
 
-from .utils import add, div
+import torch
+import torch.nn.functional as F
+
+try:
+    from cuequivariance_torch import attention_pair_bias as cueq_attention_pair_bias
+except ImportError:
+    triangle_attention = None
+
+from .utils import add, mul, permute_final_dims
 
 
 def attention(
@@ -39,7 +47,7 @@ def attention(
         bias = bias.to(torch.float32) if bias is not None else None
 
         if scale is not None:
-            query = div(query, scale, inplace=inplace)
+            query = mul(query, scale, inplace=inplace)
 
         # Compute attention weights
         attn = torch.einsum("...qc,...kc->...qk", query, key)
@@ -53,5 +61,143 @@ def attention(
 
     # Compute output
     out = torch.einsum("...qk,...kc->...qc", attn.to(value.dtype), value)
+
+    return out
+
+
+def attention_pair_bias(
+    s: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    z: torch.Tensor,
+    mask: torch.Tensor,
+    w_proj_z: torch.Tensor,
+    w_proj_g: torch.Tensor,
+    w_proj_o: torch.Tensor,
+    w_ln_z: torch.Tensor,
+    b_ln_z: torch.Tensor | None,
+    b_proj_z: torch.Tensor | None,
+    b_proj_g: torch.Tensor | None,
+    b_proj_o: torch.Tensor | None,
+    num_heads: int = 32,
+    inf: float = 1e6,
+    eps: float = 1e-5,
+    attn_scale: float | None = None,
+    use_kernels: bool = False,
+) -> torch.Tensor:
+    """Compute the attention operation with pair bias using a custom kernel if available.
+    Parameters
+    ----------
+    s : torch.Tensor
+        The input tensor of shape (B, *, L, C)
+        where B is the batch size, N is the number of samples,
+        L is the sequence length, and C is the feature dimension.
+    q : torch.Tensor
+        The query tensor of shape (B, *, H, Lq, C_h)
+    k : torch.Tensor
+        The key tensor of shape (B, *, H, Lk, C_h)
+    v : torch.Tensor
+        The value tensor of shape (B, *, H, Lk, C_h)
+    z : torch.Tensor
+        The pair bias tensor of shape (B, *, Lq, Lk, C_z)
+    mask : torch.Tensor
+        The attention mask tensor of shape (B, *, Lk)
+    w_proj_z : torch.Tensor
+        The weight tensor for projecting z, default None
+    w_proj_g : torch.Tensor
+        The weight tensor for projecting g
+    w_proj_o : torch.Tensor
+        The weight tensor for projecting o
+    w_ln_z : torch.Tensor
+        The weight tensor for layer norm on z, default None
+    b_ln_z : Optional[torch.Tensor]
+        The bias tensor for layer norm on z, default None
+    b_proj_z : torch.Tensor
+        The bias tensor for projecting z, default None
+    b_proj_g : Optional[torch.Tensor]
+        The bias tensor for projecting g, default None
+    b_proj_o : Optional[torch.Tensor]
+        The bias tensor for projecting o, default None
+    num_heads : int
+        The number of attention heads, default 32
+    inf : float
+        The value to use for masking, default 1e6
+    eps : float
+        The epsilon value for numerical stability, default 1e-5
+    attn_scale : Optional[float]
+        The scaling factor for the query-key dot product, default None
+    use_kernels : bool
+        Whether to use the custom kernel if available, default True
+    """
+    if use_kernels:
+        assert cueq_attention_pair_bias is not None, (
+            "cuequivariance_torch is not installed."
+        )
+        L = s.shape[-2]
+        Lq = q.shape[-2]
+        Lk = k.shape[-2]
+        if not (L == Lq == Lk):
+            raise NotImplementedError(
+                "cueq_attention_pair_bias only supports Lq == Lk == L."
+            )
+        # Merge batch dims for compatibility
+        batch_dims = s.shape[:-2]
+        s = s.flatten(0, -3)  # [B*N, L, C]
+        q = q.flatten(0, -4)  # [B*N, H, Q, C_h]
+        k = k.flatten(0, -4)  # [B*N, H, K, C_h]
+        v = v.flatten(0, -4)  # [B*N, H, K, C_h]
+        z = z.flatten(0, -4)  # [B*N, Q, K, C_z]
+        mask = mask.flatten(0, -2)  # [B*N, K]
+
+        out, _ = cueq_attention_pair_bias(
+            s,
+            q,
+            k,
+            v,
+            z,
+            mask,
+            num_heads,
+            w_proj_z,
+            w_proj_g,
+            w_proj_o,
+            w_ln_z,
+            b_ln_z,
+            b_proj_z,
+            b_proj_g,
+            b_proj_o,
+            inf,
+            eps,
+            attn_scale,
+            return_z_proj=False,
+        )
+        out = out.unflatten(0, batch_dims)  # restore batch dims
+
+    else:
+        # layernorm on z
+        z_ln = F.layer_norm(z, z.shape[-1:], w_ln_z, b_ln_z)  # [B, Q, K, C_z]
+        # project z to get attention bias
+        attn_bias = F.linear(z_ln, w_proj_z, b_proj_z)  # [B, Q, K, H]
+        attn_bias = permute_final_dims(attn_bias, (2, 0, 1))  # [B, H, Q, K]
+        del z_ln
+        attn_bias = attn_bias - inf * (
+            1 - mask.float()[..., None, None, :]
+        )  # [B, H, Q, K]
+
+        # === Attention === #
+        if attn_scale is None:
+            attn_scale = 1 / math.sqrt(q.shape[-1])
+        Av = attention(
+            q,  # [B, N, H, Q, C_h]
+            k,  # [B, N, H, K, C_h]
+            v,  # [B, N, H, K, C_h]
+            bias=attn_bias,  # [B, N, H, Q, K]
+            scale=attn_scale,
+        )  # [B, N, H, Q, C_h]
+        Av = permute_final_dims(Av, (1, 0, 2))  # [B, N, Q, H, C_h]
+        Av = Av.reshape(s.shape)  # [B, N, Q, C]
+
+        g = F.sigmoid(F.linear(s, w_proj_g, b_proj_g))  # [B, N, L, C]
+        out = F.linear(g * Av, w_proj_o, b_proj_o)  # [B, N, L, C]
 
     return out

--- a/src/kfold/model/layers/primitives/triangle_attention.py
+++ b/src/kfold/model/layers/primitives/triangle_attention.py
@@ -369,9 +369,9 @@ class TriangleAttention(nn.Module):
         # [*, I, 1, 1, J]
         mask = mask[..., :, None, None, :]
         if mask.dtype == torch.bool:
-            mask_bias = -self.inf * (~mask).to(x.dtype)
+            mask_bias = -self.inf * (~mask).to(torch.float32)
         else:
-            mask_bias = self.inf * (mask - 1)
+            mask_bias = self.inf * (mask - 1).to(torch.float32)
 
         # [*, H, I, J]
         triangle_bias = permute_final_dims(self.linear(x), (2, 0, 1))

--- a/src/kfold/model/layers/primitives/triangle_attention.py
+++ b/src/kfold/model/layers/primitives/triangle_attention.py
@@ -100,6 +100,7 @@ class MultiHeadAttention(nn.Module):
         c_hidden: int,
         no_heads: int,
         gating: bool = True,
+        inf: float = 1e9,
     ):
         """Initialize the attention layer.
 
@@ -121,12 +122,13 @@ class MultiHeadAttention(nn.Module):
         """
         super().__init__()
 
-        self.c_q = c_q
-        self.c_k = c_k
-        self.c_v = c_v
-        self.c_hidden = c_hidden
-        self.no_heads = no_heads
-        self.gating = gating
+        self.c_q: int = c_q
+        self.c_k: int = c_k
+        self.c_v: int = c_v
+        self.c_hidden: int = c_hidden
+        self.no_heads: int = no_heads
+        self.gating: bool = gating
+        self.inf: float = inf
 
         # DISCREPANCY: c_hidden is not the per-head channel dimension, as
         # stated in the supplement, but the overall channel dimension.
@@ -196,7 +198,6 @@ class MultiHeadAttention(nn.Module):
         q_x: torch.Tensor,
         kv_x: torch.Tensor,
         tri_bias: torch.Tensor,
-        mask_bias: torch.Tensor,
         mask: torch.Tensor,
         use_kernels: bool = False,
     ) -> torch.Tensor:
@@ -210,8 +211,6 @@ class MultiHeadAttention(nn.Module):
             [*, K, C_k] key data
         tri_bias : torch.Tensor
             [*, H, Q, K] triangular bias
-        mask_bias : torch.Tensor
-            [*, H, Q, K] mask bias
         mask : torch.Tensor
             [*, Q, K] mask
         use_kernels : bool, default=False
@@ -241,6 +240,10 @@ class MultiHeadAttention(nn.Module):
             )
             o = o.transpose(-2, -3)
         else:
+            if mask.dtype == torch.bool:
+                mask_bias = -self.inf * (~mask).to(q.dtype)
+            else:
+                mask_bias = self.inf * (mask - 1)
             biases = [mask_bias, tri_bias]
             o = _attention(q, k, v, biases)
             o = o.transpose(-2, -3)
@@ -368,22 +371,21 @@ class TriangleAttention(nn.Module):
 
         # [*, I, 1, 1, J]
         mask = mask[..., :, None, None, :]
-        if mask.dtype == torch.bool:
-            mask_bias = -self.inf * (~mask).to(x.dtype)
-        else:
-            mask_bias = self.inf * (mask - 1)
 
-        # [*, H, I, J]
-        triangle_bias = permute_final_dims(self.linear(x), (2, 0, 1))
+        with torch.autocast(x.device.type, dtype=torch.float32, enabled=use_kernels):
+            # NOTE: casting to float32 for cuequiv kernels.
+            triangle_bias = self.linear(x)
 
-        # [*, 1, H, I, J]
-        triangle_bias = triangle_bias.unsqueeze(-4)
+            # [*, H, I, J]
+            triangle_bias = permute_final_dims(triangle_bias, (2, 0, 1))
+
+            # [*, 1, H, I, J]
+            triangle_bias = triangle_bias.unsqueeze(-4)
 
         if chunk_size is not None and not use_kernels:
             x = self._chunk(
                 x,
                 triangle_bias,
-                mask_bias,
                 mask,
                 chunk_size,
                 use_kernels=use_kernels,
@@ -393,7 +395,6 @@ class TriangleAttention(nn.Module):
                 x,
                 x,
                 triangle_bias,
-                mask_bias,
                 mask,
                 use_kernels=use_kernels,
             )

--- a/src/kfold/model/layers/primitives/triangle_attention.py
+++ b/src/kfold/model/layers/primitives/triangle_attention.py
@@ -287,7 +287,6 @@ class TriangleAttention(nn.Module):
         self,
         x: torch.Tensor,
         tri_bias: torch.Tensor,
-        mask_bias: torch.Tensor,
         mask: torch.Tensor,
         chunk_size: int,
         use_kernels: bool = False,
@@ -315,7 +314,6 @@ class TriangleAttention(nn.Module):
             "q_x": x,
             "kv_x": x,
             "tri_bias": tri_bias,
-            "mask_bias": mask_bias,
             "mask": mask,
         }
 

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -12,8 +12,14 @@ from kfold.utils.registry import MAIN_MODULE, BaseConfig, Registry
 
 
 @dataclasses.dataclass(kw_only=True)
+class KernelConfig:
+    cuequivariance: bool = False
+
+
+@dataclasses.dataclass(kw_only=True)
 class BaseFoldingModelConfig:
     _class_: str = "BaseFoldingModel"
+    kernel: KernelConfig
     input_embedder: BaseConfig
     trunk: BaseConfig
     score_model: BaseConfig
@@ -27,16 +33,19 @@ class BaseFoldingModel(torch.nn.Module):
     def __init__(self, config: BaseFoldingModelConfig):
         super().__init__()
         self.config: BaseFoldingModelConfig = config
+        kernel_config = config.kernel
 
         # Initialize sub-modules here using the config
         self.input_embedder: submodules.input_embedder.BaseInputEmbedder = (
             Registry.instantiate(config.input_embedder)
         )
 
-        self.trunk: submodules.trunk.BaseTrunk = Registry.instantiate(config.trunk)
+        self.trunk: submodules.trunk.BaseTrunk = Registry.instantiate(
+            config.trunk, kernel_config=kernel_config
+        )
 
         self.score_model: submodules.score_model.BaseScoreModel = Registry.instantiate(
-            config.score_model
+            config.score_model, kernel_config=kernel_config
         )
 
         # NOTE: structure module is not a torch.nn.Module

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -70,8 +70,8 @@ class AF3DiffusionModule(BaseScoreModel):
         conditioning_transition_layers: int = 2
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config) -> None:
-        super().__init__(cfg)
+    def __init__(self, cfg: Config, kernel_config):
+        super().__init__(cfg, kernel_config)
 
         self.diffusion_stack = DiffusionModule(
             channel_s=cfg.channel_s,
@@ -122,6 +122,9 @@ class AF3DiffusionModule(BaseScoreModel):
             The trunk single representation, shape [B, Lt, c_s].
         z_trunk : torch.Tensor
             The trunk pair representation, shape [B, Lt, c_z].
+        model_cache : dict | None, optional
+            The model cache for storing intermediate results to speed up
+            computation, by default None.
 
         Returns
         -------
@@ -136,4 +139,5 @@ class AF3DiffusionModule(BaseScoreModel):
             s_trunk,
             z_trunk,
             model_cache,
+            use_cuequiv_kernels=self.kernel_config.cuequivariance,
         )

--- a/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
+++ b/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
@@ -72,8 +72,8 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
         conditioning_transition_layers: int = 2
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config) -> None:
-        super().__init__(cfg)
+    def __init__(self, cfg: Config, kernel_config):
+        super().__init__(cfg, kernel_config)
 
         diffusion_stack_class = DiffusionModuleWithApo if cfg.use_apo else DiffusionModule
 
@@ -139,4 +139,5 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
             s_trunk,
             z_trunk,
             model_cache,
+            use_cuequiv_kernels=self.kernel_config.cuequivariance,
         )

--- a/src/kfold/model/modules/score_model/base.py
+++ b/src/kfold/model/modules/score_model/base.py
@@ -12,9 +12,10 @@ class BaseScoreModel(torch.nn.Module, ABC):
     See Section 3.7: Diffusion Module, Algorithm 20 of AlphaFold3
     """
 
-    def __init__(self, cfg):
+    def __init__(self, cfg, kernel_config):
         super().__init__()
         self.cfg = cfg
+        self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
     def compile(self, compile: bool = True):

--- a/src/kfold/model/modules/score_model/boltz1_diffusion.py
+++ b/src/kfold/model/modules/score_model/boltz1_diffusion.py
@@ -66,8 +66,8 @@ class Boltz1DiffusionModule(BaseScoreModel):
         conditioning_transition_layers: int = 2
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config) -> None:
-        super().__init__(cfg)
+    def __init__(self, cfg: Config, kernel_config: dict):
+        super().__init__(cfg, kernel_config)
 
         self.diffusion_stack = DiffusionModule(
             token_s=cfg.channel_s,

--- a/src/kfold/model/modules/trunk/af3_trunk.py
+++ b/src/kfold/model/modules/trunk/af3_trunk.py
@@ -36,8 +36,6 @@ class AF3PairformerTrunk(BaseTrunk):
             Whether to use template, by default False
         use_msa: bool, optional
             Whether to use MSA, by default False
-        use_cuequiv_kernels : bool, optional
-            Whether to use cuequivariance kernels, by default False
         tri_attn_chunk_threshold : int, optional
             The threshold for chunking in triangle attention, by default 384
         """
@@ -50,16 +48,14 @@ class AF3PairformerTrunk(BaseTrunk):
         dropout: float = 0.25
         use_msa: bool = False
         use_template: bool = False
-        use_cuequiv_kernels: bool = False
         blocks_per_ckpt: int | None = None
         tri_attn_chunk_threshold: int = 384
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config):
         """Initialize the Pairformer module."""
-        super().__init__(cfg)
+        super().__init__(cfg, kernel_config)
         self.use_msa: bool = cfg.use_msa
         self.use_template: bool = cfg.use_template
-        self.use_cuequiv_kernels: bool = cfg.use_cuequiv_kernels
         self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
 
         if self.use_template:
@@ -174,8 +170,7 @@ class AF3PairformerTrunk(BaseTrunk):
                     z,
                     mask=f_input.token.pad_mask,
                     chunk_size_tri_attn=chunk_size_tri_attn,
-                    use_cuequiv_attn=self.use_cuequiv_kernels,
-                    use_cuequiv_mul=self.use_cuequiv_kernels,
+                    use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
                 # Line 13

--- a/src/kfold/model/modules/trunk/base.py
+++ b/src/kfold/model/modules/trunk/base.py
@@ -15,9 +15,10 @@ class BaseTrunk(torch.nn.Module, ABC):
         channel_s: int = 384
         channel_z: int = 128
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config):
         super().__init__()
         self.cfg = cfg
+        self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
     def compile(self, compile: bool = True):

--- a/src/kfold/model/modules/trunk/boltz1_trunk.py
+++ b/src/kfold/model/modules/trunk/boltz1_trunk.py
@@ -48,14 +48,13 @@ class Boltz1PairformerTrunk(BaseTrunk):
         pairwise_num_heads: int = 4
         use_msa: bool = False
         use_template: bool = False
-        use_cuequiv_kernels: bool = False
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config):
         """Initialize the Pairformer module."""
-        super().__init__(cfg)
+        super().__init__(cfg, kernel_config)
         self.use_msa: bool = cfg.use_msa
         self.use_template: bool = cfg.use_template
-        self.use_kernels: bool = cfg.use_cuequiv_kernels
+        self.use_kernels: bool = self.kernel_config.cuequivariance
 
         if self.use_template:
             raise NotImplementedError(

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -68,8 +68,8 @@ class EnsembleModuleConfig:
     num_heads_pwa: int = 8
     num_heads_tri_attn: int = 4
     num_blocks: int = 4
-    struct_dropout: float = 0.15
-    z_dropout: float = 0.25
+    dropout_struct: float = 0.15
+    dropout_z: float = 0.25
 
 
 # TODO: Define the configuration for MultiStateModule when implemented
@@ -98,8 +98,6 @@ class KFoldTrunk(BaseTrunk):
             Whether to use EnsembleModule, by default True
         use_multi_state: bool, optional
             Whether to use MultiStateModule, by default False
-        use_cuequiv_kernels : bool, optional
-            Whether to use cuequivariance kernels, by default False
         tri_attn_chunk_threshold : int, optional
             The threshold for chunking in triangle attention, by default 384
         """
@@ -125,13 +123,12 @@ class KFoldTrunk(BaseTrunk):
         )
 
         # other options
-        use_cuequiv_kernels: bool = False
         blocks_per_ckpt: int | None = None
         tri_attn_chunk_threshold: int = 384
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config=None):
         """Initialize the MultiStateApoTrunk module."""
-        super().__init__(cfg)
+        super().__init__(cfg, kernel_config)
         self.use_ensemble: bool = cfg.use_ensemble
         self.use_multi_state: bool = cfg.use_multi_state
 
@@ -145,8 +142,8 @@ class KFoldTrunk(BaseTrunk):
                 num_heads_pwa=cfg.ensemble_module.num_heads_pwa,
                 num_heads_tri_attn=cfg.ensemble_module.num_heads_tri_attn,
                 num_blocks=cfg.ensemble_module.num_blocks,
-                struct_dropout=cfg.ensemble_module.struct_dropout,
-                z_dropout=cfg.ensemble_module.z_dropout,
+                dropout_struct=cfg.ensemble_module.dropout_struct,
+                dropout_z=cfg.ensemble_module.dropout_z,
                 blocks_per_ckpt=cfg.blocks_per_ckpt,
             )
 
@@ -170,7 +167,6 @@ class KFoldTrunk(BaseTrunk):
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
         # Other options
-        self.use_cuequiv_kernels: bool = cfg.use_cuequiv_kernels
         self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
 
     def forward(
@@ -205,13 +201,11 @@ class KFoldTrunk(BaseTrunk):
             The updated tensor of shape (B, L, L, c_z).
         """
         if not self.training:
-            chunk_size_opm = 512
             if z_init.shape[1] > self.chunk_threshold:
                 chunk_size_tri_attn = 128
             else:
                 chunk_size_tri_attn = 512
         else:
-            chunk_size_opm = None
             chunk_size_tri_attn = None
 
         # Line 6, z_hat, s_hat = 0, 0
@@ -236,10 +230,8 @@ class KFoldTrunk(BaseTrunk):
                         f_input,
                         z,
                         s_inputs,
-                        chunk_size_opm=chunk_size_opm,
                         chunk_size_tri_attn=chunk_size_tri_attn,
-                        use_cuequiv_mul=self.use_cuequiv_kernels,
-                        use_cuequiv_attn=self.use_cuequiv_kernels,
+                        use_cuequiv_kernels=self.kernel_config.cuequivariance,
                     )
 
                 s, z = self.pairformer_module(
@@ -247,8 +239,7 @@ class KFoldTrunk(BaseTrunk):
                     z,
                     mask=f_input.token.pad_mask,
                     chunk_size_tri_attn=chunk_size_tri_attn,
-                    use_cuequiv_attn=self.use_cuequiv_kernels,
-                    use_cuequiv_mul=self.use_cuequiv_kernels,
+                    use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
                 # Line 13

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -58,6 +58,7 @@ class InterformerConfig:
     num_heads_tri_attn: int = 4
     num_blocks: int = 48
     dropout: float = 0.25
+    skip_tri_attn: bool = False
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -160,6 +161,7 @@ class KFoldTrunk(BaseTrunk):
             num_heads_tri_attn=cfg.interformer.num_heads_tri_attn,
             num_blocks=cfg.interformer.num_blocks,
             dropout=cfg.interformer.dropout,
+            skip_tri_attn=cfg.interformer.skip_tri_attn,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 

--- a/src/kfold/model/modules/trunk/pairmixer_trunk.py
+++ b/src/kfold/model/modules/trunk/pairmixer_trunk.py
@@ -32,8 +32,6 @@ class PairmixerTrunk(BaseTrunk):
             Whether to use template, by default False
         use_msa: bool, optional
             Whether to use MSA, by default False
-        use_cuequiv_kernels : bool, optional
-            Whether to use cuequivariance kernels, by default False
         blocks_per_ckpt : int, optional
             The number of blocks per checkpoint, by default None
         """
@@ -44,15 +42,13 @@ class PairmixerTrunk(BaseTrunk):
         dropout: float = 0.25
         use_msa: bool = False
         use_template: bool = False
-        use_cuequiv_kernels: bool = False
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config):
         """Initialize the Pairmixer module."""
-        super().__init__(cfg)
+        super().__init__(cfg, kernel_config)
         self.use_msa: bool = cfg.use_msa
         self.use_template: bool = cfg.use_template
-        self.use_cuequiv_kernels: bool = cfg.use_cuequiv_kernels
 
         if self.use_template:
             raise NotImplementedError(
@@ -156,7 +152,7 @@ class PairmixerTrunk(BaseTrunk):
                     s,
                     z,
                     mask=f_input.token.pad_mask,
-                    use_cuequiv_mul=self.use_cuequiv_kernels,
+                    use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
                 # Line 13
@@ -177,7 +173,6 @@ class PairmixerformerTrunk(BaseTrunk):
         dropout: float = 0.25
         use_msa: bool = False
         use_template: bool = False
-        use_cuequiv_kernels: bool = False
         blocks_per_ckpt: int | None = None
         num_heads_attn: int = 16
         num_heads_tri_attn: int = 4
@@ -197,7 +192,6 @@ class PairmixerformerTrunk(BaseTrunk):
 
         self.use_msa: bool = cfg.use_msa
         self.use_template: bool = cfg.use_template
-        self.use_cuequiv_kernels: bool = cfg.use_cuequiv_kernels
         self.chunk_threshold: int = cfg.chunk_threshold
 
         if self.use_template:
@@ -242,6 +236,7 @@ class PairmixerformerTrunk(BaseTrunk):
         z_init: torch.Tensor,
         f_input: FoldingInput,
         num_recycles: int,
+        use_cuequiv_kernels: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
@@ -290,7 +285,7 @@ class PairmixerformerTrunk(BaseTrunk):
                     s,
                     z,
                     mask=f_input.token.pad_mask,
-                    use_cuequiv_mul=self.use_cuequiv_kernels,
+                    use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
                 s, z = pairformer_module(
@@ -298,8 +293,7 @@ class PairmixerformerTrunk(BaseTrunk):
                     z,
                     mask=f_input.token.pad_mask,
                     chunk_size_tri_attn=chunk_size_tri_attn,
-                    use_cuequiv_attn=self.use_cuequiv_kernels,
-                    use_cuequiv_mul=self.use_cuequiv_kernels,
+                    use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
                 # Line 13


### PR DESCRIPTION
### cuequivariance kernel option

* Added a kernel option for `AttentionPairBias`
* Move `use_cuequiv_kernels` flag to global `kernel.cuequivariance` flag.
* Update default cuequivariance version from 0.5.0 to 0.6.0.

### refactoring

* Refactoring dropout.

### Inference bugfix

* During previous inference, apo coordinates were becoming masked due to `NaN` value (during random rotation/translation). This PR fixed this.

