### PR TITLE
feat(model): integrate GeoNorm into diffusion and trunk residual paths

### DIFF
--- a/configs/model/module/score_model/af3.yaml
+++ b/configs/model/module/score_model/af3.yaml
@@ -13,6 +13,9 @@ atom_encoder_blocks: 3
 atom_encoder_heads: 4
 token_transformer_blocks: 24
 token_transformer_heads: 16
+use_geonorm: true
+geonorm_decay: "harmonic"
+geonorm_clamp: 0.7853981633974483
 atom_decoder_blocks: 3
 atom_decoder_heads: 4
 conditioning_transition_layers: 2

--- a/configs/model/module/score_model/apo_conditioned.yaml
+++ b/configs/model/module/score_model/apo_conditioned.yaml
@@ -14,6 +14,9 @@ atom_encoder_blocks: 3
 atom_encoder_heads: 4
 token_transformer_blocks: 24
 token_transformer_heads: 16
+use_geonorm: true
+geonorm_decay: "harmonic"
+geonorm_clamp: 0.7853981633974483
 atom_decoder_blocks: 3
 atom_decoder_heads: 4
 conditioning_transition_layers: 2

--- a/configs/model/module/score_model/ecsi.yaml
+++ b/configs/model/module/score_model/ecsi.yaml
@@ -13,6 +13,9 @@ atom_encoder_blocks: 3
 atom_encoder_heads: 4
 token_transformer_blocks: 24
 token_transformer_heads: 16
+use_geonorm: true
+geonorm_decay: "harmonic"
+geonorm_clamp: 0.7853981633974483
 atom_decoder_blocks: 3
 atom_decoder_heads: 4
 conditioning_transition_layers: 2

--- a/configs/model/module/trunk/kfold-old.yaml
+++ b/configs/model/module/trunk/kfold-old.yaml
@@ -10,6 +10,9 @@ interformer:
   skip_tri_attn: false
   use_separate_projections: true
   use_qk_norm: false
+  use_geonorm: true
+  geonorm_decay: "harmonic"
+  geonorm_clamp: 0.7853981633974483
 blocks_per_ckpt: 1
 
 tri_attn_chunk_threshold: 384

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -13,6 +13,9 @@ pairformer:
   num_blocks: 48
   dropout: 0.25
   use_qk_norm: false
+  use_geonorm: true
+  geonorm_decay: "harmonic"
+  geonorm_clamp: 0.7853981633974483
 
 blocks_per_ckpt: 1
 tri_attn_chunk_threshold: 384

--- a/src/kfold/model/layers/alphafold3/diffusion.py
+++ b/src/kfold/model/layers/alphafold3/diffusion.py
@@ -83,6 +83,9 @@ class DiffusionModule(nn.Module):
         atom_encoder_heads: int = 4,
         token_transformer_blocks: int = 24,
         token_transformer_heads: int = 8,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
         atom_decoder_blocks: int = 3,
         atom_decoder_heads: int = 4,
         conditioning_transition_layers: int = 2,
@@ -169,6 +172,9 @@ class DiffusionModule(nn.Module):
             num_blocks=token_transformer_blocks,
             num_heads=token_transformer_heads,
             blocks_per_ckpt=blocks_per_ckpt,
+            use_geonorm=use_geonorm,
+            geonorm_decay=geonorm_decay,
+            geonorm_clamp=geonorm_clamp,
         )
 
         self.layernorm_a = LayerNorm(channel_token, create_offset=False)

--- a/src/kfold/model/layers/alphafold3/pairformer.py
+++ b/src/kfold/model/layers/alphafold3/pairformer.py
@@ -2,6 +2,7 @@
 
 # started from code from https://github.com/jwohlwend/boltz, MIT License,
 
+import math
 from functools import partial
 
 import torch
@@ -10,6 +11,7 @@ import torch.nn as nn
 from kfold.model.layers.primitives import (
     DropoutColumnwise,
     DropoutRowwise,
+    GeoNorm,
     TriangleAttentionEndingNode,
     TriangleAttentionStartingNode,
     TriangleMultiplicationIncoming,
@@ -35,6 +37,9 @@ class PairformerStack(nn.Module):
         num_blocks: int = 48,
         dropout: float = 0.25,
         use_qk_norm: bool = False,
+        use_geonorm: bool = False,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
         blocks_per_ckpt: int | None = None,
     ):
         """Initialize the Pairformer module."""
@@ -45,6 +50,7 @@ class PairformerStack(nn.Module):
         self.num_heads_tri_attn: int = num_heads_tri_attn
         self.dropout: float = dropout
         self.num_blocks: int = num_blocks
+        self.use_geonorm: bool = use_geonorm
 
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
 
@@ -57,7 +63,10 @@ class PairformerStack(nn.Module):
                     self.num_heads_attn,
                     self.num_heads_tri_attn,
                     self.dropout,
-                    use_qk_norm,
+                    use_qk_norm=use_qk_norm,
+                    use_geonorm=use_geonorm,
+                    geonorm_decay=geonorm_decay,
+                    geonorm_clamp=geonorm_clamp,
                 )
             )
 
@@ -106,8 +115,10 @@ class PairformerStack(nn.Module):
                 pair_mask=pair_mask.float(),
                 chunk_size_tri_attn=chunk_size_tri_attn,
                 use_cuequiv_kernels=use_cuequiv_kernels,
+                layer_number=layer_number,
+                layer_total=self.num_blocks,
             )
-            for b in self.blocks
+            for layer_number, b in enumerate(self.blocks)
         ]
         blocks_per_ckpt = self.blocks_per_ckpt
 
@@ -139,6 +150,9 @@ class PairformerBlock(nn.Module):
         num_heads_tri_attn: int = 4,
         dropout: float = 0.25,
         use_qk_norm: bool = False,
+        use_geonorm: bool = False,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
     ):
         """Initialize the Pairformer module.
 
@@ -159,6 +173,7 @@ class PairformerBlock(nn.Module):
         self.channel_s: int = channel_s
         self.channel_z: int = channel_z
         self.dropout: float = dropout
+        self.use_geonorm: bool = use_geonorm
 
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
@@ -185,6 +200,29 @@ class PairformerBlock(nn.Module):
         self.dropout_rowwise = DropoutRowwise(dropout)
         self.dropout_columnwise = DropoutColumnwise(dropout)
 
+        if self.use_geonorm:
+            self.geonorm_z_tri_mul_out = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_z_tri_mul_in = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_z_tri_att_start = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_z_tri_att_end = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_z_transition = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_s_attention = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_s_transition = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+
     def forward(
         self,
         s: torch.Tensor,
@@ -193,31 +231,41 @@ class PairformerBlock(nn.Module):
         pair_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
         use_cuequiv_kernels: bool = False,
+        layer_number: int = 0,
+        layer_total: int = 1,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
         See Section 3.6 Algorithm 20 Pairformer Stack
         """
 
         # Line 2
-        z = z + self.dropout_rowwise(
+        g_tri_mul_out = self.dropout_rowwise(
             self.tri_mul_out(
                 z,
                 pair_mask,
                 use_kernels=use_cuequiv_kernels,
             )
         )
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_mul_out(z, g_tri_mul_out, layer_number, layer_total)
+        else:
+            z = z + g_tri_mul_out
 
         # Line 3
-        z = z + self.dropout_rowwise(
+        g_tri_mul_in = self.dropout_rowwise(
             self.tri_mul_in(
                 z,
                 mask=pair_mask,
                 use_kernels=use_cuequiv_kernels,
             )
         )
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_mul_in(z, g_tri_mul_in, layer_number, layer_total)
+        else:
+            z = z + g_tri_mul_in
 
         # Line 4
-        z = z + self.dropout_rowwise(
+        g_tri_att_start = self.dropout_rowwise(
             self.tri_att_start(
                 z,
                 mask=pair_mask,
@@ -225,9 +273,15 @@ class PairformerBlock(nn.Module):
                 use_kernels=use_cuequiv_kernels,
             )
         )
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_att_start(
+                z, g_tri_att_start, layer_number, layer_total
+            )
+        else:
+            z = z + g_tri_att_start
 
         # Line 5
-        z = z + self.dropout_columnwise(
+        g_tri_att_end = self.dropout_columnwise(
             self.tri_att_end(
                 z,
                 mask=pair_mask,
@@ -235,20 +289,36 @@ class PairformerBlock(nn.Module):
                 use_kernels=use_cuequiv_kernels,
             )
         )
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_att_end(z, g_tri_att_end, layer_number, layer_total)
+        else:
+            z = z + g_tri_att_end
 
         # Line 6
-        z = z + self.transition_z(z)
+        g_z = self.transition_z(z)
+        if self.use_geonorm:
+            z = self.geonorm_z_transition(z, g_z, layer_number, layer_total)
+        else:
+            z = z + g_z
 
         # Line 7
-        s = s + self.attention(
+        g_s_attn = self.attention(
             s,  # [B, L, C_s]
             None,
             z,  # [B, L, L, C_z]
             attn_mask=single_mask,  # [B, L]
             use_kernels=use_cuequiv_kernels,
         )
+        if self.use_geonorm:
+            s = self.geonorm_s_attention(s, g_s_attn, layer_number, layer_total)
+        else:
+            s = s + g_s_attn
 
         # Line 8
-        s = s + self.transition_s(s)
+        g_s = self.transition_s(s)
+        if self.use_geonorm:
+            s = self.geonorm_s_transition(s, g_s, layer_number, layer_total)
+        else:
+            s = s + g_s
 
         return s, z

--- a/src/kfold/model/layers/alphafold3/transformers.py
+++ b/src/kfold/model/layers/alphafold3/transformers.py
@@ -11,6 +11,7 @@ from einops.layers.torch import Rearrange
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.primitives import (
     AdaLN,
+    GeoNorm,
     LayerNorm,
     Linear,
     LinearNoBias,
@@ -249,6 +250,9 @@ class DiffusionTransformer(nn.Module):
         num_blocks: int,
         num_heads: int,
         blocks_per_ckpt: int | None = None,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
     ):
         """Initialize the diffusion transformer.
 
@@ -269,6 +273,8 @@ class DiffusionTransformer(nn.Module):
 
         """
         super().__init__()
+        self.use_geonorm: bool = use_geonorm
+        self.num_blocks: int = num_blocks
         self.blocks = nn.ModuleList()
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
         for _ in range(num_blocks):
@@ -278,6 +284,9 @@ class DiffusionTransformer(nn.Module):
                     channel_s,
                     channel_z,
                     num_heads,
+                    use_geonorm=use_geonorm,
+                    geonorm_decay=geonorm_decay,
+                    geonorm_clamp=geonorm_clamp,
                 )
             )
 
@@ -309,15 +318,19 @@ class DiffusionTransformer(nn.Module):
             Whether to use custom kernel for attention, by default False
         """
         # Line 1, 4
-        blocks = [
-            partial(
-                b,
-                attn_mask=attn_mask,
-                local_attn_index=local_attn_index,
-                use_cuequiv_kernels=use_cuequiv_kernels,
+        layer_total = self.num_blocks
+        blocks = []
+        for layer_number, b in enumerate(self.blocks):
+            blocks.append(
+                partial(
+                    b,
+                    attn_mask=attn_mask,
+                    local_attn_index=local_attn_index,
+                    use_cuequiv_kernels=use_cuequiv_kernels,
+                    layer_number=layer_number,
+                    layer_total=layer_total,
+                )
             )
-            for b in self.blocks
-        ]
 
         if self.training and torch.is_grad_enabled():
             a, s, z = checkpoint_blocks(
@@ -344,6 +357,9 @@ class DiffusionTransformerBlock(nn.Module):
         channel_s: int,  # c_atom (atom-attn) or c_s (token-attn)
         channel_z: int,  # c_atompair (atom-attn) or c_z (token-attn)
         num_heads: int,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
     ):
         """Initialize the diffusion transformer block.
 
@@ -360,6 +376,14 @@ class DiffusionTransformerBlock(nn.Module):
 
         """
         super().__init__()
+        self.use_geonorm: bool = use_geonorm
+
+        # GeoNorm replaces x <- x + g with a geodesic update on the ℓ2 sphere.
+        # We keep the Attention/Transition modules unchanged and only modify
+        # the residual update, matching the paper's recommendation.
+        if self.use_geonorm:
+            self.geonorm_attn = GeoNorm(decay=geonorm_decay, clamp=geonorm_clamp)
+            self.geonorm_ffn = GeoNorm(decay=geonorm_decay, clamp=geonorm_clamp)
         self.attention = AttentionPairBias(
             channel_a=channel_a,
             channel_z=channel_z,
@@ -380,6 +404,8 @@ class DiffusionTransformerBlock(nn.Module):
         attn_mask: torch.Tensor,
         local_attn_index: LocalAttentionIndex | None = None,
         use_cuequiv_kernels: bool = False,
+        layer_number: int = 0,
+        layer_total: int = 1,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """See Section 3.7 Algorithm 23 Diffusion Transformer
 
@@ -415,7 +441,7 @@ class DiffusionTransformerBlock(nn.Module):
 
         """
         # Line 2
-        a = a + self.attention(
+        g_attn = self.attention(
             a=a,
             s=s,
             z=z,
@@ -423,8 +449,18 @@ class DiffusionTransformerBlock(nn.Module):
             local_attn_index=local_attn_index,
             use_kernels=use_cuequiv_kernels,
         )
+
+        if self.use_geonorm:
+            a = self.geonorm_attn(a, g_attn, layer_number, layer_total)
+        else:
+            a = a + g_attn
+
         # Line 3
-        a = a + self.transition(a, s)
+        g_ffn = self.transition(a, s)
+        if self.use_geonorm:
+            a = self.geonorm_ffn(a, g_ffn, layer_number, layer_total)
+        else:
+            a = a + g_ffn
 
         # NOTE: Return updated a, s, z (s and z are unchanged)
         # This is to maintain compatibility with checkpoint_blocks

--- a/src/kfold/model/layers/kfold/diffusion.py
+++ b/src/kfold/model/layers/kfold/diffusion.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 import torch.nn as nn
 
@@ -31,6 +33,9 @@ class DiffusionModuleWithApo(nn.Module):
         atom_encoder_heads: int = 4,
         token_transformer_blocks: int = 24,
         token_transformer_heads: int = 8,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
         atom_decoder_blocks: int = 3,
         atom_decoder_heads: int = 4,
         conditioning_transition_layers: int = 2,
@@ -118,6 +123,9 @@ class DiffusionModuleWithApo(nn.Module):
             num_blocks=token_transformer_blocks,
             num_heads=token_transformer_heads,
             blocks_per_ckpt=blocks_per_ckpt,
+            use_geonorm=use_geonorm,
+            geonorm_decay=geonorm_decay,
+            geonorm_clamp=geonorm_clamp,
         )
         self.layernorm_a = LayerNorm(channel_token, create_offset=False)
 

--- a/src/kfold/model/layers/kfold/interformer.py
+++ b/src/kfold/model/layers/kfold/interformer.py
@@ -19,6 +19,7 @@ ESMFold—which updates the pairwise embeddings using both the element-wise
 difference and product of the single embeddings.
 """
 
+import math
 from functools import partial
 
 import torch
@@ -29,6 +30,7 @@ from kfold.model.layers.alphafold3.transition import Transition
 from kfold.model.layers.primitives import (
     DropoutColumnwise,
     DropoutRowwise,
+    GeoNorm,
     LayerNorm,
     Linear,
     TriangleAttentionEndingNode,
@@ -54,9 +56,13 @@ class InterformerStack(nn.Module):
         skip_tri_attn: bool = False,
         use_qk_norm: bool = False,
         blocks_per_ckpt: int | None = None,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
     ) -> None:
         """Initialize the Interformer module."""
         super().__init__()
+        self.num_blocks: int = num_blocks
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
         self.blocks = nn.ModuleList()
         for _ in range(num_blocks):
@@ -70,6 +76,9 @@ class InterformerStack(nn.Module):
                     use_separate_projections,
                     skip_tri_attn,
                     use_qk_norm,
+                    use_geonorm=use_geonorm,
+                    geonorm_decay=geonorm_decay,
+                    geonorm_clamp=geonorm_clamp,
                 )
             )
 
@@ -122,8 +131,10 @@ class InterformerStack(nn.Module):
                 pair_mask=pair_mask,
                 chunk_size_tri_attn=chunk_size_tri_attn,
                 use_cuequiv_kernels=use_cuequiv_kernels,
+                layer_number=layer_number,
+                layer_total=self.num_blocks,
             )
-            for b in self.blocks
+            for layer_number, b in enumerate(self.blocks)
         ]
         blocks_per_ckpt = self.blocks_per_ckpt
 
@@ -202,6 +213,9 @@ class InterformerBlock(nn.Module):
         use_separate_projections: bool = True,
         skip_tri_attn: bool = False,
         use_qk_norm: bool = False,
+        use_geonorm: bool = True,
+        geonorm_decay: str = "harmonic",
+        geonorm_clamp: float = math.pi / 4,
     ) -> None:
         """Initialize the Interformer module.
 
@@ -230,6 +244,44 @@ class InterformerBlock(nn.Module):
         self.num_heads_tri_attn: int = num_heads_tri_attn
         self.skip_tri_attn: bool = skip_tri_attn
         self.dropout: float = dropout
+
+        self.use_geonorm: bool = use_geonorm
+        if self.use_geonorm:
+            # GeoNorm replaces x <- x + g with a geodesic update on the ℓ2 sphere.
+            # We keep the internal modules unchanged and only modify residual updates.
+            if use_separate_projections:
+                self.geonorm_z_proj_intra = GeoNorm(
+                    decay=geonorm_decay, clamp=geonorm_clamp
+                )
+                self.geonorm_z_proj_inter = GeoNorm(
+                    decay=geonorm_decay, clamp=geonorm_clamp
+                )
+            else:
+                self.geonorm_z_proj = GeoNorm(decay=geonorm_decay, clamp=geonorm_clamp)
+
+            self.geonorm_z_tri_mul_out = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_z_tri_mul_in = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            if not skip_tri_attn:
+                self.geonorm_z_tri_att_start = GeoNorm(
+                    decay=geonorm_decay, clamp=geonorm_clamp
+                )
+                self.geonorm_z_tri_att_end = GeoNorm(
+                    decay=geonorm_decay, clamp=geonorm_clamp
+                )
+            self.geonorm_z_transition = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+
+            self.geonorm_s_attention = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
+            self.geonorm_s_transition = GeoNorm(
+                decay=geonorm_decay, clamp=geonorm_clamp
+            )
 
         self.use_separate_projections: bool = use_separate_projections
         if self.use_separate_projections:
@@ -273,35 +325,59 @@ class InterformerBlock(nn.Module):
         intra_mask: torch.Tensor,
         chunk_size_tri_attn: int | None = None,
         use_cuequiv_kernels: bool = False,
+        layer_number: int = 0,
+        layer_total: int = 1,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass."""
 
         # Information flow from single (s) to pairwise (z)
         # Separate projections for intra- and inter-chain residue pairs
         if self.use_separate_projections:
-            z = z + self.pairwise_proj_intra(s) * intra_mask[..., None]
-            z = z + self.pairwise_proj_inter(s) * (~intra_mask)[..., None]
+            g_intra = self.pairwise_proj_intra(s) * intra_mask[..., None]
+            if self.use_geonorm:
+                z = self.geonorm_z_proj_intra(z, g_intra, layer_number, layer_total)
+            else:
+                z = z + g_intra
+
+            g_inter = self.pairwise_proj_inter(s) * (~intra_mask)[..., None]
+            if self.use_geonorm:
+                z = self.geonorm_z_proj_inter(z, g_inter, layer_number, layer_total)
+            else:
+                z = z + g_inter
         else:
-            z = z + self.pairwise_proj(s)
+            g_proj = self.pairwise_proj(s)
+            if self.use_geonorm:
+                z = self.geonorm_z_proj(z, g_proj, layer_number, layer_total)
+            else:
+                z = z + g_proj
 
         # Triangle multiplicative update
-        z = z + self.dropout_rowwise(
+        g_tri_mul_out = self.dropout_rowwise(
             self.tri_mul_out(
                 z,
                 pair_mask,
                 use_kernels=use_cuequiv_kernels,
             )
         )
-        z = z + self.dropout_rowwise(
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_mul_out(z, g_tri_mul_out, layer_number, layer_total)
+        else:
+            z = z + g_tri_mul_out
+
+        g_tri_mul_in = self.dropout_rowwise(
             self.tri_mul_in(
                 z,
                 mask=pair_mask,
                 use_kernels=use_cuequiv_kernels,
             )
         )
+        if self.use_geonorm:
+            z = self.geonorm_z_tri_mul_in(z, g_tri_mul_in, layer_number, layer_total)
+        else:
+            z = z + g_tri_mul_in
         if not self.skip_tri_attn:
             # Triangle attention update
-            z = z + self.dropout_rowwise(
+            g_tri_att_start = self.dropout_rowwise(
                 self.tri_att_start(
                     z,
                     mask=pair_mask,
@@ -309,7 +385,14 @@ class InterformerBlock(nn.Module):
                     use_kernels=use_cuequiv_kernels,
                 )
             )
-            z = z + self.dropout_columnwise(
+            if self.use_geonorm:
+                z = self.geonorm_z_tri_att_start(
+                    z, g_tri_att_start, layer_number, layer_total
+                )
+            else:
+                z = z + g_tri_att_start
+
+            g_tri_att_end = self.dropout_columnwise(
                 self.tri_att_end(
                     z,
                     mask=pair_mask,
@@ -317,18 +400,37 @@ class InterformerBlock(nn.Module):
                     use_kernels=use_cuequiv_kernels,
                 )
             )
+            if self.use_geonorm:
+                z = self.geonorm_z_tri_att_end(
+                    z, g_tri_att_end, layer_number, layer_total
+                )
+            else:
+                z = z + g_tri_att_end
 
         # Transition for pairwise representation
-        z = z + self.transition_z(z)
+        g_z = self.transition_z(z)
+        if self.use_geonorm:
+            z = self.geonorm_z_transition(z, g_z, layer_number, layer_total)
+        else:
+            z = z + g_z
 
         # Information flow from pairwise (z) to single (s)
-        s = s + self.attention(
+        g_s_attn = self.attention(
             s,  # [B, L, C_s]
             None,
             z,  # [B, L, L, C_z]
             attn_mask=single_mask,  # [B, L]
             use_kernels=use_cuequiv_kernels,
         )
-        s = s + self.transition_s(s)
+        if self.use_geonorm:
+            s = self.geonorm_s_attention(s, g_s_attn, layer_number, layer_total)
+        else:
+            s = s + g_s_attn
+
+        g_s = self.transition_s(s)
+        if self.use_geonorm:
+            s = self.geonorm_s_transition(s, g_s, layer_number, layer_total)
+        else:
+            s = s + g_s
 
         return s, z

--- a/src/kfold/model/layers/primitives/__init__.py
+++ b/src/kfold/model/layers/primitives/__init__.py
@@ -2,7 +2,7 @@ from .activation import SwiGLU
 from .attention import attention
 from .dropout import DropoutColumnwise, DropoutRowwise
 from .linear import Linear, LinearNoBias
-from .normalization import AdaLN, LayerNorm
+from .normalization import AdaLN, GeoNorm, LayerNorm
 from .triangle_attention import (
     TriangleAttentionEndingNode,
     TriangleAttentionStartingNode,
@@ -17,6 +17,7 @@ __all__ = [
     "Linear",
     "LinearNoBias",
     "AdaLN",
+    "GeoNorm",
     "LayerNorm",
     "attention",
     "TriangleAttentionStartingNode",

--- a/src/kfold/model/layers/primitives/normalization.py
+++ b/src/kfold/model/layers/primitives/normalization.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 import torch.nn as nn
 
@@ -85,3 +87,134 @@ class AdaLN(nn.Module):
         # Line 3
         a = self.sigmoid(self.linear_g(s)) * a + self.linear_bias(s)
         return a
+
+
+class GeoNorm(nn.Module):
+    """GeoNorm geodesic residual update.
+
+    This is based on GeoNorm (arXiv:2601.22095), which replaces the
+    projection-style normalization + residual addition with a geodesic
+    update on an ℓ2-sphere via the exponential map.
+
+    Unlike LayerNorm/RMSNorm, GeoNorm is not a unary normalization op.
+    It combines the current state `x` (residual stream) and an update
+    direction `g` (e.g. Attention(x) or FFN(x)) into an updated state.
+
+    The core update (Eq. 3-5 + Appendix D) is:
+      1) Project `g` onto the tangent space at `x`.
+      2) Compute an angle θ proportional to ||v|| / ||x|| (clamped).
+      3) Move along the great-circle geodesic: x' = x cosθ + u ||x|| sinθ
+         where u is the unit tangent direction.
+
+    Notes for this codebase:
+    - We compute in fp32 for numerical stability and cast back.
+    - If ||x|| is near-zero (common for padded tokens), we fall back to
+      standard residual addition (x + g) to avoid undefined geometry.
+    """
+
+    def __init__(
+        self,
+        clamp: float = math.pi / 4,
+        decay: str = "harmonic",
+        eps: float = 1e-8,
+        zero_norm_fallback: str = "residual",  # "residual" | "keep"
+    ) -> None:
+        super().__init__()
+        # Learnable affine on the (pre-decay) angle.
+        # (Appendix D uses scalar scale/bias.)
+        self.scale = nn.Parameter(torch.tensor(1.0))
+        self.bias = nn.Parameter(torch.tensor(0.0))
+
+        self.clamp: float = float(clamp)
+        self.decay: str = str(decay).lower()
+        self.eps: float = float(eps)
+
+        if zero_norm_fallback not in {"residual", "keep"}:
+            raise ValueError(
+                "zero_norm_fallback must be one of: 'residual', 'keep'"
+            )
+        self.zero_norm_fallback = zero_norm_fallback
+
+    def _apply_decay(
+        self,
+        theta: torch.Tensor,
+        layer_number: int,
+        layer_total: int,
+    ) -> torch.Tensor:
+        """Apply layer-wise step-size decay schedule."""
+        if self.decay in {"none", "no", ""}:
+            return theta
+        if self.decay == "harmonic":
+            return theta / float(layer_number + 1)
+        if self.decay == "sqrt":
+            return theta / math.sqrt(layer_number + 1)
+        if self.decay == "linear":
+            # Linear decay to 0 as we approach the last layer.
+            # Use max(1, layer_total) to avoid divide-by-zero.
+            denom = float(max(1, layer_total))
+            return theta * float(layer_total - layer_number) / denom
+
+        raise ValueError(
+            f"Unsupported GeoNorm decay schedule: {self.decay}. "
+            "Use one of: none, harmonic, sqrt, linear."
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        g: torch.Tensor,
+        layer_number: int,
+        layer_total: int,
+    ) -> torch.Tensor:
+        if x.shape != g.shape:
+            raise ValueError(
+                f"GeoNorm requires x and g to have the same shape, got "
+                f"x={tuple(x.shape)} and g={tuple(g.shape)}"
+            )
+
+        # Compute in float32 for stability (esp. on fp16/bf16).
+        x_dtype = x.dtype
+        x_f = x.float()
+        g_f = g.float()
+
+        # ||x|| and (||x|| + eps)^2
+        x_norm = torch.linalg.vector_norm(x_f, ord=2, dim=-1, keepdim=True)
+        x_norm_sq = (x_norm + self.eps) ** 2
+
+        # Project update direction onto tangent space at x:
+        # v = g - <x, g> / ||x||^2 * x
+        dot = (x_f * g_f).sum(dim=-1, keepdim=True)
+        v = g_f - (dot / x_norm_sq) * x_f
+
+        v_norm = torch.linalg.vector_norm(v, ord=2, dim=-1, keepdim=True) + self.eps
+        unit_tangent = v / v_norm
+
+        # Base angle (Appendix D): θ = ||v|| / ||x|| (clamped)
+        theta = torch.clamp(v_norm / (x_norm + self.eps), max=self.clamp)
+
+        # Learnable affine on theta before decay (Appendix D).
+        theta = theta * self.scale + self.bias
+
+        # Layer-wise decay schedule (paper suggests harmonic/sqrt/linear).
+        theta = self._apply_decay(
+            theta,
+            layer_number=layer_number,
+            layer_total=layer_total,
+        )
+        theta = torch.clamp(theta, max=self.clamp)
+
+        # Geodesic update on the sphere (Eq. 3):
+        # x' = x cosθ + unit_tangent * ||x|| sinθ
+        out = x_f * torch.cos(theta) + unit_tangent * x_norm * torch.sin(theta)
+
+        # If the residual stream is near-zero, the tangent space is ill-defined.
+        # This happens frequently on padded tokens / empty pair slots.
+        # Fall back to a simple residual update or keep x unchanged.
+        near_zero = (x_norm < 1e-6)
+        if near_zero.any():
+            if self.zero_norm_fallback == "residual":
+                out = torch.where(near_zero, x_f + g_f, out)
+            elif self.zero_norm_fallback == "keep":
+                out = torch.where(near_zero, x_f, out)
+
+        return out.to(dtype=x_dtype)

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 
 from kfold.data.types.model_input import FoldingInput
@@ -64,6 +66,9 @@ class AF3DiffusionModule(BaseScoreModel):
         atom_encoder_heads: int = 4
         token_transformer_blocks: int = 24
         token_transformer_heads: int = 8
+        use_geonorm: bool = True
+        geonorm_decay: str = "harmonic"
+        geonorm_clamp: float = math.pi / 4
         atom_decoder_blocks: int = 3
         atom_decoder_heads: int = 4
         conditioning_transition_layers: int = 2
@@ -85,6 +90,9 @@ class AF3DiffusionModule(BaseScoreModel):
             atom_encoder_heads=cfg.atom_encoder_heads,
             token_transformer_blocks=cfg.token_transformer_blocks,
             token_transformer_heads=cfg.token_transformer_heads,
+            use_geonorm=cfg.use_geonorm,
+            geonorm_decay=cfg.geonorm_decay,
+            geonorm_clamp=cfg.geonorm_clamp,
             atom_decoder_blocks=cfg.atom_decoder_blocks,
             atom_decoder_heads=cfg.atom_decoder_heads,
             conditioning_transition_layers=cfg.conditioning_transition_layers,

--- a/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
+++ b/src/kfold/model/modules/score_model/apo_conditioned_diffusion.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 
 from kfold.data.types.model_input import FoldingInput
@@ -66,6 +68,9 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
         atom_encoder_heads: int = 4
         token_transformer_blocks: int = 24
         token_transformer_heads: int = 8
+        use_geonorm: bool = True
+        geonorm_decay: str = "harmonic"
+        geonorm_clamp: float = math.pi / 4
         atom_decoder_blocks: int = 3
         atom_decoder_heads: int = 4
         conditioning_transition_layers: int = 2
@@ -74,7 +79,9 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
     def __init__(self, cfg: Config, kernel_config):
         super().__init__(cfg, kernel_config)
 
-        diffusion_stack_class = DiffusionModuleWithApo if cfg.use_apo else DiffusionModule
+        diffusion_stack_class = (
+            DiffusionModuleWithApo if cfg.use_apo else DiffusionModule
+        )
         self.diffusion_stack = diffusion_stack_class(
             channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
@@ -88,6 +95,9 @@ class ApoConditionedDiffusionModule(BaseScoreModel):
             atom_encoder_heads=cfg.atom_encoder_heads,
             token_transformer_blocks=cfg.token_transformer_blocks,
             token_transformer_heads=cfg.token_transformer_heads,
+            use_geonorm=cfg.use_geonorm,
+            geonorm_decay=cfg.geonorm_decay,
+            geonorm_clamp=cfg.geonorm_clamp,
             atom_decoder_blocks=cfg.atom_decoder_blocks,
             atom_decoder_heads=cfg.atom_decoder_heads,
             conditioning_transition_layers=cfg.conditioning_transition_layers,

--- a/src/kfold/model/modules/score_model/ecsi_diffusion.py
+++ b/src/kfold/model/modules/score_model/ecsi_diffusion.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 
 from kfold.data.types.model_input import FoldingInput
@@ -62,6 +64,9 @@ class ECSIDiffusionModule(BaseScoreModel):
         atom_encoder_heads: int = 4
         token_transformer_blocks: int = 24
         token_transformer_heads: int = 8
+        use_geonorm: bool = True
+        geonorm_decay: str = "harmonic"
+        geonorm_clamp: float = math.pi / 4
         atom_decoder_blocks: int = 3
         atom_decoder_heads: int = 4
         conditioning_transition_layers: int = 2
@@ -91,6 +96,9 @@ class ECSIDiffusionModule(BaseScoreModel):
             atom_encoder_heads=cfg.atom_encoder_heads,
             token_transformer_blocks=cfg.token_transformer_blocks,
             token_transformer_heads=cfg.token_transformer_heads,
+            use_geonorm=cfg.use_geonorm,
+            geonorm_decay=cfg.geonorm_decay,
+            geonorm_clamp=cfg.geonorm_clamp,
             atom_decoder_blocks=cfg.atom_decoder_blocks,
             atom_decoder_heads=cfg.atom_decoder_heads,
             conditioning_transition_layers=cfg.conditioning_transition_layers,

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -1,6 +1,7 @@
 """KFold trunk module."""
 
 import dataclasses
+import math
 
 import torch
 import torch.nn as nn
@@ -28,6 +29,9 @@ class PairformerConfig:
     dropout: float = 0.25
     # Proteina-style QK normalization (LayerNorm on Q and K before head split)
     use_qk_norm: bool = False
+    use_geonorm: bool = False
+    geonorm_decay: str = "harmonic"
+    geonorm_clamp: float = math.pi / 4
 
 
 @TRUNK.register()
@@ -91,6 +95,9 @@ class KFoldTrunk(BaseTrunk):
             num_blocks=cfg.pairformer.num_blocks,
             dropout=cfg.pairformer.dropout,
             use_qk_norm=cfg.pairformer.use_qk_norm,
+            use_geonorm=cfg.pairformer.use_geonorm,
+            geonorm_decay=cfg.pairformer.geonorm_decay,
+            geonorm_clamp=cfg.pairformer.geonorm_clamp,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 

--- a/src/kfold/model/modules/trunk/kfold_trunk_old.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk_old.py
@@ -37,6 +37,7 @@ The KFoldTrunk module consists of the following:
 """
 
 import dataclasses
+import math
 
 import torch
 import torch.nn as nn
@@ -59,6 +60,9 @@ class InterformerConfig:
     skip_tri_attn: bool = False
     # Proteina-style QK normalization (LayerNorm on Q and K before head split)
     use_qk_norm: bool = False
+    use_geonorm: bool = True
+    geonorm_decay: str = "harmonic"
+    geonorm_clamp: float = math.pi / 4
 
 
 @TRUNK.register()
@@ -118,6 +122,9 @@ class KFoldTrunkV0(BaseTrunk):
             skip_tri_attn=cfg.interformer.skip_tri_attn,
             use_separate_projections=cfg.interformer.use_separate_projections,
             use_qk_norm=cfg.interformer.use_qk_norm,
+            use_geonorm=cfg.interformer.use_geonorm,
+            geonorm_decay=cfg.interformer.geonorm_decay,
+            geonorm_clamp=cfg.interformer.geonorm_clamp,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 


### PR DESCRIPTION
## Summary
- add GeoNorm primitive and expose it via primitives package
- apply optional geodesic residual updates across diffusion/pairformer/interformer blocks
- thread geonorm flags (use_geonorm, geonorm_decay, geonorm_clamp) through score and trunk modules
- enable geonorm defaults in AF3, apo-conditioned, ECSI, and kfold trunk configs

## Notes
- this PR is based on commit 6d64ae1
- local untracked files were intentionally not included in this PR