### PR TITLE
bugfix in inference: apo perturb on ; no ligand apo init

### DIFF
--- a/configs/dataset/default.yaml
+++ b/configs/dataset/default.yaml
@@ -11,7 +11,7 @@ apo_init:
   use_random_augmentation: true
   use_residue_permutation: false
   prob_perturbation: 0.95
-  use_cached_conformer: true
+  use_cached_conformer_only: true
   use_holo_if_apo_unavailable: false
   protein_perturbation: null
   ligand_perturbation: null

--- a/configs/dataset/default.yaml
+++ b/configs/dataset/default.yaml
@@ -8,7 +8,6 @@ seed: null # should be null for data augmentation
 is_protein_monomer_distillation: false # whether this dataset is for protein monomer distillation
 
 apo_init:
-  use_random_augmentation: true
   use_residue_permutation: false
   prob_perturbation: 0.95
   use_cached_conformer_only: true
@@ -18,7 +17,6 @@ apo_init:
 
 prior_sampler:
   num_samples: 0
-  use_random_augmentation: true
   use_chain_com_sampling: false
   use_ot_permutation: false
   translation_scale: 1.0 # Angstroms

--- a/src/kfold/data/pipelines/apo_initialization.py
+++ b/src/kfold/data/pipelines/apo_initialization.py
@@ -111,7 +111,7 @@ class ApoInitializerConfig:
         NOTE: Training only.
     prob_perturbation : float
         Probability of applying perturbation to apo structures.
-    use_cached_conformer : bool
+    use_cached_conformer_only : bool
         Whether to use cached conformers only for small molecules.
     protein_perturbation : ProteinPerturbationConfig | None
         Configuration for protein apo perturbation.
@@ -122,7 +122,7 @@ class ApoInitializerConfig:
     use_random_augmentation: bool = True
     use_residue_permutation: bool = False
     prob_perturbation: float = 1.0
-    use_cached_conformer: bool = True
+    use_cached_conformer_only: bool = False
     use_holo_if_apo_unavailable: bool = True
     protein_perturbation: ProteinPerturbationConfig | None = dataclasses.field(
         default_factory=ProteinPerturbationConfig
@@ -138,7 +138,7 @@ class ApoInitializer:
     def __init__(
         self,
         config: ApoInitializerConfig,
-        ccd: CCD | None = None,
+        ccd: CCD,
         is_protein_monomer_distillation: bool = False,
     ):
         self.config: ApoInitializerConfig = config
@@ -167,7 +167,7 @@ class ApoInitializer:
         # Training mode
         # During train/val, disable ETKDG generation for efficiency,
         # i.e., only the cached ETKDG and CCD conformers (ideal, mode) are used.
-        self.conformer_mode: str = "train" if config.use_cached_conformer else "auto"
+        self.conformer_mode: str = "train" if config.use_cached_conformer_only else "auto"
 
         # Logger
         self.logger = logging.getLogger("ApoInitializer")

--- a/src/kfold/data/pipelines/apo_initialization.py
+++ b/src/kfold/data/pipelines/apo_initialization.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
 from functools import lru_cache
+from typing import Self
 
 import numpy as np
 
@@ -103,9 +104,6 @@ class ApoInitializerConfig:
 
     Attributes
     ----------
-    use_random_augmentation : bool
-        Whether to apply random rotation/translation augmentation
-        to apo structures.
     use_residue_permutation : bool
         Whether to find optimal residue permutation for symmetry correction.
         NOTE: Training only.
@@ -119,7 +117,6 @@ class ApoInitializerConfig:
         Configuration for ligand perturbation.
     """
 
-    use_random_augmentation: bool = True
     use_residue_permutation: bool = False
     prob_perturbation: float = 1.0
     use_cached_conformer_only: bool = False
@@ -142,7 +139,6 @@ class ApoInitializer:
         is_protein_monomer_distillation: bool = False,
     ):
         self.config: ApoInitializerConfig = config
-        self.use_random_augmentation: bool = config.use_random_augmentation
         self.use_residue_permutation: bool = config.use_residue_permutation
         self.use_holo_if_apo_unavailable: bool = config.use_holo_if_apo_unavailable
 
@@ -171,6 +167,19 @@ class ApoInitializer:
 
         # Logger
         self.logger = logging.getLogger("ApoInitializer")
+
+    @classmethod
+    def inference_mode(cls, ccd: CCD) -> Self:
+        """Get ApoInitializer instance for inference mode."""
+        return cls(
+            config=ApoInitializerConfig(
+                use_residue_permutation=False,
+                use_cached_conformer_only=False,
+                protein_perturbation=None,
+                ligand_perturbation=None,
+            ),
+            ccd=ccd,
+        )
 
     def __call__(
         self,
@@ -299,9 +308,8 @@ class ApoInitializer:
                 f"expected ({chain.num_residues}, {Natom}, 3), got {apo_coords.shape}"
             )
 
-            if self.use_random_augmentation:
-                # Apply random rotation/translation augmentation
-                apo_coords = self.apply_random_augmentation(apo_coords, rng)
+            # Apply random rotation/translation augmentation
+            apo_coords = self.apply_random_augmentation(apo_coords, rng)
 
             # Insert apo coordinates into chain according to atom order
             # [L, Natom, 3] -> [Nallatoms, 3]
@@ -375,9 +383,8 @@ class ApoInitializer:
             ):
                 apo_coords = self.ligand_perturbation(apo_coords, chain, rng)
 
-            if self.use_random_augmentation:
-                # Apply random rotation augmentation
-                apo_coords = self.apply_random_augmentation(apo_coords[None, ...], rng)[0]
+            # Apply random rotation augmentation
+            apo_coords = self.apply_random_augmentation(apo_coords[None, ...], rng)[0]
 
             # Feed apo coordinates
             chain.atom.apo_coords[:, :] = apo_coords
@@ -432,8 +439,7 @@ class ApoInitializer:
             apo_coords = self.apply_perturbation(sequence, apo_coords, rng)
 
         # Apply random augmentation
-        if self.use_random_augmentation:
-            apo_coords = self.apply_random_augmentation(apo_coords, rng)
+        apo_coords = self.apply_random_augmentation(apo_coords, rng)
 
         # Feed apo coordinates
         chain.atom.apo_coords[:] = apo_coords[res_indices, atom_indices]

--- a/src/kfold/data/pipelines/prior_sampling.py
+++ b/src/kfold/data/pipelines/prior_sampling.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 from collections import defaultdict
 from functools import lru_cache
+from typing import Self
 
 import numpy as np
 
@@ -39,9 +40,6 @@ class PriorSamplerConfig:
     ----------
     num_samples : int
         Number of prior coordinates to sample.
-    use_random_augmentation : bool
-        Whether to apply random rotation/translation augmentation
-        to apo structures.
     use_chain_com_sampling : bool
         If set, place each chain's center of mass on a sphere surface with
         this radius (uniformly sampled).
@@ -52,16 +50,13 @@ class PriorSamplerConfig:
     """
 
     num_samples: int = 1
-    use_random_augmentation: bool = True
     use_chain_com_sampling: bool = False
     use_ot_permutation: bool = False
     translation_scale: float = 1.0  # Angstrom
     # Langevin dynamics parameters for relaxing missing atoms
     relaxation: LangevinDynamicsConfig = dataclasses.field(
         default_factory=lambda: LangevinDynamicsConfig(
-            num_steps=200,
-            res_r=4.0,
-            bond_r=2.0,
+            num_steps=64, res_r=4.0, bond_r=2.0
         )
     )
 
@@ -83,6 +78,18 @@ class PriorSampler:
 
         # Logger
         self.logger = logging.getLogger("PriorSampler")
+
+    @classmethod
+    def inference_mode(cls, ccd: CCD, num_samples: int) -> Self:
+        """Get a PriorSampler instance configured for inference"""
+        return cls(
+            config=PriorSamplerConfig(
+                num_samples=num_samples,
+                use_chain_com_sampling=False,
+                use_ot_permutation=False,
+            ),
+            ccd=ccd,
+        )
 
     def __call__(self, struct: RefStructure, rng: np.random.Generator) -> np.ndarray:
         """Sample prior coordinates for the given structure.
@@ -158,9 +165,7 @@ class PriorSampler:
                 )
 
             # Apply random rotation/translation augmentation
-            augmented_coords = chain_coords
-            if self.config.use_random_augmentation:
-                augmented_coords = self.apply_random_augmentation(chain_coords, rng)
+            augmented_coords = self.apply_random_augmentation(chain_coords, rng)
             prior_coords_list.append(augmented_coords)
 
         if self.use_ot_permutation:

--- a/src/kfold/inference/data_pipeline.py
+++ b/src/kfold/inference/data_pipeline.py
@@ -37,7 +37,12 @@ class InputDataPipeline:
 
         # Initialize apo initializer
         self.apo_initializer = apo_initialization.ApoInitializer(
-            apo_initialization.ApoInitializerConfig(), self.ccd
+            apo_initialization.ApoInitializerConfig(
+                protein_perturbation=None,
+                ligand_perturbation=None,
+                use_cached_conformer_only=False,
+            ),
+            self.ccd,
         )
         self.prior_sampler = prior_sampling.PriorSampler(
             prior_sampling.PriorSamplerConfig(num_samples=num_samples),

--- a/src/kfold/inference/data_pipeline.py
+++ b/src/kfold/inference/data_pipeline.py
@@ -36,18 +36,8 @@ class InputDataPipeline:
         self.seed: int = seed
 
         # Initialize apo initializer
-        self.apo_initializer = apo_initialization.ApoInitializer(
-            apo_initialization.ApoInitializerConfig(
-                protein_perturbation=None,
-                ligand_perturbation=None,
-                use_cached_conformer_only=False,
-            ),
-            self.ccd,
-        )
-        self.prior_sampler = prior_sampling.PriorSampler(
-            prior_sampling.PriorSamplerConfig(num_samples=num_samples),
-            self.ccd,
-        )
+        self.apo_initializer = apo_initialization.ApoInitializer.inference_mode(ccd)
+        self.prior_sampler = prior_sampling.PriorSampler.inference_mode(ccd, num_samples)
 
         # Initialize tokenizer
         self.tokenizer = tokenization.Tokenizer(self.prior_sampler, self.ccd)


### PR DESCRIPTION
- Fix two bugs in inference pipeline:
1. ligand etkdg conformer was not used for `ccd-test.pkl` (no cached conformer)
2. apo perturbation was turned on.

- Remove unused hparams to prevent bug.