### PR TITLE
Finish to debug compilation option

### DIFF
--- a/configs/model/af3.yaml
+++ b/configs/model/af3.yaml
@@ -2,6 +2,11 @@
 _registry_: "main_module"
 _class_: AlphaFold3
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # kernel settings
 kernel:
   cuequivariance: true

--- a/configs/model/boltz1-full.yaml
+++ b/configs/model/boltz1-full.yaml
@@ -6,6 +6,11 @@ _class_: Boltz1
 load_weight: false
 freeze_weight: false
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # kernel settings
 kernel:
   cuequivariance: true

--- a/configs/model/kfold-ddbm.yaml
+++ b/configs/model/kfold-ddbm.yaml
@@ -6,6 +6,11 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"

--- a/configs/model/kfold-ecsi-pairmixer.yaml
+++ b/configs/model/kfold-ecsi-pairmixer.yaml
@@ -6,6 +6,11 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"

--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -6,6 +6,11 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -6,6 +6,11 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
+# compilation settings
+compile_trunk: false
+compile_score_model: false
+compile_mode: 'default'
+
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/pretrained.yaml"

--- a/src/kfold/model/layers/primitives/attention.py
+++ b/src/kfold/model/layers/primitives/attention.py
@@ -65,6 +65,56 @@ def attention(
     return out
 
 
+@torch.compiler.disable
+def kernel_attention_pair_bias(
+    s: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    z: torch.Tensor,
+    mask: torch.Tensor,
+    w_proj_z: torch.Tensor,
+    w_proj_g: torch.Tensor,
+    w_proj_o: torch.Tensor,
+    w_ln_z: torch.Tensor,
+    b_ln_z: torch.Tensor | None,
+    b_proj_z: torch.Tensor | None,
+    b_proj_g: torch.Tensor | None,
+    b_proj_o: torch.Tensor | None,
+    num_heads: int = 32,
+    inf: float = 1e6,
+    eps: float = 1e-5,
+    attn_scale: float | None = None,
+) -> torch.Tensor:
+    """A wrapper for attention_pair_bias with kernel support disabled."""
+    if cueq_attention_pair_bias is None:
+        raise ImportError(
+            "cuequivariance_torch is not installed. Please install it to use the kernel."
+        )
+    out, _ = cueq_attention_pair_bias(
+        s,
+        q,
+        k,
+        v,
+        z,
+        mask,
+        num_heads,
+        w_proj_z,
+        w_proj_g,
+        w_proj_o,
+        w_ln_z,
+        b_ln_z,
+        b_proj_z,
+        b_proj_g,
+        b_proj_o,
+        inf,
+        eps,
+        attn_scale,
+        return_z_proj=False,
+    )
+    return out
+
+
 def attention_pair_bias(
     s: torch.Tensor,
     q: torch.Tensor,
@@ -131,9 +181,6 @@ def attention_pair_bias(
         Whether to use the custom kernel if available, default False
     """
     if use_kernels:
-        assert cueq_attention_pair_bias is not None, (
-            "cuequivariance_torch is not installed."
-        )
         L = s.shape[-2]
         Lq = q.shape[-2]
         Lk = k.shape[-2]
@@ -150,14 +197,13 @@ def attention_pair_bias(
         z = z.flatten(0, -4)  # [B*N, Q, K, C_z]
         mask = mask.flatten(0, -2)  # [B*N, K]
 
-        out, _ = cueq_attention_pair_bias(
+        out = kernel_attention_pair_bias(
             s,
             q,
             k,
             v,
             z,
             mask,
-            num_heads,
             w_proj_z,
             w_proj_g,
             w_proj_o,
@@ -166,11 +212,11 @@ def attention_pair_bias(
             b_proj_z,
             b_proj_g,
             b_proj_o,
+            num_heads,
             inf,
             eps,
             attn_scale,
-            return_z_proj=False,
-        )
+        )  # [B*N, L, C]
         out = out.unflatten(0, batch_dims)  # restore batch dims
 
     else:

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -19,6 +19,9 @@ class KernelConfig:
 @dataclasses.dataclass(kw_only=True)
 class BaseFoldingModelConfig:
     _class_: str = "BaseFoldingModel"
+    compile_trunk: bool = False
+    compile_score_model: bool = False
+    compile_mode: str = "default"
     kernel: KernelConfig
     input_embedder: BaseConfig
     trunk: BaseConfig
@@ -65,12 +68,8 @@ class BaseFoldingModel(torch.nn.Module):
 
         # Compile submodules
         # NOTE: (SeonghwanSeo) This is very slow... Right now, just disable them.
-        if getattr(config, "compile_trunk", False):
-            self.trunk.compile(getattr(config, "compile_trunk", False))
-        if getattr(config, "compile_score_model", False):
-            self.score_model.compile(getattr(config, "compile_score_model", False))
-        # if getattr(config, "compile_confidence_head", False):
-        #     self.confidence_head.compile()
+        self.trunk.compile(config.compile_trunk, config.compile_mode)
+        self.score_model.compile(config.compile_score_model, config.compile_mode)
 
     def forward(
         self,

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -96,7 +96,7 @@ class AF3DiffusionModule(BaseScoreModel):
         """Compile the trunk module."""
         self.diffusion_stack = torch.compile(
             self.diffusion_stack,
-            mode=mode,
+            mode="default",  # reduce-overhead mode has issues on DDP.
             dynamic=False,
             fullgraph=False,
         )  # type: ignore
@@ -140,6 +140,9 @@ class AF3DiffusionModule(BaseScoreModel):
         r_update : torch.Tensor
             The denoised atom positions, shape [B, N, La, 3].
         """
+        if self.training:
+            assert model_cache is None, "model_cache is only used during evaluation."
+
         # Revert to uncompiled version for validation
         diffusion_stack: DiffusionModule
         if self.is_compiled and not self.training:

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -92,6 +92,15 @@ class AF3DiffusionModule(BaseScoreModel):
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 
+    def do_compile(self, mode: str = "default"):
+        """Compile the trunk module."""
+        self.diffusion_stack = torch.compile(
+            self.diffusion_stack,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
+        )  # type: ignore
+
     def forward(
         self,
         r_noisy: torch.Tensor,
@@ -131,7 +140,14 @@ class AF3DiffusionModule(BaseScoreModel):
         r_update : torch.Tensor
             The denoised atom positions, shape [B, N, La, 3].
         """
-        return self.diffusion_stack(
+        # Revert to uncompiled version for validation
+        diffusion_stack: DiffusionModule
+        if self.is_compiled and not self.training:
+            diffusion_stack = self.diffusion_stack._orig_mod  # noqa: SLF001
+        else:
+            diffusion_stack = self.diffusion_stack
+
+        return diffusion_stack(
             r_noisy,
             c_noise,
             f_input,

--- a/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
+++ b/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
@@ -100,7 +100,7 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
         """Compile the trunk module."""
         self.diffusion_stack = torch.compile(
             self.diffusion_stack,
-            mode=mode,
+            mode="default",  # reduce-overhead mode has issues on DDP.
             dynamic=False,
             fullgraph=False,
         )  # type: ignore
@@ -140,6 +140,9 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
         r_update : torch.Tensor
             The denoised atom positions, shape [B, N, La, 3].
         """
+        if self.training:
+            assert model_cache is None, "model_cache is only used during evaluation."
+
         # Revert to uncompiled version for validation
         diffusion_stack: DiffusionModule
         if self.is_compiled and not self.training:

--- a/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
+++ b/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
@@ -96,6 +96,15 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 
+    def do_compile(self, mode: str = "default"):
+        """Compile the trunk module."""
+        self.diffusion_stack = torch.compile(
+            self.diffusion_stack,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
+        )  # type: ignore
+
     def forward(
         self,
         r_noisy: torch.Tensor,
@@ -131,7 +140,14 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
         r_update : torch.Tensor
             The denoised atom positions, shape [B, N, La, 3].
         """
-        return self.diffusion_stack(
+        # Revert to uncompiled version for validation
+        diffusion_stack: DiffusionModule
+        if self.is_compiled and not self.training:
+            diffusion_stack = self.diffusion_stack._orig_mod  # noqa: SLF001
+        else:
+            diffusion_stack = self.diffusion_stack
+
+        return diffusion_stack(
             r_noisy,
             c_noise,
             f_input,

--- a/src/kfold/model/modules/score_model/base.py
+++ b/src/kfold/model/modules/score_model/base.py
@@ -18,15 +18,19 @@ class BaseScoreModel(torch.nn.Module, ABC):
         self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
-    def compile(self, compile: bool = True):
+    def compile(self, compile: bool = True, mode: str = "default"):
         """Compile the score model module."""
         if compile:
-            self.do_compile()
+            self.do_compile(mode)
             self.is_compiled = True
 
-    def do_compile(self):
-        """Compile the score model module."""
-        self.forward = torch.compile(self.forward, dynamic=False, fullgraph=False)  # type: ignore
+    def do_compile(self, mode: str = "default"):
+        """Compile the trunk module."""
+        # NOTE: you should compile the submodules inside the trunk
+        # since the computation graph is changed depending on the
+        # number of recycling steps. Thus, compile the sub module
+        # instead of the whole trunk module.
+        raise NotImplementedError("do_compile method is not implemented yet.")
 
     @abstractmethod
     def forward(

--- a/src/kfold/model/modules/trunk/af3_trunk.py
+++ b/src/kfold/model/modules/trunk/af3_trunk.py
@@ -82,14 +82,17 @@ class AF3PairformerTrunk(BaseTrunk):
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
-    def do_compile(self):
+    def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
         self.pairformer_module = torch.compile(
-            self.pairformer_module, dynamic=False, fullgraph=False
+            self.pairformer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
         )  # type: ignore
 
     def forward(
@@ -132,6 +135,13 @@ class AF3PairformerTrunk(BaseTrunk):
         else:
             chunk_size_tri_attn = None
 
+        # Revert to uncompiled version for validation
+        pairformer_module: PairformerStack
+        if self.is_compiled and not self.training:
+            pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
+        else:
+            pairformer_module = self.pairformer_module
+
         # Line 6, z_hat, s_hat = 0, 0
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
@@ -142,6 +152,11 @@ class AF3PairformerTrunk(BaseTrunk):
             with torch.set_grad_enabled(enable_grad):
                 if enable_grad and torch.is_autocast_enabled():
                     torch.clear_autocast_cache()
+
+                if self.is_compiled and enable_grad and i > 0:
+                    # Clone the tensors for compilation.
+                    s_hat = s_hat.clone()
+                    z_hat = z_hat.clone()
 
                 # Line 8
                 z = z_init + self.linear_z(self.layernorm_z(z_hat))
@@ -158,13 +173,6 @@ class AF3PairformerTrunk(BaseTrunk):
                 s = s_init + self.linear_s(self.layernorm_s(s_hat))
 
                 # Line 12
-                # Revert to uncompiled version for validation
-                pairformer_module: PairformerStack
-                if self.is_compiled and not self.training:
-                    pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
-                else:
-                    pairformer_module = self.pairformer_module
-
                 s, z = pairformer_module(
                     s,
                     z,

--- a/src/kfold/model/modules/trunk/base.py
+++ b/src/kfold/model/modules/trunk/base.py
@@ -21,13 +21,13 @@ class BaseTrunk(torch.nn.Module, ABC):
         self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
-    def compile(self, compile: bool = True):
+    def compile(self, compile: bool = True, mode: str = "default"):
         """Compile the trunk module."""
         if compile:
-            self.do_compile()
+            self.do_compile(mode)
             self.is_compiled = True
 
-    def do_compile(self):
+    def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the

--- a/src/kfold/model/modules/trunk/boltz1_trunk.py
+++ b/src/kfold/model/modules/trunk/boltz1_trunk.py
@@ -94,14 +94,17 @@ class Boltz1PairformerTrunk(BaseTrunk):
         init.gating_init_(self.s_recycle.weight)
         init.gating_init_(self.z_recycle.weight)
 
-    def do_compile(self):
+    def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
         self.pairformer_module = torch.compile(
-            self.pairformer_module, dynamic=False, fullgraph=False
+            self.pairformer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
         )  # type: ignore
 
     def forward(

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -171,6 +171,27 @@ class KFoldTrunk(BaseTrunk):
         # Other options
         self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
 
+    def do_compile(self, mode: str = "default"):
+        """Compile the trunk module."""
+        # NOTE: you should compile the submodules inside the trunk
+        # since the computation graph is changed depending on the
+        # number of recycling steps. Thus, compile the sub module
+        # instead of the whole trunk module.
+        if self.use_ensemble:
+            self.ensemble_module = torch.compile(
+                self.ensemble_module,
+                mode=mode,
+                dynamic=False,
+                fullgraph=False,
+            )  # type: ignore
+
+        self.pairformer_module = torch.compile(
+            self.pairformer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=True,
+        )  # type: ignore
+
     def forward(
         self,
         s_inputs: torch.Tensor,
@@ -210,7 +231,14 @@ class KFoldTrunk(BaseTrunk):
         else:
             chunk_size_tri_attn = None
 
-        # Line 6, z_hat, s_hat = 0, 0
+        # Revert to uncompiled version for validation
+        pairformer_module: InterformerStack
+        if self.is_compiled and not self.training:
+            pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
+        else:
+            pairformer_module = self.pairformer_module
+
+        # z_hat, s_hat = 0, 0
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
 
@@ -220,6 +248,11 @@ class KFoldTrunk(BaseTrunk):
             with torch.set_grad_enabled(enable_grad):
                 if enable_grad and torch.is_autocast_enabled():
                     torch.clear_autocast_cache()
+
+                if self.is_compiled and enable_grad and i > 0:
+                    # Clone the tensors for compilation.
+                    s_hat = s_hat.clone()
+                    z_hat = z_hat.clone()
 
                 s = s_init + self.linear_s(self.layernorm_s(s_hat))
                 z = z_init + self.linear_z(self.layernorm_z(z_hat))
@@ -236,7 +269,7 @@ class KFoldTrunk(BaseTrunk):
                         use_cuequiv_kernels=self.kernel_config.cuequivariance,
                     )
 
-                s, z = self.pairformer_module(
+                s, z = pairformer_module(
                     s,
                     z,
                     mask=f_input.token.pad_mask,
@@ -244,7 +277,6 @@ class KFoldTrunk(BaseTrunk):
                     use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )
 
-                # Line 13
                 s_hat, z_hat = s, z
 
         s_trunk, z_trunk = s_hat, z_hat

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -189,7 +189,7 @@ class KFoldTrunk(BaseTrunk):
             self.pairformer_module,
             mode=mode,
             dynamic=False,
-            fullgraph=True,
+            fullgraph=False,
         )  # type: ignore
 
     def forward(

--- a/src/kfold/model/modules/trunk/pairmixer_trunk.py
+++ b/src/kfold/model/modules/trunk/pairmixer_trunk.py
@@ -72,14 +72,17 @@ class PairmixerTrunk(BaseTrunk):
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
-    def do_compile(self):
+    def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
         self.pairmixer_module = torch.compile(
-            self.pairmixer_module, dynamic=False, fullgraph=False
+            self.pairmixer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
         )  # type: ignore
 
     def forward(
@@ -119,12 +122,24 @@ class PairmixerTrunk(BaseTrunk):
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
 
+        # Revert to uncompiled version for validation
+        pairmixer_module: PairmixerStack
+        if self.is_compiled and not self.training:
+            pairmixer_module = self.pairmixer_module._orig_mod  # noqa: SLF001
+        else:
+            pairmixer_module = self.pairmixer_module
+
         for i in range(0, num_recycles + 1):
             enable_grad = self.training and i == num_recycles
 
             with torch.set_grad_enabled(enable_grad):
                 if enable_grad and torch.is_autocast_enabled():
                     torch.clear_autocast_cache()
+
+                if self.is_compiled and enable_grad and i > 0:
+                    # Clone the tensors for compilation.
+                    s_hat = s_hat.clone()
+                    z_hat = z_hat.clone()
 
                 # Line 8
                 z = z_init + self.linear_z(self.layernorm_z(z_hat))
@@ -141,13 +156,6 @@ class PairmixerTrunk(BaseTrunk):
                 s = s_init + self.linear_s(self.layernorm_s(s_hat))
 
                 # Line 12
-                # Revert to uncompiled version for validation
-                pairmixer_module: PairmixerStack
-                if self.is_compiled and not self.training:
-                    pairmixer_module = self.pairmixer_module._orig_mod  # noqa: SLF001
-                else:
-                    pairmixer_module = self.pairmixer_module
-
                 s, z = pairmixer_module(
                     s,
                     z,
@@ -180,9 +188,9 @@ class PairmixerformerTrunk(BaseTrunk):
         pairmixer_blocks: int = 42
         chunk_threshold: int = 384
 
-    def __init__(self, cfg: Config):
+    def __init__(self, cfg: Config, kernel_config):
         """Initialize the Pairmixerformer module."""
-        super().__init__(cfg)
+        super().__init__(cfg, kernel_config)
 
         if cfg.num_blocks < cfg.pairmixer_blocks:
             raise ValueError(
@@ -221,12 +229,18 @@ class PairmixerformerTrunk(BaseTrunk):
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
-    def do_compile(self):
+    def do_compile(self, mode: str = "default"):
         self.pairmixer_module = torch.compile(
-            self.pairmixer_module, dynamic=False, fullgraph=False
+            self.pairmixer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
         )  # type: ignore
         self.pairformer_module = torch.compile(
-            self.pairformer_module, dynamic=False, fullgraph=False
+            self.pairformer_module,
+            mode=mode,
+            dynamic=False,
+            fullgraph=False,
         )  # type: ignore
 
     def forward(
@@ -248,6 +262,14 @@ class PairmixerformerTrunk(BaseTrunk):
         else:
             chunk_size_tri_attn = None
 
+        # Revert to uncompiled version for validation
+        if self.is_compiled and not self.training:
+            pairmixer_module = self.pairmixer_module._orig_mod  # noqa: SLF001
+            pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
+        else:
+            pairmixer_module = self.pairmixer_module
+            pairformer_module = self.pairformer_module
+
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
 
@@ -257,6 +279,11 @@ class PairmixerformerTrunk(BaseTrunk):
             with torch.set_grad_enabled(enable_grad):
                 if enable_grad and torch.is_autocast_enabled():
                     torch.clear_autocast_cache()
+
+                if self.is_compiled and enable_grad and i > 0:
+                    # Clone the tensors for compilation.
+                    s_hat = s_hat.clone()
+                    z_hat = z_hat.clone()
 
                 # Line 8
                 z = z_init + self.linear_z(self.layernorm_z(z_hat))
@@ -273,14 +300,6 @@ class PairmixerformerTrunk(BaseTrunk):
                 s = s_init + self.linear_s(self.layernorm_s(s_hat))
 
                 # Line 12
-                # Revert to uncompiled version for validation
-                if self.is_compiled and not self.training:
-                    pairmixer_module = self.pairmixer_module._orig_mod  # noqa: SLF001
-                    pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
-                else:
-                    pairmixer_module = self.pairmixer_module
-                    pairformer_module = self.pairformer_module
-
                 s, z = pairmixer_module(
                     s,
                     z,

--- a/src/kfold/training/folding/loss/diffusion.py
+++ b/src/kfold/training/folding/loss/diffusion.py
@@ -96,7 +96,7 @@ class WeightedMSELoss(torch.nn.Module):
         x_pred: torch.Tensor,
         x_true: torch.Tensor,
         f_input: FoldingInput,
-        memory_efficient: bool = True,
+        remove_pad: bool = False,
     ) -> torch.Tensor:
         """Compute the weighted MSE loss.
 
@@ -108,8 +108,8 @@ class WeightedMSELoss(torch.nn.Module):
             Ground truth coordinates. Shape (B, N, L, 3).
         f_input : FoldingInput
             The FoldingInput object containing model inputs.
-        memory_efficient : bool
-            Whether to use memory efficient implementation.
+        remove_pad : bool
+            Whether to minimize the padding for memory efficiency.
 
         Returns
         -------
@@ -122,7 +122,7 @@ class WeightedMSELoss(torch.nn.Module):
         w = self.get_atom_weights(f_input)  # [B, L]
         mask = f_input.atom.resolved_mask  # [B, L]
 
-        if memory_efficient:
+        if remove_pad:
             # Minimize the number of padding
             pad_mask = f_input.atom.pad_mask  # [B, L]
             max_atoms = int(pad_mask.sum(dim=-1).max().clamp(min=1))


### PR DESCRIPTION
This PR enables torch compile for model training on DDP & multi-node environment. I found there is 10% speed-up with all the enhancements in this PR.

### torch compile
I introduced torch compile for trunk and score model. The recommended mode is `default`.
* trunk:
     * both `reduce-overhead` and `default` are allowed, however, the speed difference is marginal.
* score model:
    * On multi-gpu environment, I failed to compile model with `reduce-overhead` mode.

### match shape
I change to keep padding during loss computation.