### PR TITLE
reduce gradient/param logging overhead

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -223,7 +223,7 @@ def build_trainer(cfg, debug: bool = False, skip_val: bool = False) -> pl.Traine
     callbacks.append(model_summary)
 
     # TQDM
-    tqdm_refresh_rate = 1 if debug else 10
+    tqdm_refresh_rate = 1 if debug else cfg.train.trainer.log_every_n_steps
     tqdm_callback = pl_callbacks.TQDMProgressBar(refresh_rate=tqdm_refresh_rate)
     callbacks.append(tqdm_callback)
 

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -425,7 +425,7 @@ class KFoldTrainingModule(pl.LightningModule):
                     )
 
         for k, v in metrics.items():
-            self.log(f"train/{k}", v, prog_bar=(k == "loss"))
+            self.log(f"train/{k}", v, prog_bar=(k == "loss"), sync_dist=False)
 
         return loss
 
@@ -781,29 +781,33 @@ class KFoldTrainingModule(pl.LightningModule):
         """Log model parameter and gradient norms."""
 
         model = self.model
-        self.log("train/grad_norm", gradient_norm(model), prog_bar=False)
-        self.log("train/param_norm", parameter_norm(model), prog_bar=False)
+        self.log("monitor/grad_norm", gradient_norm(model), prog_bar=False)
+        self.log("monitor/param_norm", parameter_norm(model), prog_bar=False)
 
         if self.train_structure_module:
             self.log(
-                "train/grad_norm_trunk",
+                "monitor/grad_norm_trunk",
                 gradient_norm(model.trunk),
+                sync_dist=False,
                 prog_bar=False,
             )
             self.log(
-                "train/param_norm_trunk",
+                "monitor/param_norm_trunk",
                 parameter_norm(model.trunk),
+                sync_dist=False,
                 prog_bar=False,
             )
 
             self.log(
-                "train/grad_norm_score_model",
+                "monitor/grad_norm_score_model",
                 gradient_norm(model.score_model),
+                sync_dist=False,
                 prog_bar=False,
             )
             self.log(
-                "train/param_norm_score_model",
+                "monitor/param_norm_score_model",
                 parameter_norm(model.score_model),
+                sync_dist=False,
                 prog_bar=False,
             )
 
@@ -812,13 +816,15 @@ class KFoldTrainingModule(pl.LightningModule):
                 "Logging for confidence module not implemented yet."
             )
             # self.log(
-            #     "train/grad_norm_confidence_head",
+            #     "monitor/grad_norm_confidence_head",
             #     gradient_norm(model.confidence_head),
+            #     sync_dist=False,
             #     prog_bar=False,
             # )
             # self.log(
-            #     "train/param_norm_confidence_head",
+            #     "monitor/param_norm_confidence_head",
             #     parameter_norm(model.confidence_head),
+            #     sync_dist=False,
             #     prog_bar=False,
             # )
 

--- a/src/kfold/training/utils/gradient_logging.py
+++ b/src/kfold/training/utils/gradient_logging.py
@@ -4,15 +4,22 @@ import torch
 @torch.no_grad()
 def gradient_norm(module: torch.nn.Module) -> float:
     # Only compute over parameters that are being trained
-    parameters = filter(lambda p: p.requires_grad, module.parameters())
-    parameters = filter(lambda p: p.grad is not None, parameters)
-    norm = torch.tensor([p.grad.norm(p=2) ** 2 for p in parameters]).sum().sqrt()
-    return norm.item()
+    grads = [
+        p.grad for p in module.parameters() if p.requires_grad and p.grad is not None
+    ]
+    if not grads:
+        return 0.0
+    norms = torch._foreach_norm(grads, ord=2)
+    total_norm = torch.linalg.vector_norm(torch.stack(norms), ord=2)
+    return total_norm.item()
 
 
 @torch.no_grad()
 def parameter_norm(module: torch.nn.Module) -> float:
-    # Only compute over parameters that are being trained
-    parameters = filter(lambda p: p.requires_grad, module.parameters())
-    norm = torch.tensor([p.norm(p=2) ** 2 for p in parameters]).sum().sqrt()
-    return norm.item()
+    # Get all parameters that are being trained
+    parameters = [p for p in module.parameters() if p.requires_grad]
+    if not parameters:
+        return 0.0
+    norms = torch._foreach_norm(parameters)
+    total_norm = torch.linalg.vector_norm(torch.stack(norms), ord=2)
+    return total_norm.item()

--- a/src/kfold/training/utils/gradient_logging.py
+++ b/src/kfold/training/utils/gradient_logging.py
@@ -20,6 +20,6 @@ def parameter_norm(module: torch.nn.Module) -> float:
     parameters = [p for p in module.parameters() if p.requires_grad]
     if not parameters:
         return 0.0
-    norms = torch._foreach_norm(parameters)
+    norms = torch._foreach_norm(parameters, ord=2)
     total_norm = torch.linalg.vector_norm(torch.stack(norms), ord=2)
     return total_norm.item()


### PR DESCRIPTION
This pull request focuses on improving logging consistency, efficiency, and configuration flexibility for training metrics and model state monitoring. The most significant changes include refactoring metric and model state logging to use a unified "monitor/" prefix, optimizing gradient and parameter norm calculations, and making the TQDM progress bar refresh rate configurable.

**Logging consistency and configuration:**

* Changed all model state metric logging keys from the `train/` prefix to `monitor/`, including gradient and parameter norms for the main model and its submodules, and updated the commented-out confidence head logging accordingly. Also added `sync_dist=False` to relevant logs to prevent unnecessary synchronization.
* Updated the logging of training metrics in `training_step` to explicitly set `sync_dist=False`, ensuring local-only logging for these metrics.

**Performance and utility improvements:**

* Optimized `gradient_norm` and `parameter_norm` in `gradient_logging.py` by using `torch._foreach_norm` and `torch.linalg.vector_norm` for more efficient computation, and added safeguards to return 0.0 if no parameters are present.

**Trainer and progress bar configuration:**

* Made the TQDM progress bar refresh rate configurable by using `cfg.train.trainer.log_every_n_steps` instead of a hardcoded value, allowing for more flexible debugging and logging intervals.