### PR TITLE
Add trunk option -- split_intra_inter_channels

### DIFF
--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -8,6 +8,7 @@ interformer:
   num_blocks: 48
   dropout: 0.25
   skip_tri_attn: false
+  split_intra_inter_channels: false
 ensemble_module:
   channel_struct_input: 0 # to be filled in by the ensemble config
   channel_struct: 128

--- a/configs/train-esm2-edm-mini.yaml
+++ b/configs/train-esm2-edm-mini.yaml
@@ -9,6 +9,7 @@ model:
       num_blocks: 2
     interformer:
       num_blocks: 16
+      split_intra_inter_channels: true # performance was improved; experimental
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
@@ -41,9 +42,18 @@ train:
     train_datasets:
       - _yaml_: "dataset/rcsb-train.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260109/dataset/rcsb-train/
+        apo_init:
+          prior_sampler:
+            type: null
+          apo_perturbation:
+            rieprody:
+              rmsd_threshold: 15.0
     val_datasets:
       - _yaml_: "dataset/rcsb-val.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260109/dataset/rcsb-val/
+        apo_init:
+          prior_sampler:
+            type: null
     pretrained_embedding:
       seq: esm2-3b
       seq_dim: 2560

--- a/src/kfold/model/layers/kfold/diffusion.py
+++ b/src/kfold/model/layers/kfold/diffusion.py
@@ -142,6 +142,7 @@ class DiffusionModuleWithApo(nn.Module):
         s_trunk: torch.Tensor,
         z_trunk: torch.Tensor,
         model_cache: dict | None = None,
+        use_cuequiv_kernels: bool = False,
     ) -> torch.Tensor:
         """Forward pass of diffusion score model.
 
@@ -210,6 +211,7 @@ class DiffusionModuleWithApo(nn.Module):
             s=s,  # [B, N, Lt, c_s]
             z=z,  # [B, 1, Lt, Lt, c_z], broadcasted to [B, N, Lt, Lt, c_z]
             attn_mask=token_mask,  # [B, 1, Lt], broadcasted to [B, N, Lt]
+            use_cuequiv_kernels=use_cuequiv_kernels,
         )
         a = self.layernorm_a(a)
 

--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -74,6 +74,7 @@ class InterformerStack(nn.Module):
         s: torch.Tensor,
         z: torch.Tensor,
         mask: torch.Tensor,
+        intra_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
         use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -87,6 +88,8 @@ class InterformerStack(nn.Module):
             The pairwise embeddings
         mask : torch.Tensor
             The token mask
+        intra_mask : torch.Tensor
+            The intra-chain mask
         chunk_size_tri_attn : int | None, optional
             The chunk size for triangle attention, by default None
         use_cuequiv_kernels : bool, optional
@@ -111,6 +114,7 @@ class InterformerStack(nn.Module):
             partial(
                 b,
                 single_mask=mask,
+                intra_mask=intra_mask,
                 pair_mask=pair_mask,
                 chunk_size_tri_attn=chunk_size_tri_attn,
                 use_cuequiv_kernels=use_cuequiv_kernels,
@@ -218,7 +222,8 @@ class InterformerBlock(nn.Module):
         self.skip_tri_attn: bool = skip_tri_attn
         self.dropout: float = dropout
 
-        self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
+        self.pairwise_proj_intra = PairwiseProdDiff(channel_s, channel_z)
+        self.pairwise_proj_inter = PairwiseProdDiff(channel_s, channel_z)
 
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
@@ -251,13 +256,16 @@ class InterformerBlock(nn.Module):
         z: torch.Tensor,
         single_mask: torch.Tensor,
         pair_mask: torch.Tensor,
+        intra_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
         use_cuequiv_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
 
         # Information flow from single (s) to pairwise (z)
-        z = z + self.pairwise_proj(s)
+        # Separate projections for intra- and inter-chain residue pairs
+        z = z + self.pairwise_proj_intra(s) * intra_mask[..., None]
+        z = z + self.pairwise_proj_inter(s) * (~intra_mask)[..., None]
 
         # Triangle multiplicative update
         z = z + self.dropout_rowwise(

--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -50,6 +50,7 @@ class InterformerStack(nn.Module):
         num_heads_tri_attn: int = 4,
         num_blocks: int = 48,
         dropout: float = 0.25,
+        split_intra_inter_channels: bool = False,
         skip_tri_attn: bool = False,
         blocks_per_ckpt: int | None = None,
     ) -> None:
@@ -64,8 +65,9 @@ class InterformerStack(nn.Module):
                     channel_z,
                     num_heads_attn,
                     num_heads_tri_attn,
-                    skip_tri_attn,
                     dropout,
+                    split_intra_inter_channels,
+                    skip_tri_attn,
                 )
             )
 
@@ -194,8 +196,9 @@ class InterformerBlock(nn.Module):
         channel_z: int = 128,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
-        skip_tri_attn: bool = False,
         dropout: float = 0.25,
+        split_intra_inter_channels: bool = False,
+        skip_tri_attn: bool = False,
     ) -> None:
         """Initialize the Interformer module.
 
@@ -209,10 +212,13 @@ class InterformerBlock(nn.Module):
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
             The number of triangle attention heads, by default 4
-        skip_tri_attn : bool, optional
-            Whether to skip triangle attention, by default False
         dropout : float, optional
             The dropout rate, by default 0.25
+        split_intra_inter_channels : bool, optional
+            Whether to use separate projections for intra- and inter-chain
+            residue pairs, by default False
+        skip_tri_attn : bool, optional
+            Whether to skip triangle attention, by default False
         """
         super().__init__()
         self.channel_s: int = channel_s
@@ -222,8 +228,12 @@ class InterformerBlock(nn.Module):
         self.skip_tri_attn: bool = skip_tri_attn
         self.dropout: float = dropout
 
-        self.pairwise_proj_intra = PairwiseProdDiff(channel_s, channel_z)
-        self.pairwise_proj_inter = PairwiseProdDiff(channel_s, channel_z)
+        self.split_intra_inter_channels: bool = split_intra_inter_channels
+        if split_intra_inter_channels:
+            self.pairwise_proj_intra = PairwiseProdDiff(channel_s, channel_z)
+            self.pairwise_proj_inter = PairwiseProdDiff(channel_s, channel_z)
+        else:
+            self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
 
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
@@ -264,8 +274,11 @@ class InterformerBlock(nn.Module):
 
         # Information flow from single (s) to pairwise (z)
         # Separate projections for intra- and inter-chain residue pairs
-        z = z + self.pairwise_proj_intra(s) * intra_mask[..., None]
-        z = z + self.pairwise_proj_inter(s) * (~intra_mask)[..., None]
+        if self.split_intra_inter_channels:
+            z = z + self.pairwise_proj_intra(s) * intra_mask[..., None]
+            z = z + self.pairwise_proj_inter(s) * (~intra_mask)[..., None]
+        else:
+            z = z + self.pairwise_proj(s)
 
         # Triangle multiplicative update
         z = z + self.dropout_rowwise(

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -242,6 +242,10 @@ class KFoldTrunk(BaseTrunk):
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
 
+        intra_mask = (
+            f_input.token.asym_id[..., :, None] == f_input.token.asym_id[..., None, :]
+        )  # [..., L, L]
+
         for i in range(0, num_recycles + 1):
             enable_grad = self.training and i == num_recycles
 
@@ -273,6 +277,7 @@ class KFoldTrunk(BaseTrunk):
                     s,
                     z,
                     mask=f_input.token.pad_mask,
+                    intra_mask=intra_mask,
                     chunk_size_tri_attn=chunk_size_tri_attn,
                     use_cuequiv_kernels=self.kernel_config.cuequivariance,
                 )

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -58,6 +58,7 @@ class InterformerConfig:
     num_heads_tri_attn: int = 4
     num_blocks: int = 48
     dropout: float = 0.25
+    split_intra_inter_channels: bool = True
     skip_tri_attn: bool = False
 
 
@@ -159,6 +160,7 @@ class KFoldTrunk(BaseTrunk):
             num_blocks=cfg.interformer.num_blocks,
             dropout=cfg.interformer.dropout,
             skip_tri_attn=cfg.interformer.skip_tri_attn,
+            split_intra_inter_channels=cfg.interformer.split_intra_inter_channels,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -58,7 +58,7 @@ class InterformerConfig:
     num_heads_tri_attn: int = 4
     num_blocks: int = 48
     dropout: float = 0.25
-    split_intra_inter_channels: bool = True
+    split_intra_inter_channels: bool = False
     skip_tri_attn: bool = False
 
 


### PR DESCRIPTION
This pull request introduces a new feature to the Interformer module: the ability to use separate projections for intra- and inter-chain residue pairs via a `split_intra_inter_channels` option. This is exposed through configuration files and integrated throughout the model pipeline. Additionally, experimental and dataset-related configuration changes are included. Below are the most important changes grouped by theme:

**Model Architecture Improvements:**

* Added `split_intra_inter_channels` parameter to the Interformer module and its configuration, allowing for separate projections for intra- and inter-chain residue pairs. The logic and initialization for this feature are implemented in `interformer.py`, with corresponding updates to the forward pass to use the correct projections based on the mask. 
* Updated the Interformer forward method and its call sites to accept and use an `intra_mask` tensor, which distinguishes intra- from inter-chain residue pairs.
