### PR TITLE
Allow custom manifest

### DIFF
--- a/configs/dataset/default.yaml
+++ b/configs/dataset/default.yaml
@@ -3,6 +3,7 @@ name: ???
 
 # Data paths
 data_path: <DATA_PATH_PLACEHOLDER>
+manifest_path: null # optionally provide a custom manifest path
 seed: null # should be null for data augmentation
 
 apo_init:

--- a/configs/train-esm2-ecsi-mini.yaml
+++ b/configs/train-esm2-ecsi-mini.yaml
@@ -37,9 +37,15 @@ train:
     train_datasets:
       - _yaml_: "dataset/rcsb-train.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260109/dataset/rcsb-train/
+        manifest_path: /mnt/parallel_storage/wykim_lab/icl_shwan/data/manifests/v260110/all/rcsb-train.json
+        apo_init:
+          translation_scale: 1.0
     val_datasets:
       - _yaml_: "dataset/rcsb-val.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260109/dataset/rcsb-val/
+        manifest_path: /mnt/parallel_storage/wykim_lab/icl_shwan/data/manifests/v260110/all/rcsb-val.json
+        apo_init:
+          translation_scale: 1.0
     pretrained_embedding:
       seq: esm2-3b
       seq_dim: 2560

--- a/scripts/process/manifest/extract_manifest.py
+++ b/scripts/process/manifest/extract_manifest.py
@@ -14,7 +14,7 @@ def parse_args():
         "--input",
         type=pathlib.Path,
         required=True,
-        help="Path to the original manifest.",
+        help="Path to the original JSON manifest.",
     )
     parser.add_argument(
         "-o",
@@ -28,6 +28,12 @@ def parse_args():
         type=str,
         required=True,
         choices=["complex-only", "non-nucleic", "pp-pl-only"],
+        help=(
+            "Filter to apply to the input manifest: "
+            "'complex-only' keeps only multi-chain complexes; "
+            "'non-nucleic' excludes complexes containing nucleic acid chains; "
+            "'pp-pl-only' keeps only protein-protein and protein-ligand complexes "
+        ),
     )
 
     args = parser.parse_args()
@@ -53,7 +59,7 @@ def main():
 
             def filter_func(m: Metadata) -> bool:
                 # Exclude if any chain is nucleic acid
-                return any(chain.ctype.is_nucleic_acid for chain in m.chains)
+                return not any(chain.ctype.is_nucleic_acid for chain in m.chains)
 
         case "pp-pl-only":
             print("Including only protein-protein and protein-ligand complex structures.")
@@ -62,6 +68,10 @@ def main():
             def filter_func(m: Metadata) -> bool:
                 if any(chain.ctype.is_nucleic_acid for chain in m.chains):
                     # Exclude nucleic acid chains
+                    return False
+                if all(chain.ctype.is_nonpolymer for chain in m.chains):
+                    # Need at least one polymer chain
+                    # NOTE: this is not required since they have been already excluded.
                     return False
                 if len([chain for chain in m.chains if not chain.ctype.is_ion]) < 2:
                     # Need at least two non-ion chains for PP or PL complex
@@ -83,11 +93,12 @@ def main():
     metadatas = list(filter(filter_func, metadatas))
 
     # Report filtering results
-    print(f"Filtered {total_count - len(metadatas)} nucleic-acid complexes ")
+    filtered_count = total_count - len(metadatas)
+    print(f"Filtered {filtered_count} entries.")
     print(f"Final count: {len(metadatas)}.")
 
     # Save the subset manifest
-    print(f"Saving the subset manifest to {args.output}...")
+    print(f"Saving the subset manifest to '{args.output}'...")
     with open(args.output, "w") as f:
         json.dump([r.to_dict() for r in metadatas], f, indent=2)
     print("Done.")

--- a/scripts/process/manifest/extract_manifest.py
+++ b/scripts/process/manifest/extract_manifest.py
@@ -1,0 +1,97 @@
+"""Construct the subset of manifest file"""
+
+import argparse
+import json
+import pathlib
+
+from kfold.data.types.metadata import Metadata
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Construct subset of manifest.")
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the original manifest.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the subset manifest to be created.",
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        required=True,
+        choices=["complex-only", "non-nucleic", "pp-pl-only"],
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    """Construct the subset of manifest file."""
+    args = parse_args()
+
+    # Define filter function
+    match args.filter:
+        case "complex-only":
+            print("Filtering out single-chain only structures.")
+
+            def filter_func(m: Metadata) -> bool:
+                # Include only if more than one chain
+                return len(m.chains) > 1
+
+        case "non-nucleic":
+            print("Excluding NA-NA, NA-ligand complex structures.")
+
+            def filter_func(m: Metadata) -> bool:
+                # Exclude if any chain is nucleic acid
+                return any(chain.ctype.is_nucleic_acid for chain in m.chains)
+
+        case "pp-pl-only":
+            print("Including only protein-protein and protein-ligand complex structures.")
+            print("NOTE: This will exclude single-protein and single-ion complexes.")
+
+            def filter_func(m: Metadata) -> bool:
+                if any(chain.ctype.is_nucleic_acid for chain in m.chains):
+                    # Exclude nucleic acid chains
+                    return False
+                if len([chain for chain in m.chains if not chain.ctype.is_ion]) < 2:
+                    # Need at least two non-ion chains for PP or PL complex
+                    return False
+                return True
+
+        case _:
+            raise ValueError(f"Unknown filter option: {args.filter}")
+
+    # Get metadatas
+    print("Loading metadatas...")
+    with open(args.input) as f:
+        metadata_dicts: list[dict] = json.load(f)
+    metadatas: list[Metadata] = [Metadata.from_dict(d) for d in metadata_dicts]
+    total_count = len(metadatas)
+    print(f"Total entries found: {total_count}")
+
+    # Apply the filter
+    metadatas = list(filter(filter_func, metadatas))
+
+    # Report filtering results
+    print(f"Filtered {total_count - len(metadatas)} nucleic-acid complexes ")
+    print(f"Final count: {len(metadatas)}.")
+
+    # Save the subset manifest
+    print(f"Saving the subset manifest to {args.output}...")
+    with open(args.output, "w") as f:
+        json.dump([r.to_dict() for r in metadatas], f, indent=2)
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/process/rcsb/b3_construct_training_set.py
+++ b/scripts/process/rcsb/b3_construct_training_set.py
@@ -47,7 +47,7 @@ def main():
         pickle.dump(metadata_dicts, f)
     print(f"Saved manifest (pickle) to {manifest_path}")
 
-    # Save to json file (human-readable; not used in pipeline)
+    # Save to json file (human-readable)
     manifest_path: pathlib.Path = data_dir / "manifest.json"
     with open(manifest_path, "w") as f:
         json.dump(metadata_dicts, f, indent=2)

--- a/scripts/process/rcsb/b4_construct_validation_set.py
+++ b/scripts/process/rcsb/b4_construct_validation_set.py
@@ -83,7 +83,7 @@ def main():
         pickle.dump(metadata_dicts, f)
     print(f"Saved manifest (pickle) to {manifest_path}")
 
-    # Save to a json file (human-readable; not used in pipeline)
+    # Save to a json file (human-readable)
     manifest_path: pathlib.Path = data_dir / "manifest.json"
     with open(manifest_path, "w") as f:
         json.dump(metadata_dicts, f, indent=2)

--- a/src/kfold/training/dataset/datamodule.py
+++ b/src/kfold/training/dataset/datamodule.py
@@ -86,7 +86,9 @@ class TrainingDataModule(pl.LightningDataModule):
         # Print dataset info
         for d in multi_ds.datasets:
             self.print_rank_zero(
-                f"Constructed training dataset '{d.name}' with {len(d)} samples."
+                f"Constructed training dataset '{d.name}':\n"
+                f"  Num complexes: {len(d.metadatas)}\n"
+                f"  Num samples: {len(d)}"
             )
         return multi_ds
 
@@ -105,7 +107,9 @@ class TrainingDataModule(pl.LightningDataModule):
             safe_load=self.config.safe_load,
         )
         self.print_rank_zero(
-            f"Constructed validation dataset '{ds.name}' with {len(ds)} samples."
+            f"Constructed validation dataset '{ds.name}':\n"
+            f"  Num complexes: {len(ds.metadatas)}\n"
+            f"  Num samples: {len(ds)}"
         )
         return ds
 

--- a/src/kfold/training/dataset/dataset.py
+++ b/src/kfold/training/dataset/dataset.py
@@ -15,10 +15,10 @@ rcsb-train/
     struct_embedding/
         saprot/
     apo/
-        ESMFold/
+        esmfold/
             uniq_prot1-esmfold.pdb
             ...
-        AFDB/
+        afdb/
             F-P01116-F1-model_v6.cif.gz
             ...
 afdb-distillation/ ...
@@ -105,16 +105,18 @@ class DatasetConfig:
         Name of the dataset.
     data_path : str | Path
         Path to the dataset directory.
+    manifest_path : str | Path | None
+        Optional path to the custom manifest file.
     seed : int | None
         Random seed for data loading.
-    apo_initialize : apo_initialize.ApoInitializerConfig
+    apo_init : apo_initialize.ApoInitializerConfig
         Configuration for apo structure initialization.
     """
 
     name: str
     data_path: str | Path
+    manifest_path: str | Path | None = None
     seed: int | None = None
-
     apo_init: apo_initialization.ApoInitializerConfig = dataclasses.field(
         default_factory=apo_initialization.ApoInitializerConfig
     )
@@ -195,7 +197,7 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         # === Initialize parameters === #
         self.config: DatasetConfig = config
         self.name: str = config.name
-        self.data_root = Path(config.data_path)
+        self.data_root: Path = Path(config.data_path)
         self.seed: int | None = config.seed
         self.return_symmetry: bool = return_symmetry
         self.return_structure: bool = return_structure
@@ -259,7 +261,9 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         self.ccd: CCD = ccd
 
         # Metadata
-        self.metadatas: list[Metadata] = self.load_manifest()
+        self.metadatas: list[Metadata] = self.load_manifest(
+            custom_manifest=config.manifest_path  # optional custom manifest path
+        )
 
         # Lookup table
         self.lookup_table: dict = self.load_lookup_table()
@@ -283,8 +287,11 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         return len(self.metadatas)
 
     # === Setup === #
-    def load_manifest(self) -> list[Metadata]:
-        manifest_path = self.data_root / "manifest.json"
+    def load_manifest(self, custom_manifest: str | Path | None = None) -> list[Metadata]:
+        if custom_manifest is not None:
+            manifest_path = Path(custom_manifest)
+        else:
+            manifest_path = self.data_root / "manifest.json"
         if not manifest_path.exists():
             raise FileNotFoundError(f"Manifest file {manifest_path} not found.")
         with open(manifest_path) as f:

--- a/src/kfold/training/dataset/dataset.py
+++ b/src/kfold/training/dataset/dataset.py
@@ -109,7 +109,7 @@ class DatasetConfig:
         Optional path to the custom manifest file.
     seed : int | None
         Random seed for data loading.
-    apo_init : apo_initialize.ApoInitializerConfig
+    apo_init : ApoInitializerConfig
         Configuration for apo structure initialization.
     """
 


### PR DESCRIPTION
This pull request introduces support for custom manifest files in dataset configuration and improves dataset reporting and manifest processing. The changes make it easier to specify and filter dataset manifests, enhance reporting on dataset construction, and add a utility script for manifest file extraction.

**Manifest file support and dataset configuration:**

* Added an optional `manifest_path` field to dataset configuration (`default.yaml`, `DatasetConfig` in `dataset.py`) and updated training/validation config files to use this field, allowing users to specify a custom manifest file for datasets.
* Modified the dataset loading logic to use the custom manifest path if provided, falling back to the default `manifest.json` otherwise. 

**Manifest processing and utilities:**

* Added a new script `extract_manifest.py` to construct filtered subsets of manifest files based on user-specified criteria (e.g., complex-only, non-nucleic, protein-protein/protein-ligand only). 