### PR TITLE
Hotfix - fix memory leakage

### DIFF
--- a/scripts/process/rcsb/b4_construct_validation_set.py
+++ b/scripts/process/rcsb/b4_construct_validation_set.py
@@ -119,7 +119,7 @@ def main():
             n_rna += 1
         if any(ctype.is_dna for ctype in ctypes):
             n_dna += 1
-        if any(ctype.is_ligand for ctype in ctypes):
+        if any(ctype.is_small_molecule for ctype in ctypes):
             n_ligands += 1
         if any(ctype.is_ion for ctype in ctypes):
             n_ions += 1
@@ -146,15 +146,15 @@ def main():
             n_protein_dna += 1
 
         if any(ctype.is_protein for ctype in ctypes) and any(
-            ctype.is_ligand for ctype in ctypes
+            ctype.is_small_molecule for ctype in ctypes
         ):
             n_protein_ligand += 1
         if any(ctype.is_rna for ctype in ctypes) and any(
-            ctype.is_ligand for ctype in ctypes
+            ctype.is_small_molecule for ctype in ctypes
         ):
             n_rna_ligand += 1
         if any(ctype.is_dna for ctype in ctypes) and any(
-            ctype.is_ligand for ctype in ctypes
+            ctype.is_small_molecule for ctype in ctypes
         ):
             n_dna_ligand += 1
 

--- a/src/kfold/constants/chain.py
+++ b/src/kfold/constants/chain.py
@@ -35,6 +35,10 @@ class ChainType(IntEnum):
 
     @property
     def is_ligand(self) -> bool:
+        return self in {ChainType.LIGAND, ChainType.ION}
+
+    @property
+    def is_small_molecule(self) -> bool:
         return self is ChainType.LIGAND
 
     @property

--- a/src/kfold/data/pipelines/_apo_prior.py
+++ b/src/kfold/data/pipelines/_apo_prior.py
@@ -16,7 +16,7 @@ from kfold.data.utils.simulation.langevin_dynamics import run_langevin_dynamics
 class PolymerPriorConfig:
     """Configuration for PolymerPriorSampler."""
 
-    type: str = "globular"  # Type of prior: "null", "zero", "normal", "globular".
+    type: str | None = "globular"  # Type of prior: "null", "zero", "normal", "globular".
     # Langevin dynamics parameters.
     num_steps: int = 64
     dt: float = 0.25
@@ -38,7 +38,7 @@ class PolymerPriorSampler:
         self.bond_r: float = config.bond_r
         self.sphere_r: float = config.sphere_r
 
-        assert self.prior_type in ["null", "zero", "normal", "globular"], (
+        assert self.prior_type in [None, "null", "zero", "normal", "globular"], (
             f"Unknown prior type: {self.prior_type}"
         )
 
@@ -61,7 +61,7 @@ class PolymerPriorSampler:
         x_init : np.ndarray
             Sampled coordinates of shape [L, Natom, 3].
         """
-        if self.prior_type == "null":
+        if self.prior_type in ("null", None):
             return self.sample_null(mask)
         elif self.prior_type == "zero":
             return self.sample_zero(mask)

--- a/src/kfold/data/pipelines/apo_initialization.py
+++ b/src/kfold/data/pipelines/apo_initialization.py
@@ -10,7 +10,7 @@ from kfold.data.types.ccd import CCD, Component
 from kfold.data.types.structure import RefStructure
 from kfold.data.utils.io.structure import read_protein_structure
 from kfold.utils.geometry.random_augment import center_random_augmentation
-from kfold.utils.geometry.rigid_align import compute_rmsd, weighted_rigid_align
+from kfold.utils.geometry.rigid_align import weighted_rigid_align
 
 from ._apo_perturbation import ApoPerturbation, ApoPerturbationConfig
 from ._apo_prior import PolymerPriorConfig, PolymerPriorSampler
@@ -25,11 +25,10 @@ NUM_ATOMS_PER_RESIDUE: dict[C.ChainType, int] = {
 # === Helper functions === #
 @lru_cache(32)
 def get_ambiguous_atoms_in_residue(
-    res_name: str | C.ResidueName,
+    res_name: str,
 ) -> list[list[int]] | None:
     """Get the indices of ambiguous atoms for a given residue type."""
-    if isinstance(res_name, str):
-        res_name: C.ResidueName = C.ResidueName[res_name]
+    res_name: C.ResidueName = C.ResidueName[res_name]
     if res_name not in C.atom.RESIDUE_AMBIGUOUS_ATOMS:
         # If there is no ambiguous atoms, return empty list
         return None
@@ -51,13 +50,9 @@ def get_ambiguous_atoms_in_residue(
 def get_molecule_symmetries(
     ccd_id: str,
     mol_atom_names: list[str],
-    ccd: CCD,
+    ref_mol: Component,
 ) -> list[list[int]] | None:
     """Get molecule's symmetries from ccd."""
-    if ccd_id not in ccd:
-        return None
-
-    ref_mol: Component = ccd[ccd_id]
     symmetries = ref_mol.symmetries
     if symmetries is None or len(symmetries) <= 1:
         # No symmetries
@@ -134,6 +129,49 @@ def get_zero_coordinates(ctype: C.ChainType, ccd_sequence: list[str]) -> np.ndar
     mask = get_valid_atom_mask(ctype, ccd_sequence)
     coords[mask] = 0.0
     return coords
+
+
+def compute_minimal_rmsd_no_svd(
+    coords: np.ndarray, target: np.ndarray, mask: np.ndarray
+) -> float:
+    """Compute minimal RMSD between two sets of coordinates without SVD.
+    NOTE(SeonghwanSeo): This function replaces the SVD-based RMSD computation
+    for avoiding memory leakage issues in pytorch DataLoader workers.
+    """
+    # 1. Masking & Centering
+    p = coords[mask]
+    q = target[mask]
+    n = p.shape[0]
+
+    p_center = p.mean(axis=0)
+    q_center = q.mean(axis=0)
+    p_centered = p - p_center
+    q_centered = q - q_center
+
+    # E0 = sum(|p|^2) + sum(|q|^2)
+    e0 = np.sum(p_centered**2) + np.sum(q_centered**2)
+
+    # Covariance Matrix H (3x3)
+    # H = P.T @ Q
+    h = p_centered.T @ q_centered
+
+    # Compute singular values via eigen decomposition of H^T H
+    s_sq_matrix = h.T @ h
+    eigenvalues = np.linalg.eigvalsh(s_sq_matrix)
+
+    # Singular values are the square roots of eigenvalues
+    eigenvalues = np.clip(eigenvalues, 0, None)
+    singular_values = np.sqrt(eigenvalues)
+    if np.linalg.det(h) < 0:
+        singular_values[0] = -singular_values[0]
+
+    trace_max = np.sum(singular_values)
+    rmsd_sq = (e0 - 2 * trace_max) / n
+
+    # Numerical stability
+    if rmsd_sq < 0:
+        return 0.0
+    return np.sqrt(rmsd_sq)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -327,9 +365,20 @@ class ApoInitializer:
                 if entity_id in lookup:
                     # Load apo structure from file
                     assert ctype.is_protein, "Only protein chains have apo structures."
-                    apo_coords = self.get_protein_apo_structure(
-                        ccd_sequence, lookup[entity_id], rng
-                    )
+                    try:
+                        apo_coords = self.get_protein_apo_structure(
+                            ccd_sequence, lookup[entity_id], rng
+                        )
+                    except Exception as e:
+                        # NOTE: There are some errors in rcsb-to-uniprot mapping file.
+                        # For robustness, we fall back to prior sampling if loading fails.
+                        print(
+                            "Failed to load apo structure for entity "
+                            f"{entity_id}: {e}. Sampling from prior instead."
+                        )
+                        apo_coords = self.sample_apo_structure_from_prior(
+                            ccd_sequence, ctype, rng
+                        )
                 else:
                     # No apo structure available, sample from prior
                     apo_coords = self.sample_apo_structure_from_prior(
@@ -617,10 +666,16 @@ class ApoInitializer:
 
         # First, chain permutation
         # RNG state is used for sampling permutations when too many exist
-        self.find_best_chain_permutation(struct, max_permutations=100, rng=rng)
+        try:
+            self.find_best_chain_permutation(struct, max_permutations=100, rng=rng)
+        except Exception as e:
+            print(f"Failed to find best chain permutation: {e}. Skipping permutation.")
 
         # Second, residue-level permutation (e.g., flipping)
-        self.find_best_residue_permutation(struct)
+        try:
+            self.find_best_residue_permutation(struct)
+        except Exception as e:
+            print(f"Failed to find best residue permutation: {e}. Skipping permutation.")
 
     def find_best_chain_permutation(
         self,
@@ -630,17 +685,46 @@ class ApoInitializer:
     ) -> None:
         # === 1. Prepare coordinates === #
         entity_ids: list[int] = sorted(set(chain.entity_id for chain in struct.chains))
-        entity_order: list[int] = [chain.entity_id for chain in struct.chains]
         entity_apo_dict: dict[int, list[np.ndarray]] = defaultdict(list)
+        entity_ctypes: dict[int, C.ChainType] = {}
         for chain in struct.chains:
             entity_apo_dict[chain.entity_id].append(chain.atom.apo_coords.copy())
+            entity_ctypes[chain.entity_id] = chain.ctype
+
+        for eid in entity_ids:
+            apo_coords_list = entity_apo_dict[eid]
+
+            # Check if all chains are homologous (same length)
+            lengths = [coords.shape[0] for coords in apo_coords_list]
+            is_homologous: bool = all(v == lengths[0] for v in lengths)
+            if not is_homologous:
+                assert entity_ctypes[eid].is_small_molecule, (
+                    "Non-homologous chains are only supported for covalent ligands."
+                )
+                entity_ids.remove(eid)
+
+            # Check the chain apo coordinates are provided
+            elif any(np.isnan(coords).all() for coords in apo_coords_list):
+                # If any chain has no apo coordinates, remove from permutation
+                entity_ids.remove(eid)
+
+        perm_chains = [chain for chain in struct.chains if chain.entity_id in entity_ids]
+        entity_order = [chain.entity_id for chain in perm_chains]
+
+        if len(perm_chains) == 0:
+            # No chains to permute
+            return
+
+        # If the total number of resolved apo atoms is less than 5, skip permutation
+        if sum(chain.atom.is_apo_resolved.sum() for chain in perm_chains) < 5:
+            return
 
         # === 2. Anchor Selection for Alignment === #
         entity_anchors: dict[int, np.ndarray] = {}
         entity_anchor_weights: dict[int, np.ndarray] = {}
         entity_anchor_coords: dict[int, list[np.ndarray]] = {}
 
-        for chain in struct.chains:
+        for chain in perm_chains:
             eid = chain.entity_id
             if eid in entity_anchors:
                 continue
@@ -652,6 +736,7 @@ class ApoInitializer:
                 idx = np.where(chain.atom.name == "C1'")[0]
             else:
                 idx = np.arange(chain.num_atoms)
+
             if len(idx) == 0:
                 idx = np.arange(chain.num_atoms)
 
@@ -659,20 +744,19 @@ class ApoInitializer:
             stride = max(1, len(idx) // 20)
             idx = idx[::stride]
             entity_anchors[eid] = idx
-            entity_anchor_weights[eid] = np.full(len(idx), 1.0 / len(idx))
+            entity_anchor_weights[eid] = np.full(
+                len(idx), chain.num_atoms / len(idx), dtype=np.float32
+            )
             entity_anchor_coords[eid] = [coords[idx] for coords in entity_apo_dict[eid]]
 
         align_weights = np.concatenate(
-            [entity_anchor_weights[chain.entity_id] for chain in struct.chains], axis=0
+            [entity_anchor_weights[chain.entity_id] for chain in perm_chains], axis=0
         )
         del entity_anchor_weights
 
         # === 3. Prepare label centers and masks === #
         label_centers = np.concatenate(
-            [
-                chain.atom.coords[entity_anchors[chain.entity_id]]
-                for chain in struct.chains
-            ],
+            [chain.atom.coords[entity_anchors[chain.entity_id]] for chain in perm_chains],
             axis=0,
         )
         label_mask = np.isfinite(label_centers).all(axis=-1)
@@ -733,8 +817,10 @@ class ApoInitializer:
         counts = defaultdict(int)
         if best_permutation is not None:
             # Reorder apo coordinates according to best permutation
-            for chain in struct.chains:
+            for chain in perm_chains:
                 eid = chain.entity_id
+                if eid not in entity_ids:
+                    continue
                 orig_idx = counts[eid]  # index in the entity
                 perm_idx = best_permutation[eid][orig_idx]
                 if orig_idx != perm_idx:
@@ -752,6 +838,7 @@ class ApoInitializer:
         struct : RefStructure
             Reference structure containing holo coordinates.
         """
+        component_cache: dict[str, Component] = {}
         for chain in struct.chains:
             ctype = chain.ctype
 
@@ -772,20 +859,21 @@ class ApoInitializer:
                 if ctype.is_polymer and chain.residue.is_standard[res_i]:
                     # Get ambiguous atom permutations for this standard residue
                     perms = get_ambiguous_atoms_in_residue(res_name)
-                    if perms is None:
-                        # No ambiguous atoms for this residue
-                        continue
-
                 elif res_name in self.ccd:
-                    # Get molecule symmetries from CCD
+                    if res_name not in component_cache:
+                        # Load reference molecule from CCD
+                        ref_mol = self.ccd[res_name]
+                        # Cache the component
+                        component_cache[res_name] = ref_mol
+                    else:
+                        ref_mol = component_cache[res_name]
                     atom_names: list[str] = chain.atom.name[atom_st:atom_end].tolist()
-                    perms = get_molecule_symmetries(res_name, atom_names, self.ccd)
-                    if perms is None:
-                        # No symmetries for this molecule
-                        continue
-
+                    perms = get_molecule_symmetries(res_name, atom_names, ref_mol)
                 else:
-                    # No symmetry information available
+                    perms = None
+
+                if perms is None:
+                    # No ambiguous atoms for this residue
                     continue
 
                 # Find the best permutation
@@ -796,16 +884,17 @@ class ApoInitializer:
                 res_apo_coords = chain.atom.apo_coords[atom_st:atom_end]  # [num_atoms, 3]
                 res_holo_mask = np.isfinite(res_holo_coords).all(-1)  # [num_atoms,]
                 res_apo_mask = np.isfinite(res_apo_coords).all(-1)  # [num_atoms,]
+                if res_holo_mask.sum() < 5:
+                    continue  # Not enough resolved atoms to align
 
                 for perm in perms:
                     permuted_apo_mask = res_apo_mask[perm]
                     align_mask = res_holo_mask & permuted_apo_mask
                     if np.sum(align_mask) < 5:
                         continue  # Not enough resolved atoms to align
-
                     permuted_apo_coords = res_apo_coords[perm, :]
-                    rmsd = compute_rmsd(
-                        permuted_apo_coords, res_holo_coords, align_mask, align=True
+                    rmsd = compute_minimal_rmsd_no_svd(
+                        permuted_apo_coords, res_holo_coords, align_mask
                     )
                     if rmsd < min_rmsd:
                         min_rmsd = rmsd
@@ -832,10 +921,10 @@ class ApoInitializer:
             Reference structure containing apo coordinates.
         """
         for chain in struct.chains:
-            apo_coords = chain.atom.apo_coords
+            apo_coords: np.ndarray = chain.atom.apo_coords
 
             # Mask of valid atoms: [N_atoms]
-            atom_mask: np.ndarray = np.isfinite(apo_coords).all(axis=-1)
+            atom_mask: np.ndarray = chain.atom.is_apo_resolved
 
             # Check if any atoms are missing
             if atom_mask.all():

--- a/src/kfold/data/pipelines/apo_initialization.py
+++ b/src/kfold/data/pipelines/apo_initialization.py
@@ -691,7 +691,7 @@ class ApoInitializer:
             entity_apo_dict[chain.entity_id].append(chain.atom.apo_coords.copy())
             entity_ctypes[chain.entity_id] = chain.ctype
 
-        for eid in entity_ids:
+        for eid in list(entity_ids):
             apo_coords_list = entity_apo_dict[eid]
 
             # Check if all chains are homologous (same length)

--- a/src/kfold/data/pipelines/tokenization.py
+++ b/src/kfold/data/pipelines/tokenization.py
@@ -1,5 +1,7 @@
 """Tokenization pipeline for structures."""
 
+from functools import lru_cache
+
 import numpy as np
 from rdkit import Chem
 
@@ -98,6 +100,17 @@ def tokenize_structure(
     struct: TokenizedStructure
         The parsed tokenized structure.
     """
+
+    @lru_cache(maxsize=128)
+    def get_ccd_component(ccd_name: str) -> Component:
+        """Get CCD component with caching.
+
+        NOTE (SeonghwanSeo): CCD.__getitem__ deserialize the Component,
+        which is time-consuming. Therefore, we cache the Component objects here.
+        The cache is removed when the function is terminated.
+        """
+        return ccd[ccd_name]
+
     rng = rng or np.random.default_rng()
 
     conformer_mode = "auto"
@@ -316,7 +329,7 @@ def tokenize_structure(
                 ref_mol: Component = Component.from_smiles(ccd_name, smiles, num_confs=1)
             else:
                 assert ccd_name in ccd, f"Residue name {ccd_name} not found in CCD."
-                ref_mol: Component = ccd[ccd_name]
+                ref_mol: Component = get_ccd_component(ccd_name)
 
             # Get reference conformer positions with random augmentation
             ref_pos: np.ndarray = ref_mol.get_conformer(conformer_mode, rng)  # type: ignore

--- a/src/kfold/data/types/ccd.py
+++ b/src/kfold/data/types/ccd.py
@@ -184,9 +184,9 @@ class Component:
         return pickle.dumps(self.to_dict())
 
     @classmethod
-    def from_bytes(cls, date_bytes: bytes) -> Self:
+    def from_bytes(cls, data_bytes: bytes) -> Self:
         """Create a Component instance from bytes."""
-        return cls.from_dict(pickle.loads(date_bytes))
+        return cls.from_dict(pickle.loads(data_bytes))
 
     def to_dict(self) -> dict:
         """Convert the Component instance to a dictionary without deepcopy"""

--- a/src/kfold/data/types/ccd.py
+++ b/src/kfold/data/types/ccd.py
@@ -115,7 +115,8 @@ def get_model_coordinates(
 @dataclasses.dataclass(frozen=True, slots=True)
 class Component:
     """Base class for data processing components.
-    NOTE: Skip field validation to reduce overhead.
+    NOTE:
+    - Skip field validation to reduce overhead.
 
     Attributes
     ----------
@@ -177,6 +178,15 @@ class Component:
     def num_non_leaving_atoms(self) -> int:
         """Get the number of non-leaving atoms in the component."""
         return int(np.sum(~self.is_leaving_atom))
+
+    def to_bytes(self) -> bytes:
+        """Convert the Component instance to bytes."""
+        return pickle.dumps(self.to_dict())
+
+    @classmethod
+    def from_bytes(cls, date_bytes: bytes) -> Self:
+        """Create a Component instance from bytes."""
+        return cls.from_dict(pickle.loads(date_bytes))
 
     def to_dict(self) -> dict:
         """Convert the Component instance to a dictionary without deepcopy"""
@@ -616,30 +626,55 @@ class Component:
 
 
 class CCD(Mapping[str, Component]):
-    """Common Component Dictionary (CCD) for data processing components."""
+    """Common Component Dictionary (CCD) for data processing components.
 
-    def __init__(self, components: dict[str, Component]) -> None:
-        self.components: dict[str, Component] = components
+    NOTE: (SeonghwanSeo) This class only contains the serialized bytes of each
+    component instead of objects to avoid memory leakage when used in multiprocessing
+    (e.g., DataLoader in PyTorch). Each component is deserialized on-the-fly when
+    accessed. This may introduce some overhead due to repeated deserialization.
+    Therefore, it is recommended to use caching mechanisms (e.g., `functools.lru_cache`).
+
+    example:
+
+    ```python
+    def process(..., ccd: CCD):
+        @lru_cache(maxsize=128)
+        def get_ccd_component(ccd_name: str) -> Component:
+            return ccd[ccd_name]
+
+        comp = get_ccd_component("ALA") # deserialized
+        comp = get_ccd_component("ALA") # cached
+        ...
+    ```
+
+    """
+
+    def __init__(self, component_bytes: dict[str, bytes]) -> None:
+        self.component_bytes: dict[str, bytes] = component_bytes
 
     def __keys__(self):
-        return self.components.keys()
-
-    def __getitem__(self, key: str) -> Component:
-        return self.components[key]
-
-    def __iter__(self):
-        return iter(self.components)
+        return self.component_bytes.keys()
 
     def __len__(self) -> int:
-        return len(self.components)
+        return len(self.component_bytes)
+
+    def __iter__(self):
+        return iter(self.component_bytes)
+
+    def __getitem__(self, key: str) -> Component:
+        return self.get_component(key)
+
+    def get_component(self, code: str) -> Component:
+        """Get a component by its code."""
+        return Component.from_bytes(self.component_bytes[code])
 
     def copy(self) -> Self:
         """Create a shallow copy of the CCD instance."""
-        return self.__class__(self.components.copy())
+        return self.__class__(self.component_bytes.copy())
 
     def add_component(self, component: Component) -> None:
         """Add a new component to the CCD."""
-        self.components[component.code] = component
+        self.component_bytes[component.code] = component.to_bytes()
 
     def save(self, save_path: str | pathlib.Path) -> None:
         """Save the CCD instance to a file.
@@ -649,9 +684,8 @@ class CCD(Mapping[str, Component]):
         save_path : str | pathlib.Path
             The path to save the CCD file.
         """
-        dicts = {code: comp.to_dict() for code, comp in self.components.items()}
         with open(save_path, "wb") as f:
-            pickle.dump(dicts, f)
+            pickle.dump(self.component_bytes, f)
 
     @classmethod
     def load(cls, load_path: str | pathlib.Path) -> Self:
@@ -669,7 +703,8 @@ class CCD(Mapping[str, Component]):
         """
         with open(load_path, "rb") as f:
             dicts = pickle.load(f)
-        components = {
-            code: Component.from_dict(comp_dict) for code, comp_dict in dicts.items()
-        }
+        if isinstance(next(iter(dicts.values())), bytes):
+            return cls(dicts)
+        # Convert from dict to bytes for backward compatibility
+        components = {code: pickle.dumps(comp_dict) for code, comp_dict in dicts.items()}
         return cls(components)

--- a/src/kfold/data/types/structure.py
+++ b/src/kfold/data/types/structure.py
@@ -357,6 +357,28 @@ class Atom:
             "apo_plddt": np.float16,
         }
 
+    @property
+    def is_resolved(self) -> np.ndarray:
+        """Get mask of resolved atoms in holo structure.
+
+        Returns
+        -------
+        holo_mask: np.ndarray (bool)
+            Shape [Natom,], bool
+        """
+        return np.isfinite(self.coords).all(axis=-1)
+
+    @property
+    def is_apo_resolved(self) -> np.ndarray:
+        """Get mask of resolved atoms in apo structure.
+
+        Returns
+        -------
+        apo_mask: np.ndarray (bool)
+            Shape [Natom,], bool
+        """
+        return np.isfinite(self.apo_coords).all(axis=-1)
+
 
 @dataclasses.dataclass(frozen=True)
 class Bond:

--- a/src/kfold/training/dataset/datamodule.py
+++ b/src/kfold/training/dataset/datamodule.py
@@ -160,8 +160,8 @@ class TrainingDataModule(pl.LightningDataModule):
             shuffle=False,
             collate_fn=collate,
             num_workers=self.config.num_workers,
-            pin_memory=self.config.pin_memory,
-            persistent_workers=True if self.config.num_workers > 0 else False,
+            pin_memory=False,
+            persistent_workers=False,
         )
 
     def print_rank_zero(self, msg: str, prefix: str = "[DataModule] ") -> None:

--- a/src/kfold/training/dataset/dataset.py
+++ b/src/kfold/training/dataset/dataset.py
@@ -255,6 +255,12 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
                 config.apo_init.apo_perturbation.rieprody.metric_lmdb_path = (
                     rieprody_lmdb_path
                 )
+        else:
+            assert (
+                config.apo_init.use_perturbation is False
+                or config.apo_init.apo_perturbation is None
+                or config.apo_init.apo_perturbation.rieprody is None
+            ), "RieProDy LMDB path not found but rieprody perturbation is enabled."
 
         # === Load dataset components === #
         # CCD (shared across datasets)
@@ -345,8 +351,8 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
                 # Select apo structure (randomly if multiple)
                 if len(apo_list) == 0:
                     print(
-                        "Warning: No apo structure found for entity "
-                        f"{entity_id} in entry {name}."
+                        "Warning: No available apo structure found "
+                        f"for entity {entity_id} in entry {name}."
                     )
                     continue
                 elif len(apo_list) == 1:
@@ -362,10 +368,7 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
                 # Check apo structure file existence
                 apo_path = apo_dir / source / path
                 if not apo_path.exists():
-                    print(
-                        "Warning: Apo structure file not found for entity "
-                        f"{entity_id} in entry {name}."
-                    )
+                    print(f"Warning: Apo structure file not found: {apo_path}.")
                     continue
 
                 # Get lmdb key


### PR DESCRIPTION
There is memory leakage in `OT-permutation` process due to repeated numpy svd operation (O(L))
This PR fixes this issue by implementing alternative rmsd calculation without svd operation.
Moreover, some minor bugs are also fixed. (e.g., a mismatch in the number of atoms in covalent inhibitor ligands).