### PR TITLE
Reduce warning logs

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -204,9 +204,9 @@ def build_trainer(cfg, debug: bool = False, skip_val: bool = False) -> pl.Traine
 
         @rank_zero_only
         def _save_config() -> None:
-            config_out = Path(wandb_logger.experiment.dir) / "config.yaml"
+            config_out = Path(wandb_logger.experiment.dir) / "train_config.yaml"
             save_config(cfg, config_out)
-            wandb_logger.experiment.save("config.yaml")
+            wandb_logger.experiment.save("train_config.yaml")
 
         _save_config()
 

--- a/src/kfold/data/utils/simulation/rieprody.py
+++ b/src/kfold/data/utils/simulation/rieprody.py
@@ -3,9 +3,7 @@ Fallback to Langevin dynamics if RieProDy perturbation is unavailable.
 """
 
 import dataclasses
-import enum
 import os
-import warnings
 from io import BytesIO
 from pathlib import Path
 from typing import Self
@@ -19,14 +17,13 @@ import kfold.constants as C
 from kfold.utils.geometry.rigid_align import compute_rmsd, rigid_align
 
 
-class RieProdyError(enum.Enum):
-    """Enumeration of RiePrody perturbation errors."""
-
-    NONE = enum.auto()
-    LMDB_LOAD_FAILURE = enum.auto()
-    SHAPE_MISMATCH = enum.auto()
-    SIMULATION_FAILURE = enum.auto()
-    NAN_INF_IN_OUTPUT = enum.auto()
+# fmt: off
+class RieProdyPerturbationError(Exception):
+    """Custom exception for RieProDy perturbation errors."""
+class ShapeMismatchError(RieProdyPerturbationError): ...
+class SimulationError(RieProdyPerturbationError): ...
+class NanInfInOutputError(RieProdyPerturbationError): ...
+# fmt: on
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -123,6 +120,9 @@ class RiePrody:
         self.fallback_on_rmsd_exceed: bool = config.fallback_on_rmsd_exceed
         self._disable_log: bool = config.disable_log
 
+        if os.environ.get("RIEPRODY_DISABLE_LOG", "0") == "1":
+            self._disable_log = True
+
         # Initialize RieProDy ProteinPerturbationModule
         self.metric_comp: MetricCompConfig = config.metric_comp
         self.random_walk: RandomWalkConfig = config.random_walk
@@ -164,18 +164,6 @@ class RiePrody:
             f"LMDB path does not exist: {self.lmdb_path}"
         )
         self._lmdb_env: lmdb.Environment | None = None
-
-        # === Debug / diagnostics (prints only on exceptions) === #
-        self._debug_apo_perturbation: bool = (
-            os.environ.get("KFOLD_APO_PERTURB_DEBUG", "0") == "1"
-        )
-        try:
-            self._debug_apo_perturbation_max_errors: int = int(
-                os.environ.get("KFOLD_APO_PERTURB_DEBUG_MAX", "3")
-            )
-        except ValueError:
-            self._debug_apo_perturbation_max_errors = 3
-        self._debug_apo_perturbation_error_count: int = 0
 
         # === Perturbation statistics === #
         self._stats_total_perturbations: int = 0
@@ -238,25 +226,22 @@ class RiePrody:
             # Convert data to RieProDy format
             rieprody_data = self._prepare_rieprody_data(metric_data)
 
-        out = self.run_simulation(rieprody_data, rng)
-        if isinstance(out, RieProdyError):
-            match out:
-                case RieProdyError.LMDB_LOAD_FAILURE:
-                    self.log(f"LMDB load failure (key={key})")
-                case RieProdyError.SHAPE_MISMATCH:
-                    self.log(f"Output shape mismatch (key={key})")
-                    self._stats_shape_mismatch += 1
-                case RieProdyError.NAN_INF_IN_OUTPUT:
-                    self.log(f"NaN/Inf detected! (key={key})")
-                    self._stats_nan_inf_in_output += 1
-                case RieProdyError.SIMULATION_FAILURE:
-                    self.log(f"Simulation failure (key={key})")
-                    self._stats_exception += 1
-                case _:
-                    self.log(f"Unknown error (key={key})")
+        try:
+            perturbed_coords: np.ndarray = self.run_simulation(rieprody_data, rng)
+        except ShapeMismatchError as e:
+            self.log(f"Output shape mismatch (key={key}), {e}")
+            self._stats_shape_mismatch += 1
             return coords if self.fallback_on_failure else None
-        else:
-            perturbed_coords: np.ndarray = out
+        except NanInfInOutputError as e:
+            self.log(f"NaN/Inf detected! (key={key}), {e}")
+            self._stats_nan_inf_in_output += 1
+            return coords if self.fallback_on_failure else None
+        except SimulationError as e:
+            self.log(f"Simulation failure (key={key}), {e}")
+            self._stats_exception += 1
+            return coords if self.fallback_on_failure else None
+        except Exception as e:
+            raise e
 
         # Align perturbed coords to original coords
         perturbed_mask: np.ndarray = np.isfinite(perturbed_coords).all(axis=-1)
@@ -343,24 +328,22 @@ class RiePrody:
         perturbed_coords_list: list[np.ndarray] = []
         rng = rng or np.random.default_rng()
         for _ in range(num_samples):
-            out = self.run_simulation(rieprody_data, rng)
-            if isinstance(out, RieProdyError):
-                # Log error and continue
-                match out:
-                    case RieProdyError.LMDB_LOAD_FAILURE:
-                        self.log(f"LMDB load failure (key={key})")
-                    case RieProdyError.SHAPE_MISMATCH:
-                        self.log(f"Output shape mismatch (key={key})")
-                        self._stats_shape_mismatch += 1
-                    case RieProdyError.NAN_INF_IN_OUTPUT:
-                        self.log(f"NaN/Inf detected! (key={key})")
-                        self._stats_nan_inf_in_output += 1
-                    case RieProdyError.SIMULATION_FAILURE:
-                        self.log(f"Simulation failure (key={key})")
-                        self._stats_exception += 1
-                    case _:
-                        self.log(f"Unknown error (key={key})")
+            try:
+                out = self.run_simulation(rieprody_data, rng)
+            except ShapeMismatchError as e:
+                self.log(f"Output shape mismatch (key={key}), {e}")
+                self._stats_shape_mismatch += 1
                 continue
+            except NanInfInOutputError as e:
+                self.log(f"NaN/Inf detected! (key={key}), {e}")
+                self._stats_nan_inf_in_output += 1
+                continue
+            except SimulationError as e:
+                self.log(f"Simulation failure (key={key}), {e}")
+                self._stats_exception += 1
+                continue
+            except Exception as e:
+                raise e
 
             perturbed_coords: np.ndarray = out
 
@@ -401,7 +384,7 @@ class RiePrody:
         self,
         rieprody_data: dict,
         rng: np.random.Generator,
-    ) -> np.ndarray | RieProdyError:
+    ) -> np.ndarray:
         """Metric-based perturbation.
 
         Parameters
@@ -443,20 +426,18 @@ class RiePrody:
                 return_q=False,
             )  # [num_steps+1, L, 14, 3]
             if trajectory_atom14.ndim != 4 or trajectory_atom14.shape[2:] != (14, 3):
-                warnings.warn(
+                raise ShapeMismatchError(
                     f"Rieprody output shape mismatch: "
                     f"expected [num-step, length, 14, 3], "
                     f"got {trajectory_atom14.shape}",
-                    UserWarning,
                 )
-                return RieProdyError.SHAPE_MISMATCH
 
             # TODO: Handle multiple steps later
             perturbed_atom14: np.ndarray = (
                 trajectory_atom14[-1].detach().cpu().numpy()
             )  # [L, 14, 3]
             if not np.isfinite(perturbed_atom14).all():
-                return RieProdyError.NAN_INF_IN_OUTPUT
+                raise NanInfInOutputError("NaN/Inf detected in RieProDy output.")
 
             # Convert atom14 to atom37
             # WARN: RieProDy atom14 ordering is different from standard atom14 ordering.
@@ -470,11 +451,7 @@ class RiePrody:
             return perturbed
 
         except Exception as e:
-            warnings.warn(
-                f"Exception during RieProDy perturbation: {e}",
-                UserWarning,
-            )
-            return RieProdyError.SIMULATION_FAILURE
+            raise SimulationError(f"Exception during RieProDy perturbation: {e}") from e
 
     # === Internal methods === #
     def log(self, *args, **kwargs):
@@ -495,14 +472,10 @@ class RiePrody:
         max_time = self.random_walk.total_time
         min_time = self.random_walk.total_time_min
         if max_time < min_time:
-            warnings.warn(
-                (
-                    f"random_walk.total_time ({max_time}) < "
-                    f"random_walk.total_time_min ({min_time}). Swapping the bounds."
-                ),
-                UserWarning,
+            raise ValueError(
+                f"random_walk.total_time ({max_time}) < "
+                f"random_walk.total_time_min ({min_time})."
             )
-            min_time, max_time = max_time, min_time
 
         if max_time == min_time:
             return max_time
@@ -592,11 +565,8 @@ class RiePrody:
                     with np.load(byte_io, allow_pickle=True) as npz_file:
                         data = {k: npz_file[k] for k in npz_file.files}
                 return data
-            except Exception as e:
-                warnings.warn(
-                    f"Failed to load metric data for {key}: {e}",
-                    UserWarning,
-                )
+            except Exception:
+                # Failed to load from LMDB
                 return None
 
     def _prepare_rieprody_data(self, metric_data: dict) -> dict:

--- a/src/kfold/data/utils/simulation/rieprody.py
+++ b/src/kfold/data/utils/simulation/rieprody.py
@@ -126,6 +126,19 @@ class RiePrody:
         # Initialize RieProDy ProteinPerturbationModule
         self.metric_comp: MetricCompConfig = config.metric_comp
         self.random_walk: RandomWalkConfig = config.random_walk
+
+        # Check random_walk parameters
+        if self.random_walk.num_steps <= 0:
+            raise ValueError(
+                f"random_walk.num_steps must be positive, got "
+                f"{self.random_walk.num_steps}."
+            )
+        if self.random_walk.total_time_min > self.random_walk.total_time:
+            raise ValueError(
+                f"random_walk.total_time_min ({self.random_walk.total_time_min}) "
+                f"> random_walk.total_time ({self.random_walk.total_time})."
+            )
+
         module_config = SimpleConfig(
             {
                 "metric_comp": self.metric_comp,
@@ -396,8 +409,8 @@ class RiePrody:
 
         Returns
         -------
-        perturbed_coords : np.ndarray | RieProdyError
-            Perturbed coordinates of shape [L, 37, 3] or RieProDyError on failure.
+        perturbed_coords : np.ndarray
+            Perturbed coordinates of shape [L, 37, 3].
         """
         self._stats_total_perturbations += 1
         if (
@@ -471,15 +484,8 @@ class RiePrody:
         """
         max_time = self.random_walk.total_time
         min_time = self.random_walk.total_time_min
-        if max_time < min_time:
-            raise ValueError(
-                f"random_walk.total_time ({max_time}) < "
-                f"random_walk.total_time_min ({min_time})."
-            )
-
         if max_time == min_time:
             return max_time
-
         return float(rng.uniform(min_time, max_time))
 
     @property

--- a/src/kfold/training/dataset/dataset.py
+++ b/src/kfold/training/dataset/dataset.py
@@ -335,8 +335,8 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
         rng = rng or np.random.default_rng()
 
         # Fetch apo info from lookup table
-        name = ref_struct.metadata.id
-        entry_info = self.lookup_table[name]
+        entry_id = ref_struct.id
+        entry_info = self.lookup_table[entry_id]
 
         apo_dir = self.data_root / "apo"
         apo_lookup_map: dict[int, dict] = {}
@@ -350,7 +350,7 @@ class SafeLoadingDataset(torch.utils.data.Dataset, ABC):
                 if len(apo_list) == 0:
                     print(
                         "Warning: No available apo structure found "
-                        f"for entity {entity_id} in entry {name}."
+                        f"for entity {entity_id} in entry {entry_id}."
                     )
                     continue
                 elif len(apo_list) == 1:


### PR DESCRIPTION
Current code prints too many warning logs. To monitor training logs better, I add `disable_log` configs.