### PR TITLE
remove unused parameters moreover

### DIFF
--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -12,8 +12,6 @@ pairformer:
   num_heads_tri_attn: 4
   num_blocks: 48
   dropout: 0.25
-  skip_tri_attn: false
-  use_separate_projections: true
   use_qk_norm: false
 
 blocks_per_ckpt: 1

--- a/src/kfold/model/modules/input_embedder/kfold_embedder.py
+++ b/src/kfold/model/modules/input_embedder/kfold_embedder.py
@@ -335,13 +335,6 @@ class KFoldInputEmbedder(BaseInputEmbedder):
 
         return s_inputs, s_init, z_init
 
-    def _add_token_interaction_embedding(
-        self, s_inputs: torch.Tensor, f_input: FoldingInput
-    ) -> torch.Tensor:
-        """Placeholder for adding token interaction embeddings.
-        Used in `pretrained_embedder_with_interaction.py`."""
-        return s_inputs
-
     def get_apo_embedding(self, f_input: FoldingInput) -> torch.Tensor:
         """Get apo embedding for the input features.
 


### PR DESCRIPTION
This pull request makes minor configuration and code cleanup changes related to the kfold model and its input embedder. Specifically, it removes unused configuration options and a placeholder method that is no longer needed.

Configuration cleanup:

* Removed the `skip_tri_attn` and `use_separate_projections` options from the `pairformer` section in `configs/model/module/trunk/kfold.yaml`, as these parameters are no longer used.

Code simplification:

* Deleted the `_add_token_interaction_embedding` placeholder method from `kfold_embedder.py`, since it was unused and only served as a stub for future extensions.