### PR TITLE
Expand validation set from 1024 to 1280.

### DIFF
--- a/docs/DEVELOPMENT_NOTE.md
+++ b/docs/DEVELOPMENT_NOTE.md
@@ -155,12 +155,12 @@ We note that this time split is identical to Boltz2's validation set (2024-01-01
 
 Closely following AlphaFold3's validation set construction methodology (see SI 5.8 of the AlphaFold3 paper), we implemented the following steps:
 
-1. Take all targets released between 2023-01-01 and 2023-12-31 (inclusive) with a token count <= 2560, chain count <= 1000, and resolution <= 4.0 Å.
+1. Take all PDB targets released between 2023-01-01 and 2023-12-31 (inclusive) with a token count <= 2560, chain count <= 1000, and resolution <= 4.5 Å.
 2. Remove entries where any chain was filtered out during the PDB data filtering step (see SI 2.5.4 of the AlphaFold3 paper).
 3. Select low-homology interfaces using the following criteria:
     1. Collect all interface chain pairs. Interfaces with multi-residue ligands are excluded.
     2. Filter for low-homology interfaces only:
-        - Remove the interface if any training target has two chains with sequence identity >= 40% (polymer) or Tanimoto similarity >= 0.8 (ligand) to the involved chains.
+        - Remove the interface if any training target has two chains with sequence identity >= 40% (polymer) or Tanimoto similarity >= 0.85 (ligand) to the involved chains.
         - Remove polymer-ion interfaces if any training target has one polymer chain with sequence identity >= 40% to the involved polymer chain.
         - Remove ligand-ligand interfaces.
     3. Assign interfaces to clusters `(cluster_id1, cluster_id2`) based on the following homology criteria:
@@ -168,20 +168,20 @@ Closely following AlphaFold3's validation set construction methodology (see SI 5
         - 100% sequence identity for DNA/RNA chains.
         - CCD identity for ligands.
     4. Sample one interface from each cluster.
-    5. Sample interfaces for each interface type:
-        - Protein-Protein: 500 interfaces
-        - Protein-DNA: 100 interfaces
-        - Protein-RNA: 100 interfaces
-        - Protein-Ligand: 400 interfaces
-        - DNA-DNA: 50 interfaces
-        - DNA-RNA: all interfaces
-        - DNA-Ligand: 50 interfaces
-        - RNA-RNA: all interfaces
-        - RNA-Ligand: all interfaces
-        - Ligand-Ligand: 0 interfaces
+    5. Retain up to the following limits per interface type:
+        - Protein-Protein: 600
+        - Protein-DNA: 200
+        - Protein-RNA: All
+        - Protein-Ligand: 500
+        - DNA-DNA: 100
+        - DNA-RNA: All
+        - DNA-Ligand: 50
+        - RNA-RNA: All
+        - RNA-Ligand: All
+        - Ligand-Ligand: 0
 4. Select low-homology monomers using the following criteria:
-    1. Take all targets with a single polymer chain released between 2023-01-01 and 2023-12-31 (inclusive) with a token count <= 2560 and resolution <= 4.0 Å.
-    2. Filter out polymers with greater than 40% sequence identity to any training target.
-    3. Take all nucleic acid monomers.
-5. Take all PDB entries containing the selected interfaces or polymers, and filter out entries with a token count > 2048.
-6. Sample 1024 PDB entries among the selected 1056 entries for the final validation set.
+    1. Take all targets with a single nucleic acid chain. (single polymer chains with multiple ligands are permitted)
+    2. Filter out polymers with >= 40% sequence identity to any training target.
+5. Take all PDB entries containing the remaining interfaces and monomers from steps 3 and 4.
+6. Remove entries with more than 2048 tokens.
+7. Sample 1280 PDB entries from the remaining set to construct the validation set.

--- a/scripts/process/rcsb/c_process_cifs.py
+++ b/scripts/process/rcsb/c_process_cifs.py
@@ -14,7 +14,7 @@ python c_process_rcsb.py \
 
 ## Train/valid splits:
 - train: up to 2022-12-31, max resolution 9.0A, max chains 300
-- val: 2023-01-01 to 2023-12-31, max resolution 4.0A, max chains 1000, max tokens 2560
+- val: 2023-01-01 to 2023-12-31, max resolution 4.5A, max chains 1000, max tokens 2560
 - test: 2024-01-01 to 2026-01-09, max resolution 4.5A, max chains 1000, max tokens 5120,
     filter NMR.
 

--- a/scripts/process/rcsb/c_process_cifs.py
+++ b/scripts/process/rcsb/c_process_cifs.py
@@ -14,7 +14,14 @@ python c_process_rcsb.py \
 
 ## Train/valid splits:
 - train: up to 2022-12-31, max resolution 9.0A, max chains 300
-- val: 2023-01-01 to 2023-12-31, max resolution 4.5A, max chains 1000, max residues 2560
+- val: 2023-01-01 to 2023-12-31, max resolution 4.0A, max chains 1000, max tokens 2560
+- test: 2024-01-01 to 2026-01-09, max resolution 4.5A, max chains 1000, max tokens 5120,
+    filter NMR.
+
+We follow similar processing and filtering criteria as in the AlphaFold3 paper. However,
+we also introduce additional filtering logic to extract high-quality structures for
+evaluation: `handle_invalid_chains="disallow"` in validation and test splits.
+This is to reduce biases due to extracting partial structures with valid chains only.
 """
 
 import argparse
@@ -41,10 +48,11 @@ FAILED = 1
 DATE_FILTERED = 2
 RESOLUTION_FILTERED = 3
 METHOD_FILTERED = 4
-CHAIN_COUNT_FILTERED = 5
-RESIDUE_COUNT_FILTERED = 6
-EMPTY_STRUCTURE_FILTERED = 7
-INVALID_CHAIN_FILTERED = 8
+INVALID_POLYMER_TYPES = 5
+CHAIN_COUNT_FILTERED = 6
+RESIDUE_COUNT_FILTERED = 7
+EMPTY_STRUCTURE_FILTERED = 8
+INVALID_CHAIN_FILTERED = 9
 
 
 @dataclasses.dataclass
@@ -121,8 +129,9 @@ KFOLD_SPLITS = {
     "val": DataFilter(
         date_start=datetime.fromisoformat("2023-01-01 00:00:00"),
         date_end=datetime.fromisoformat("2023-12-31 23:59:59"),
-        max_resolution=4.0,
+        max_resolution=4.5,
         max_chains=1000,
+        min_tokens=16,
         max_tokens=2560,
         handle_invalid_chains="disallow",
     ),
@@ -261,6 +270,20 @@ def parse_cif(
         block, expand_assembly=True, clean_up=True
     )
 
+    # Filter out invalid polymer types (e.g., PNA)
+    if data_filter.handle_invalid_chains == "disallow":
+        for entity in raw_struct.entities:
+            if (
+                entity.entity_type == gemmi.EntityType.Polymer
+                and entity.polymer_type
+                not in (
+                    gemmi.PolymerType.PeptideL,
+                    gemmi.PolymerType.Dna,
+                    gemmi.PolymerType.Rna,
+                )
+            ):
+                return INVALID_POLYMER_TYPES
+
     # Filter by chain count
     if not check_chain_count_cutoff(
         raw_struct, data_filter.min_chains, data_filter.max_chains
@@ -379,6 +402,7 @@ def main():
     print(f"  Date filtered: {results.count(DATE_FILTERED)}")
     print(f"  Resolution filtered: {results.count(RESOLUTION_FILTERED)}")
     print(f"  Method filtered: {results.count(METHOD_FILTERED)}")
+    print(f"  Invalid polymer types filtered: {results.count(INVALID_POLYMER_TYPES)}")
     print(f"  Chain count filtered: {results.count(CHAIN_COUNT_FILTERED)}")
     print(f"  Residue count filtered: {results.count(RESIDUE_COUNT_FILTERED)}")
     print(f"  Empty structure filtered: {results.count(EMPTY_STRUCTURE_FILTERED)}")

--- a/scripts/process/rcsb/e1_get_val_ids.py
+++ b/scripts/process/rcsb/e1_get_val_ids.py
@@ -3,27 +3,25 @@
 Intermediate results:
 --- Cluster-based sampling ---
 # Multimer:
-Stage 3: Final sampling interfaces for each interface type
   Protein-Protein: 1707 -> 600
   Protein-DNA: 402 -> 200
   Protein-RNA: 184 -> 184
-  Protein-Ligand: 2106 -> 500
+  Protein-Ligand: 2115 -> 500
   DNA-DNA: 293 -> 100
   DNA-RNA: 31 -> 31
   DNA-Ligand: 67 -> 50
   RNA-RNA: 42 -> 42
   RNA-Ligand: 16 -> 16
-  Ligand-Ligand: 296 -> 0
+  Ligand-Ligand: 293 -> 0
 
 # Monomer:
-Stage 3: Final sampling polymers for each chain type
-  DNA: 17 -> 17
-  RNA: 25 -> 25
+  DNA: 17
+  RNA: 25
 
 --- Final sampling ---
-Multimer entries: 1257
+Multimer entries: 1265
 Monomer entries: 42
-Total entries: 1295
+Total entries: 1303
 Final entries: 1280
 """
 
@@ -581,56 +579,19 @@ def filter_monomers(
     print("Total polymers after homology filtering:", len(filtered_polymers))
 
     # ============================================================
-    # Clustering and sampling polymers
+    # Collect all sequences
     # ============================================================
-    print("\nStage 2-1: Clustering interfaces...")
-    seq_to_cluster: dict[str, dict[str, str]] = run_clustering(
-        filtered_polymers, mmseqs=mmseqs
-    )
-    polymer_clusters: dict[str, list[Seq]] = defaultdict(list)
-    for seq in filtered_polymers:
-        cluster_id = seq_to_cluster[seq.ctype_str][seq.sequence]
-        polymer_clusters[cluster_id].append(seq)
-
-    print("\nStage 2-2: Sample polymer(s) for each cluster...")
-    # Protein: sample one per cluster.
-    # RNA/DNA: take all, except for over-represented RNA clusters.
-    sampled_polymers: list[Seq] = []
-    for cluster_id, polymers in polymer_clusters.items():
-        ctype = polymers[0].ctype
-        rng = get_rng(cluster_id)
-        n_cluster = len(polymers)
-        if ctype.is_protein:
-            sampled_polymers.append(polymers[rng.integers(n_cluster)])
-        else:
-            # For DNA/RNA, always take all
-            sampled_polymers.extend(polymers)
-    print(f"Total polymers after filtering and clustering: {len(sampled_polymers)}")
-
-    # ============================================================
-    # Final sampling for each chain type
-    # ============================================================
-    print("\nStage 3: Final sampling polymers for each chain type")
+    print("\nStage 2: Collect sequences...")
     polymers_per_ctype = defaultdict(list)
-    for seq in sampled_polymers:
+    for seq in filtered_polymers:
         polymers_per_ctype[seq.ctype].append(seq)
-    del sampled_polymers  # free up memory
+    del filtered_polymers  # free up memory
 
     sampled_polymers: list[Seq] = []
     for ctype in sorted(polymers_per_ctype):
         polymers = polymers_per_ctype[ctype]
-        rng = get_rng(ctype.name)
-        n_polymers = len(polymers)
-        n_samples = min(NUM_MONOMER_SAMPLES.get(ctype, n_polymers), n_polymers)
-        if n_samples == 0:
-            pass
-        elif n_polymers == n_samples:
-            sampled_polymers.extend(polymers)
-        else:
-            sampled_indices = rng.choice(len(polymers), size=n_samples, replace=False)
-            for idx in sampled_indices:
-                sampled_polymers.append(polymers[idx])
-        print(f"  {ctype}: {n_polymers} -> {n_samples}")
+        sampled_polymers.extend(polymers)
+        print(f"  {ctype}: {len(polymers)}")
 
     print("\nMonomer filtering completed.")
     print(f"Total polymers after final sampling: {len(sampled_polymers)}")

--- a/scripts/process/rcsb/e1_get_val_ids.py
+++ b/scripts/process/rcsb/e1_get_val_ids.py
@@ -4,28 +4,27 @@ Intermediate results:
 --- Cluster-based sampling ---
 # Multimer:
 Stage 3: Final sampling interfaces for each interface type
-  Protein-Protein: 1665 -> 500
-  Protein-DNA: 398 -> 100
-  Protein-RNA: 181 -> 100
-  Protein-Ligand: 2058 -> 400
-  DNA-DNA: 281 -> 50
+  Protein-Protein: 1707 -> 600
+  Protein-DNA: 402 -> 200
+  Protein-RNA: 184 -> 184
+  Protein-Ligand: 2106 -> 500
+  DNA-DNA: 293 -> 100
   DNA-RNA: 31 -> 31
-  DNA-Ligand: 70 -> 50
+  DNA-Ligand: 67 -> 50
   RNA-RNA: 42 -> 42
   RNA-Ligand: 16 -> 16
-  Ligand-Ligand: 288 -> 0
+  Ligand-Ligand: 296 -> 0
 
 # Monomer:
 Stage 3: Final sampling polymers for each chain type
-  Protein: 198 -> 0
-  DNA: 20 -> 20
+  DNA: 17 -> 17
   RNA: 25 -> 25
 
 --- Final sampling ---
-Multimer entries: 1017
-Monomer entries: 45
-Total entries: 1056
-Final entries: 1024
+Multimer entries: 1257
+Monomer entries: 42
+Total entries: 1295
+Final entries: 1280
 """
 
 import argparse
@@ -34,6 +33,7 @@ import multiprocessing
 import os
 import pathlib
 from collections import defaultdict
+from datetime import datetime
 from typing import Any, NamedTuple, TypeVar
 
 import numpy as np
@@ -73,23 +73,21 @@ VERBOSE = 0
 INIT_MAX_TOKENS = 2560
 FINAL_MAX_TOKENS = 2048
 SEQUENCE_IDENTITY_THRESHOLD = 0.40
-TANIMOTO_SIMILARITY_THRESHOLD = 0.80
+TANIMOTO_SIMILARITY_THRESHOLD = 0.85
 NUM_INTERFACE_SAMPLES: dict[tuple[C.ChainType, C.ChainType], int] = {
-    norm_key(C.ChainType.PROTEIN, C.ChainType.PROTEIN): 500,
-    norm_key(C.ChainType.PROTEIN, C.ChainType.DNA): 100,
-    norm_key(C.ChainType.PROTEIN, C.ChainType.RNA): 100,
-    norm_key(C.ChainType.PROTEIN, C.ChainType.LIGAND): 400,
-    norm_key(C.ChainType.DNA, C.ChainType.DNA): 50,
+    norm_key(C.ChainType.PROTEIN, C.ChainType.PROTEIN): 600,
+    norm_key(C.ChainType.PROTEIN, C.ChainType.DNA): 200,
+    norm_key(C.ChainType.PROTEIN, C.ChainType.RNA): 200,
+    norm_key(C.ChainType.PROTEIN, C.ChainType.LIGAND): 500,
+    norm_key(C.ChainType.DNA, C.ChainType.DNA): 100,
     norm_key(C.ChainType.DNA, C.ChainType.RNA): 50,
     norm_key(C.ChainType.DNA, C.ChainType.LIGAND): 50,
     norm_key(C.ChainType.RNA, C.ChainType.RNA): 50,
     norm_key(C.ChainType.RNA, C.ChainType.LIGAND): 50,
     norm_key(C.ChainType.LIGAND, C.ChainType.LIGAND): 0,
 }
-NUM_MONOMER_SAMPLES: dict[C.ChainType, int] = {
-    C.ChainType.PROTEIN: 0,  # No protein monomers
-}
-FINAL_VALIDATION_SET_SIZE = 1024
+NUM_MONOMER_SAMPLES: dict[C.ChainType, int] = {}
+FINAL_VALIDATION_SET_SIZE = 1280
 
 
 class Seq(NamedTuple):
@@ -307,14 +305,17 @@ def run_clustering(
     uniq_proteins: list[tuple[str, str]] = sorted(
         [(repr_id, seq) for seq, repr_id in protein_to_repr_id.items()]
     )
-    protein_cluster_map = run_mmseqs2_cluster(
-        uniq_proteins,
-        min_sequence_identity=sequence_identity,
-        chain_type="protein",
-        verbose=VERBOSE,
-        print_cmd=(VERBOSE > 0),
-        mmseqs2_exec=mmseqs,
-    )
+    if len(uniq_proteins) > 0:
+        protein_cluster_map = run_mmseqs2_cluster(
+            uniq_proteins,
+            min_sequence_identity=sequence_identity,
+            chain_type="protein",
+            verbose=VERBOSE,
+            print_cmd=(VERBOSE > 0),
+            mmseqs2_exec=mmseqs,
+        )
+    else:
+        protein_cluster_map = {}
 
     # Construct Sequence to Cluster ID mapping
     # Protein sequences use 40% homology clustering
@@ -554,9 +555,6 @@ def filter_monomers(
     # Determine low homology polymers
     # ============================================================
     print("\nStage 1-1: Get homology mappings for all sequences...")
-    protein_homologs: dict[str, set[str]] = get_polymer_homologs(
-        C.ChainType.PROTEIN, all_polymers, train_sequences, mmseqs
-    )
     dna_homologs: dict[str, set[str]] = get_polymer_homologs(
         C.ChainType.DNA, all_polymers, train_sequences, mmseqs
     )
@@ -565,10 +563,10 @@ def filter_monomers(
     )
 
     # Combine homology results
-    seq_homologs_map: dict[str, set[str]] = protein_homologs | dna_homologs | rna_homologs
-    assert len(seq_homologs_map) == (
-        len(protein_homologs) + len(dna_homologs) + len(rna_homologs)
-    ), "Homology map size mismatch."
+    seq_homologs_map: dict[str, set[str]] = dna_homologs | rna_homologs
+    assert len(seq_homologs_map) == (len(dna_homologs) + len(rna_homologs)), (
+        "Homology map size mismatch."
+    )
     assert len(seq_homologs_map) == len(all_polymers), (
         "Some sequences missing in homology map."
     )
@@ -690,16 +688,13 @@ def read_npz_file(npz_file: pathlib.Path) -> dict:
         all_interfaces.append((seq1, seq2))
         visited_iface_entities.add(key)
 
-    # Monomers (exclude protein-only structures)
+    # Monomers (Nucleic acids only)
     if struct.num_polymer_chains == 1:
         chain: Chain = next(c for c in struct.chains if c.is_polymer)
         assert chain.is_polymer, "Monomer chain must be polymer."
         seq = entity_sequences[chain.entity_id]
-        # Add polymer-ligand systems as monomers
-        if struct.num_chains > 1:
-            all_monomers.append(seq)
-        # Add nucleic acid monomers
-        elif struct.num_chains == 1 and chain.is_nucleic_acid:
+        # Add nucleic acid monomers only
+        if chain.is_nucleic_acid:
             all_monomers.append(seq)
 
     return {
@@ -892,22 +887,29 @@ def main():
             f.write(f"{pdb_id}\n")
     print(f"Validation set PDB IDs saved to: {val_ids_file}")
 
-    # Extract statistics
+    # Summarize final validation set statistics
     print("\nExtracting final validation set statistics...")
     chains_per_ctype = defaultdict(int)
     interfaces_per_ctype = defaultdict(int)
 
-    # Load all NPZ files again
+    earlest_release_date = datetime.max
+    latest_release_date = datetime.min
     npz_files: list[pathlib.Path] = [f for f in npz_files if f.stem in val_ids]
     for f in npz_files:
         struct: RefStructure = RefStructure.load_npz(f)
         pdb_id = struct.id
+
+        # Update date
+        release_date = datetime.fromisoformat(struct.metadata.exp.release_date)
+        earlest_release_date = min(earlest_release_date, release_date)
+        latest_release_date = max(latest_release_date, release_date)
+
+        # Collect type info
         asym_id_to_type: dict[int, str] = {}
         for chain in struct.chains:
             ctype_str = str(chain.ctype)
             chains_per_ctype[ctype_str] += 1
             asym_id_to_type[chain.asym_id] = ctype_str
-
         m: Metadata = struct.metadata
         for interface in m.interfaces:
             asym_id_1, asym_id_2 = interface.asym_ids
@@ -916,6 +918,10 @@ def main():
             ctypes = norm_key(ctype1, ctype2)
             interfaces_per_ctype[ctypes] += 1
 
+    print("Release date range:")
+    print(f"  Earliest: {earlest_release_date.date().isoformat()}")
+    print(f"  Latest: {latest_release_date.date().isoformat()}")
+    print()
     print("Final chain type statistics:")
     for ctype in sorted(chains_per_ctype.keys()):
         print(f"  {ctype}: {chains_per_ctype[ctype]}")


### PR DESCRIPTION
Extend the validation set from 1024 to 1280. In particular, new pipeline takes all rna interface clusters.

Updates:
- Resolution cutoff: 4.0 -> 4.5
- Tanimoto similarity cutoff: 0.8 -> 0.85
- The number of clusters per interface type:
        - Protein-Protein: 500 -> 600
        - Protein-DNA: 100 -> 200
        - Protein-RNA: 100 -> All
        - Protein-Ligand: 400 -> 500
        - DNA-DNA: 50 -> 100
        - DNA-RNA: All (same)
        - DNA-Ligand: 50 (same)
        - RNA-RNA: All (same)
        - RNA-Ligand: All (same)
        - Ligand-Ligand: 0