### PR TITLE
synchronize recycling steps across all gpus during training

### DIFF
--- a/src/kfold/training/folding/training_module.py
+++ b/src/kfold/training/folding/training_module.py
@@ -134,7 +134,7 @@ class KFoldTrainingModule(pl.LightningModule):
         # Pre-sample recycling steps for training
         # This ensures all GPUs use the same recycling schedule
         rng = np.random.default_rng(seed=42)
-        self.recycles_per_step: list[int] = rng.integers(
+        self.recycles_per_step: np.ndarray = rng.integers(
             0,
             self.training_config.num_recycles + 1,
             size=100_000,

--- a/src/kfold/training/folding/training_module.py
+++ b/src/kfold/training/folding/training_module.py
@@ -131,6 +131,15 @@ class KFoldTrainingModule(pl.LightningModule):
 
         self.save_hyperparameters(to_dict(self.global_config))
 
+        # Pre-sample recycling steps for training
+        # This ensures all GPUs use the same recycling schedule
+        rng = np.random.default_rng(seed=42)
+        self.recycles_per_step: list[int] = rng.integers(
+            0,
+            self.training_config.num_recycles + 1,
+            size=100_000,
+        )
+
     def freeze_submodules(self):
         """Freeze submodules based on the training configuration."""
         # FIXME: (SeonghwanSeo) I did not test this function yet.
@@ -287,7 +296,9 @@ class KFoldTrainingModule(pl.LightningModule):
         f_input, _ = batch  # second one is full_structure_dict, not used in training step
 
         # Sample recycling steps
-        num_recycles = np.random.randint(0, training_config.num_recycles + 1)
+        # Use shared recycling schedule across all the gpus
+        idx = self.global_step % len(self.recycles_per_step)
+        num_recycles = int(self.recycles_per_step[idx])
 
         # Compute the forward pass
         out: dict[str, torch.Tensor] = self(


### PR DESCRIPTION
This pull request makes an improvement to how recycling steps are sampled during training in the `training_module.py`. Instead of randomly sampling recycling steps independently on each GPU, it introduces a pre-sampled, fixed recycling schedule that is shared across all GPUs. This ensures consistency and reproducibility in the recycling schedule during distributed training.

Key changes:

**Recycling step sampling improvements:**

* Added initialization of a large, fixed array (`self.recycles_per_step`) of pre-sampled recycling steps in the module's constructor, using a seeded random number generator for reproducibility.
* Updated the `training_step` method to use the shared recycling schedule by indexing into `self.recycles_per_step` with the current global step, ensuring all GPUs follow the same recycling schedule.