### PR TITLE
bugfix in plm module

### DIFF
--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from kfold.model.layers.primitives import LayerNorm, Linear, LinearNoBias
+from kfold.model.layers.primitives import LayerNorm, Linear
 
 
 class PairwiseProdDiff(nn.Module):
@@ -13,7 +13,7 @@ class PairwiseProdDiff(nn.Module):
         super().__init__()
         assert c_out % 2 == 0, "c_out must be even."
         c_hidden = c_out // 2
-        self.linear_in = LinearNoBias(c_in, c_hidden * 2, init="default")
+        self.linear_in = Linear(c_in, c_hidden * 2, init="default")
         self.linear_out = Linear(c_hidden * 2, c_out, init="final")
 
     def forward(self, s: torch.Tensor) -> torch.Tensor:

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 
-from kfold.model.layers.primitives import LayerNorm, Linear
+from kfold.model.layers.primitives import LayerNorm, Linear, LinearNoBias
 
 
 class PairwiseProdDiff(nn.Module):
@@ -13,7 +13,7 @@ class PairwiseProdDiff(nn.Module):
         super().__init__()
         assert c_out % 2 == 0, "c_out must be even."
         c_hidden = c_out // 2
-        self.linear_in = Linear(c_in, c_hidden * 2, init="default")
+        self.linear_in = LinearNoBias(c_in, c_hidden * 2, init="default")
         self.linear_out = Linear(c_hidden * 2, c_out, init="final")
 
     def forward(self, s: torch.Tensor) -> torch.Tensor:
@@ -93,10 +93,11 @@ class PLMModule(nn.Module):
         """
         s_plm = self.layernorm(s_plm)
         if self.use_separate_projections:
+            pair_mask = mask[..., None] & mask[..., None, :]
             intra_mask = asym_id[..., None] == asym_id[..., None, :]
-            intra_mask = intra_mask & (mask[..., None] & mask[..., None, :])
+            intra_mask, inter_mask = intra_mask & pair_mask, (~intra_mask) & pair_mask
             z = z + self.pairwise_proj_intra(s_plm) * intra_mask[..., None]
-            z = z + self.pairwise_proj_inter(s_plm) * (~intra_mask)[..., None]
+            z = z + self.pairwise_proj_inter(s_plm) * inter_mask[..., None]
         else:
             pair_mask = mask[..., None] & mask[..., None, :]
             z = z + self.pairwise_proj(s_plm) * pair_mask[..., None]

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -94,8 +94,9 @@ class PLMModule(nn.Module):
         s_plm = self.layernorm(s_plm)
         if self.use_separate_projections:
             pair_mask = mask[..., None] & mask[..., None, :]
-            intra_mask = asym_id[..., None] == asym_id[..., None, :]
-            intra_mask, inter_mask = intra_mask & pair_mask, (~intra_mask) & pair_mask
+            is_same_chain = asym_id[..., None] == asym_id[..., None, :]
+            intra_mask = is_same_chain & pair_mask
+            inter_mask = (~is_same_chain) & pair_mask
             z = z + self.pairwise_proj_intra(s_plm) * intra_mask[..., None]
             z = z + self.pairwise_proj_inter(s_plm) * inter_mask[..., None]
         else:

--- a/src/kfold/model/layers/primitives/linear.py
+++ b/src/kfold/model/layers/primitives/linear.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 import torch.nn as nn
 
 from . import initialize
@@ -54,4 +52,8 @@ class Linear(nn.Linear):
             raise ValueError(f"Unknown initialization method: {init}")
 
 
-LinearNoBias = partial(Linear, bias=False)
+class LinearNoBias(Linear):
+    """A linear layer without bias term."""
+
+    def __init__(self, in_features: int, out_features: int, init: str = "default"):
+        super().__init__(in_features, out_features, bias=False, init=init)


### PR DESCRIPTION
This pull request refactors the use of bias-less linear layers in the kfold model by replacing the use of a `partial` function with a dedicated `LinearNoBias` class. It also improves masking logic in the pairwise projection section for better clarity and correctness. The most important changes are:

### Linear Layer Refactoring

* Introduced a new `LinearNoBias` class (subclassing `Linear`) in `linear.py` to explicitly represent linear layers without a bias term, replacing the previous use of `functools.partial`. This makes the codebase clearer and more maintainable.
* Updated imports and usage in `plm_module.py` to use `LinearNoBias` instead of the old `Linear` partial. [[1]](diffhunk://#diff-a1ced6d3b01fbace3b665e9c2c2d5f107d5bbe7e065b752b3ecfc32ae45c7c65L4-R4) [[2]](diffhunk://#diff-a1ced6d3b01fbace3b665e9c2c2d5f107d5bbe7e065b752b3ecfc32ae45c7c65L16-R16)
* Removed unused `functools.partial` import from `linear.py`.

### Masking Logic Improvements

* Refined the masking logic in the pairwise projection section of `plm_module.py` to introduce explicit `pair_mask`, `intra_mask`, and `inter_mask` variables, improving clarity and correctness of how intra- and inter-chain projections are applied.