### PR TITLE
Feat/use attn

### DIFF
--- a/configs/model/module/sequence_encoder/esmc_600m.yaml
+++ b/configs/model/module/sequence_encoder/esmc_600m.yaml
@@ -4,4 +4,4 @@ path: ???
 d_model: 1152
 n_heads: 18
 n_layers: 36
-return_attn: false
+return_attn: true

--- a/configs/model/module/trunk/kfold-prime.yaml
+++ b/configs/model/module/trunk/kfold-prime.yaml
@@ -3,26 +3,28 @@ _class_: "KFoldTrunkPrime"
 channel_s: 384
 channel_z: 128
 
+channel_s_plm: 1152
+channel_z_plm: 648
+
 plm_module:
-  channel_plm_input: ???
-  channel_plm: 512
   num_heads_attn: 16
   num_heads_tri_attn: 4
   num_blocks: 4
   dropout_plm: 0.15
   dropout_z: 0.25
   use_separate_projections: true
-  use_qk_norm: true
+  use_qk_norm: false
+  blocks_per_ckpt: 1
 
 pairformer:
   num_heads_attn: 16
   num_heads_tri_attn: 4
   num_blocks: 24
   dropout: 0.25
-  use_qk_norm: true
+  use_qk_norm: false
+  blocks_per_ckpt: 1
 
-num_register_tokens: 8
+num_register_tokens: 0
 register_token_init_std: 0.05
 
-blocks_per_ckpt: 1
 tri_attn_chunk_threshold: 384

--- a/configs/model/module/trunk/kfold-prime.yaml
+++ b/configs/model/module/trunk/kfold-prime.yaml
@@ -3,7 +3,7 @@ _class_: "KFoldTrunkPrime"
 channel_s: 384
 channel_z: 128
 
-channel_plm: 1152
+channel_plm: 768
 channel_seq_emb: 1152
 channel_seq_attn: 648
 use_attn: true

--- a/configs/model/module/trunk/kfold-prime.yaml
+++ b/configs/model/module/trunk/kfold-prime.yaml
@@ -3,8 +3,10 @@ _class_: "KFoldTrunkPrime"
 channel_s: 384
 channel_z: 128
 
-channel_s_plm: 1152
-channel_z_plm: 648
+channel_plm: 1152
+channel_seq_emb: 1152
+channel_seq_attn: 648
+use_attn: true
 
 plm_module:
   num_heads_attn: 16

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -3,26 +3,28 @@ _class_: "KFoldTrunk"
 channel_s: 384
 channel_z: 128
 
+channel_s_plm: 1152
+channel_z_plm: 648
+
 plm_module:
-  channel_plm_input: ???
-  channel_plm: 512
   num_heads_attn: 16
   num_heads_tri_attn: 4
   num_blocks: 4
   dropout_plm: 0.15
   dropout_z: 0.25
   use_separate_projections: true
-  use_qk_norm: true
+  use_qk_norm: false
+  blocks_per_ckpt: 1
 
 pairformer:
   num_heads_attn: 16
   num_heads_tri_attn: 4
   num_blocks: 48
   dropout: 0.25
-  use_qk_norm: true
+  use_qk_norm: false
+  blocks_per_ckpt: 1
 
-num_register_tokens: 8
+num_register_tokens: 0
 register_token_init_std: 0.05
 
-blocks_per_ckpt: 1
 tri_attn_chunk_threshold: 384

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -3,7 +3,7 @@ _class_: "KFoldTrunk"
 channel_s: 384
 channel_z: 128
 
-channel_plm: 1152
+channel_plm: 768
 channel_seq_emb: 1152
 channel_seq_attn: 648
 use_attn: true

--- a/configs/model/module/trunk/kfold.yaml
+++ b/configs/model/module/trunk/kfold.yaml
@@ -3,8 +3,10 @@ _class_: "KFoldTrunk"
 channel_s: 384
 channel_z: 128
 
-channel_s_plm: 1152
-channel_z_plm: 648
+channel_plm: 1152
+channel_seq_emb: 1152
+channel_seq_attn: 648
+use_attn: true
 
 plm_module:
   num_heads_attn: 16

--- a/configs/train-ecsi-large.yaml
+++ b/configs/train-ecsi-large.yaml
@@ -1,5 +1,5 @@
 model:
-  _yaml_: "model/kfold-prime-edm.yaml"
+  _yaml_: "model/kfold-prime-ecsi.yaml"
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
@@ -17,13 +17,13 @@ model:
 
 train:
   _yaml_: "train/stage_1.yaml"
-  name: edm-prime-large
+  name: ecsi-prime-mini
   out_dir: ./experiments/
 
   global_hparams:
     batch_size: 1
     max_tokens: 376
-    global_batch_size: 256
+    global_batch_size: 128
 
   data:
     ccd_path: /cache/wykim_lab/kfold_data/v260227/ccd-train.pkl
@@ -31,40 +31,33 @@ train:
       - _yaml_: "dataset/rcsb-train.yaml"
         weight: 0.6
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/rcsb-train/
-        prior_sampler: null
 
       - _yaml_: "dataset/afdb-long.yaml"
         weight: 0.345
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/afdb-long/
-        prior_sampler: null
 
       - _yaml_: "dataset/afdb-short.yaml"
         weight: 0.005
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/afdb-short/
-        prior_sampler: null
 
       - _yaml_: "dataset/humap.yaml"
         weight: 0.03
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/huMAP/
-        prior_sampler: null
 
       - _yaml_: "dataset/natural_ab.yaml"
         weight: 0.01
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/NatAb/
-        prior_sampler: null
 
       - _yaml_: "dataset/encore.yaml"
         weight: 0.01
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/ENCORE/
-        prior_sampler: null
 
     val_datasets:
       - _yaml_: "dataset/rcsb-val.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/rcsb-val/
-        prior_sampler: null
 
   wandb:
     use: false
-    project: "KFold-Combined"
-    group: edm
+    project: "KFold"
+    group: ecsi # set your group name
     entity: K-Fold # set your entity name

--- a/configs/train-ecsi-large.yaml
+++ b/configs/train-ecsi-large.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: null

--- a/configs/train-ecsi-mini.yaml
+++ b/configs/train-ecsi-mini.yaml
@@ -3,16 +3,21 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
+    channel_s_plm: 1152
+    channel_z_plm: 648
     plm_module:
-      channel_plm_input: 1152
+      use_qk_norm: true
+      blocks_per_ckpt: 4
     pairformer:
       num_blocks: 16
-    blocks_per_ckpt: 4
+      use_qk_norm: true
+      blocks_per_ckpt: 16
+    num_register_tokens: 8
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
     atom_decoder_blocks: 1
-    blocks_per_ckpt: null
+    blocks_per_ckpt: 8
 
 train:
   _yaml_: "train/stage_1.yaml"

--- a/configs/train-ecsi-mini.yaml
+++ b/configs/train-ecsi-mini.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: 4

--- a/configs/train-ecsi-prime.yaml
+++ b/configs/train-ecsi-prime.yaml
@@ -3,16 +3,21 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
+    channel_s_plm: 1152
+    channel_z_plm: 648
     plm_module:
-      channel_plm_input: 1152
+      use_qk_norm: true
+      blocks_per_ckpt: 4
     pairformer:
       num_blocks: 12
-    blocks_per_ckpt: 4
+      use_qk_norm: true
+      blocks_per_ckpt: 12
+    num_register_tokens: 8
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
     atom_decoder_blocks: 1
-    blocks_per_ckpt: null
+    blocks_per_ckpt: 8
 
 train:
   _yaml_: "train/stage_1.yaml"

--- a/configs/train-ecsi-prime.yaml
+++ b/configs/train-ecsi-prime.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: 4

--- a/configs/train-edm-large.yaml
+++ b/configs/train-edm-large.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: null

--- a/configs/train-edm-mini.yaml
+++ b/configs/train-edm-mini.yaml
@@ -3,16 +3,21 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
+    channel_s_plm: 1152
+    channel_z_plm: 648
     plm_module:
-      channel_plm_input: 1152
+      use_qk_norm: true
+      blocks_per_ckpt: 4
     pairformer:
       num_blocks: 16
-    blocks_per_ckpt: 4
+      use_qk_norm: true
+      blocks_per_ckpt: 16
+    num_register_tokens: 8
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
     atom_decoder_blocks: 1
-    blocks_per_ckpt: null
+    blocks_per_ckpt: 8
 
 train:
   _yaml_: "train/stage_1.yaml"

--- a/configs/train-edm-mini.yaml
+++ b/configs/train-edm-mini.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: 4

--- a/configs/train-edm-prime.yaml
+++ b/configs/train-edm-prime.yaml
@@ -3,16 +3,21 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
+    channel_s_plm: 1152
+    channel_z_plm: 648
     plm_module:
-      channel_plm_input: 1152
+      use_qk_norm: true
+      blocks_per_ckpt: 4
     pairformer:
       num_blocks: 12
-    blocks_per_ckpt: 4
+      use_qk_norm: true
+      blocks_per_ckpt: 12
+    num_register_tokens: 8
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
     atom_decoder_blocks: 1
-    blocks_per_ckpt: null
+    blocks_per_ckpt: 8
 
 train:
   _yaml_: "train/stage_1.yaml"

--- a/configs/train-edm-prime.yaml
+++ b/configs/train-edm-prime.yaml
@@ -3,8 +3,8 @@ model:
   sequence_encoder:
     path: /mnt/parallel_storage/share/plm_weights/esm/esm-seo-v2.pt
   trunk:
-    channel_s_plm: 1152
-    channel_z_plm: 648
+    channel_seq_emb: 1152
+    channel_seq_attn: 648
     plm_module:
       use_qk_norm: true
       blocks_per_ckpt: 4

--- a/configs/train-edm-prime.yaml
+++ b/configs/train-edm-prime.yaml
@@ -6,18 +6,18 @@ model:
     channel_seq_emb: 1152
     channel_seq_attn: 648
     plm_module:
-      use_qk_norm: true
+      use_qk_norm: false
       blocks_per_ckpt: 4
     pairformer:
       num_blocks: 12
-      use_qk_norm: true
+      use_qk_norm: false
       blocks_per_ckpt: 12
-    num_register_tokens: 8
+    num_register_tokens: 0
   score_model:
     atom_encoder_blocks: 1
     token_transformer_blocks: 8
     atom_decoder_blocks: 1
-    blocks_per_ckpt: 8
+    blocks_per_ckpt: null
 
 train:
   _yaml_: "train/stage_1.yaml"
@@ -25,8 +25,8 @@ train:
   out_dir: ./experiments/
 
   global_hparams:
-    batch_size: 4
-    max_tokens: 376
+    batch_size: 2
+    max_tokens: 384
     global_batch_size: 128
 
   data:
@@ -35,11 +35,18 @@ train:
       - _yaml_: "dataset/rcsb-train.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/rcsb-train/
         prior_sampler: null
+        apo_init:
+          use_residue_permutation: false
 
     val_datasets:
       - _yaml_: "dataset/rcsb-val.yaml"
         data_path: /cache/wykim_lab/kfold_data/v260227/dataset/rcsb-val/
         prior_sampler: null
+
+  loss:
+    diffusion_loss:
+      smooth_lddt_loss:
+        chunk_size: 12
 
   wandb:
     use: false

--- a/configs/train/structure-only.yaml
+++ b/configs/train/structure-only.yaml
@@ -139,7 +139,7 @@ loss:
 
     # Smooth LDDT Loss
     smooth_lddt_loss:
-      chunk_size: 2 # in number of samples.
+      chunk_size: 8 # in number of samples.
 
   # Confidence loss
   # TODO

--- a/src/kfold/data/pipelines/apo_initialization.py
+++ b/src/kfold/data/pipelines/apo_initialization.py
@@ -619,7 +619,7 @@ class ApoInitializer:
                 if chain.residue.is_standard[res_i]:
                     # Get ambiguous atom permutations for this standard residue
                     assert ctype.is_polymer, "Only polymer chains have standard residues."
-                    perms = get_ambiguous_atoms_in_residue(res_name, extended=True)
+                    perms = get_ambiguous_atoms_in_residue(res_name, extended=False)
                 elif res_name in self.ccd:
                     ref_mol = get_ref_comp(res_name)
                     atom_names: list[str] = all_atom_names[atom_st:atom_end]
@@ -645,8 +645,9 @@ class ApoInitializer:
                 min_rmsd = float("inf")
                 for perm in perms[:100]:
                     permuted_apo = res_apo[perm, :]
-                    permuted_apo_mask = res_apo_mask[perm]
-                    m = res_holo_mask & permuted_apo_mask
+                    m = res_holo_mask & res_apo_mask[perm]
+                    if not m.any():
+                        continue
                     rmsd = compute_rmsd(
                         permuted_apo[m], res_holo[m], mask=None, align=True, no_svd=True
                     )
@@ -656,5 +657,3 @@ class ApoInitializer:
                 if best_perm is not None:
                     # Apply best permutation
                     res_apo[:, :] = res_apo[best_perm, :]
-                else:
-                    pass

--- a/src/kfold/data/pipelines/tokenization.py
+++ b/src/kfold/data/pipelines/tokenization.py
@@ -608,8 +608,7 @@ def find_best_residue_permutation(
             continue
         rmsd = compute_rmsd(x[m], label_pos[m], mask=None, align=True, no_svd=True)
         if rmsd < best_rmsd:
-            best_rmsd = rmsd
-            best_perm = perm
+            best_rmsd, best_perm = rmsd, perm
     if best_perm is not None and best_perm == list(range(len(ref_pos))):
         best_perm = None
     return best_perm

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -79,7 +79,7 @@ class PLMEmbedder(nn.Module):
     def forward(
         self,
         s_input: torch.Tensor,
-        s_plm: torch.Tensor,
+        seq_emb: torch.Tensor,
     ) -> torch.Tensor:
         """Perform the forward pass.
 
@@ -87,7 +87,7 @@ class PLMEmbedder(nn.Module):
         ----------
         s_input : torch.Tensor
             The input single representations of shape (B, L, C_s)
-        s_plm : torch.Tensor
+        seq_emb : torch.Tensor
             The sequence embeddings from PLM of shape (B, L, C_s_plm)
 
         Returns
@@ -96,7 +96,7 @@ class PLMEmbedder(nn.Module):
             The fused single representations of shape (B, L, C_s * 2)
         """
         s_input_proj = self.linear_s_input(s_input)  # (B, L, C_s_plm)
-        s_seq_emb_proj = self.linear_seq_emb(s_plm)  # (B, L, C_s_plm)
+        s_seq_emb_proj = self.linear_seq_emb(seq_emb)  # (B, L, C_s_plm)
         s_fused = s_input_proj + s_seq_emb_proj  # (B, L, C_s_plm)
         return s_fused
 

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -69,8 +69,7 @@ class PLMModule(nn.Module):
         self,
         channel_s: int = 384,
         channel_z: int = 128,
-        channel_plm_input: int = 2560,
-        channel_plm: int = 512,
+        channel_s_plm: int = 1152,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
         num_blocks: int = 4,
@@ -83,21 +82,16 @@ class PLMModule(nn.Module):
         super().__init__()
         self.channel_s: int = channel_s
         self.channel_z: int = channel_z
-        self.channel_plm_input: int = channel_plm_input
-        self.channel_plm: int = channel_plm
-        self.blocks_per_ckpt: int | None = blocks_per_ckpt
+        self.channel_s_plm: int = channel_s_plm
 
-        self.proj_s_plm = nn.Sequential(
-            LayerNorm(channel_plm_input, create_offset=False),
-            LinearNoBias(channel_plm_input, channel_plm, init="default"),
-        )
-        self.proj_s_input = LinearNoBias(channel_s, channel_plm, init="default")
+        self.proj_s_input = LinearNoBias(channel_s, channel_s * 2, init="default")
+        self.proj_s_plm = LinearNoBias(channel_s_plm, channel_s * 2, init="default")
 
         self.blocks = torch.nn.ModuleList()
         for i in range(num_blocks):
             self.blocks.append(
                 PLMBlock(
-                    channel_plm=channel_plm,
+                    channel_s=channel_s * 2,
                     channel_z=channel_z,
                     num_heads_attn=num_heads_attn,
                     num_heads_tri_attn=num_heads_tri_attn,
@@ -108,6 +102,7 @@ class PLMModule(nn.Module):
                     is_last_block=(i == num_blocks - 1),
                 )
             )
+        self.blocks_per_ckpt: int | None = blocks_per_ckpt
 
     def forward(
         self,
@@ -124,11 +119,11 @@ class PLMModule(nn.Module):
         Parameters
         ----------
         z : torch.Tensor
-            The pair representations
+            The pair representations of shape (B, L, L, C_z)
         s_input : torch.Tensor
-            The input single representations
+            The input single representations of shape (B, L, C_s)
         s_plm : torch.Tensor
-            The sequence embeddings
+            The sequence embeddings from PLM of shape (B, L, C_s_plm)
         asym_id : torch.Tensor
             The asymmetry IDs of shape (B, L)
         mask : torch.Tensor
@@ -150,8 +145,7 @@ class PLMModule(nn.Module):
         inter_mask = pair_mask & (~is_same_chain)
 
         # Initial linear projection
-        s_plm = self.proj_s_plm(s_plm)
-        s_plm = s_plm + self.proj_s_input(s_input)
+        s = self.proj_s_plm(s_plm) + self.proj_s_input(s_input)
 
         # PLM Blocks
         blocks = [
@@ -167,15 +161,15 @@ class PLMModule(nn.Module):
             for b in self.blocks
         ]
         if self.training and torch.is_grad_enabled():
-            s_plm, z = checkpoint_blocks(
+            s, z = checkpoint_blocks(
                 blocks,
-                (s_plm, z),
+                (s, z),
                 self.blocks_per_ckpt,
                 use_reentrant=False,
             )
         else:
             for b in blocks:
-                s_plm, z = b(s_plm, z)
+                s, z = b(s, z)
 
         return z
 
@@ -183,7 +177,7 @@ class PLMModule(nn.Module):
 class PLMBlock(nn.Module):
     def __init__(
         self,
-        channel_plm: int = 512,
+        channel_s: int = 1536,
         channel_z: int = 128,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
@@ -194,15 +188,15 @@ class PLMBlock(nn.Module):
         is_last_block: bool = False,
     ) -> None:
         super().__init__()
-        self.channel_plm: int = channel_plm
+        self.channel_s: int = channel_s
         self.channel_z: int = channel_z
         self.use_separate_projections: bool = use_separate_projections
 
         if self.use_separate_projections:
-            self.pairwise_proj_intra = PairwiseProdDiff(channel_plm, channel_z)
-            self.pairwise_proj_inter = PairwiseProdDiff(channel_plm, channel_z)
+            self.pairwise_proj_intra = PairwiseProdDiff(channel_s, channel_z)
+            self.pairwise_proj_inter = PairwiseProdDiff(channel_s, channel_z)
         else:
-            self.pairwise_proj = PairwiseProdDiff(channel_plm, channel_z)
+            self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
 
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
@@ -222,14 +216,14 @@ class PLMBlock(nn.Module):
         self.is_last_block: bool = is_last_block
         if not self.is_last_block:
             self.attention = AttentionPairBias(
-                channel_a=channel_plm,
+                channel_a=channel_s,
                 channel_z=channel_z,
                 channel_s=None,
                 num_heads=num_heads_attn,
                 use_single_cond=False,
                 qk_norm=use_qk_norm,
             )
-            self.transition_plm = Transition(channel_plm, expansion_factor=4)
+            self.transition_plm = Transition(channel_s, expansion_factor=4)
 
     def forward(
         self,
@@ -246,10 +240,10 @@ class PLMBlock(nn.Module):
 
         Parameters
         ----------
-        z : torch.Tensor
-            The pair representations
         s_plm : torch.Tensor
             The sequence embeddings
+        z : torch.Tensor
+            The pair representations
         mask : torch.Tensor
             The token mask of shape (B, L)
         pair_mask : torch.Tensor

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -61,12 +61,51 @@ class PairwiseProdDiff(nn.Module):
         return z
 
 
+class PLMEmbedder(nn.Module):
+    """
+    Separated embedder of PLMModule to avoid redundant computation across recyling steps.
+    """
+
+    def __init__(
+        self,
+        channel_s_input: int = 384,
+        channel_seq_emb: int = 1152,
+        channel_plm: int = 768,
+    ) -> None:
+        super().__init__()
+        self.linear_s_input = LinearNoBias(channel_s_input, channel_plm, init="default")
+        self.linear_seq_emb = LinearNoBias(channel_seq_emb, channel_plm, init="default")
+
+    def forward(
+        self,
+        s_input: torch.Tensor,
+        s_plm: torch.Tensor,
+    ) -> torch.Tensor:
+        """Perform the forward pass.
+
+        Parameters
+        ----------
+        s_input : torch.Tensor
+            The input single representations of shape (B, L, C_s)
+        s_plm : torch.Tensor
+            The sequence embeddings from PLM of shape (B, L, C_s_plm)
+
+        Returns
+        -------
+        torch.Tensor
+            The fused single representations of shape (B, L, C_s * 2)
+        """
+        s_input_proj = self.linear_s_input(s_input)  # (B, L, C_s_plm)
+        s_seq_emb_proj = self.linear_seq_emb(s_plm)  # (B, L, C_s_plm)
+        s_fused = s_input_proj + s_seq_emb_proj  # (B, L, C_s_plm)
+        return s_fused
+
+
 class PLMModule(nn.Module):
     def __init__(
         self,
-        channel_s: int = 384,
         channel_z: int = 128,
-        channel_s_plm: int = 1152,
+        channel_plm: int = 768,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
         num_blocks: int = 4,
@@ -77,20 +116,12 @@ class PLMModule(nn.Module):
         blocks_per_ckpt: int | None = None,
     ) -> None:
         super().__init__()
-        self.channel_s: int = channel_s
-        self.channel_z: int = channel_z
-        self.channel_s_plm: int = channel_s_plm
-
-        self.linear_s_input = LinearNoBias(channel_s, channel_s * 2, init="default")
-        # Assume the plm embedding is post-norm output.
-        self.linear_s_plm = LinearNoBias(channel_s_plm, channel_s * 2, init="default")
-
         self.blocks = torch.nn.ModuleList()
         for i in range(num_blocks):
             self.blocks.append(
                 PLMBlock(
-                    channel_s=channel_s * 2,
                     channel_z=channel_z,
+                    channel_plm=channel_plm,
                     num_heads_attn=num_heads_attn,
                     num_heads_tri_attn=num_heads_tri_attn,
                     dropout_plm=dropout_plm,
@@ -105,7 +136,6 @@ class PLMModule(nn.Module):
     def forward(
         self,
         z: torch.Tensor,
-        s_input: torch.Tensor,
         s_plm: torch.Tensor,
         asym_id: torch.Tensor,
         mask: torch.Tensor,
@@ -118,8 +148,6 @@ class PLMModule(nn.Module):
         ----------
         z : torch.Tensor
             The pair representations of shape (B, L, L, C_z)
-        s_input : torch.Tensor
-            The input single representations of shape (B, L, C_s)
         s_plm : torch.Tensor
             The sequence embeddings from PLM of shape (B, L, C_s_plm)
         asym_id : torch.Tensor
@@ -142,9 +170,6 @@ class PLMModule(nn.Module):
         intra_mask = pair_mask & is_same_chain
         inter_mask = pair_mask & (~is_same_chain)
 
-        # Initial linear projection
-        s = self.linear_s_plm(s_plm) + self.linear_s_input(s_input)
-
         # PLM Blocks
         blocks = [
             partial(
@@ -159,15 +184,15 @@ class PLMModule(nn.Module):
             for b in self.blocks
         ]
         if self.training and torch.is_grad_enabled():
-            s, z = checkpoint_blocks(
+            s_plm, z = checkpoint_blocks(
                 blocks,
-                (s, z),
+                (s_plm, z),
                 self.blocks_per_ckpt,
                 use_reentrant=False,
             )
         else:
             for b in blocks:
-                s, z = b(s, z)
+                s_plm, z = b(s_plm, z)
 
         return z
 
@@ -175,8 +200,8 @@ class PLMModule(nn.Module):
 class PLMBlock(nn.Module):
     def __init__(
         self,
-        channel_s: int = 1536,
         channel_z: int = 128,
+        channel_plm: int = 768,
         num_heads_attn: int = 16,
         num_heads_tri_attn: int = 4,
         dropout_plm: float = 0.15,
@@ -186,15 +211,15 @@ class PLMBlock(nn.Module):
         is_last_block: bool = False,
     ) -> None:
         super().__init__()
-        self.channel_s: int = channel_s
         self.channel_z: int = channel_z
+        self.channel_plm: int = channel_plm
         self.use_separate_projections: bool = use_separate_projections
 
         if self.use_separate_projections:
-            self.pairwise_proj_intra = PairwiseProdDiff(channel_s, channel_z)
-            self.pairwise_proj_inter = PairwiseProdDiff(channel_s, channel_z)
+            self.pairwise_proj_intra = PairwiseProdDiff(channel_plm, channel_z)
+            self.pairwise_proj_inter = PairwiseProdDiff(channel_plm, channel_z)
         else:
-            self.pairwise_proj = PairwiseProdDiff(channel_s, channel_z)
+            self.pairwise_proj = PairwiseProdDiff(channel_plm, channel_z)
 
         self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
         self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
@@ -214,14 +239,14 @@ class PLMBlock(nn.Module):
         self.is_last_block: bool = is_last_block
         if not self.is_last_block:
             self.attention = AttentionPairBias(
-                channel_a=channel_s,
+                channel_a=channel_plm,
                 channel_z=channel_z,
                 channel_s=None,
                 num_heads=num_heads_attn,
                 use_single_cond=False,
                 qk_norm=use_qk_norm,
             )
-            self.transition_plm = Transition(channel_s, expansion_factor=4)
+            self.transition_plm = Transition(channel_plm, expansion_factor=4)
 
     def forward(
         self,

--- a/src/kfold/model/layers/kfold/plm_module.py
+++ b/src/kfold/model/layers/kfold/plm_module.py
@@ -47,10 +47,7 @@ class PairwiseProdDiff(nn.Module):
             The output tensor (*, L, L, c_out).
         """
         s = self.layernorm(s)  # (*, L, c_in)
-        s_i, s_j = torch.chunk(
-            self.linear_in(s), 2, dim=-1
-        )  # (*, L, c_hid), (*, L, c_hid)
-
+        s_i, s_j = self.linear_in(s).chunk(2, dim=-1)  # 2 * (*, L, c_hid)
         s_i = s_i.unsqueeze(-2)  # (*, L, 1, c_hidden)
         s_j = s_j.unsqueeze(-3)  # (*, 1, L, c_hidden)
 
@@ -84,8 +81,9 @@ class PLMModule(nn.Module):
         self.channel_z: int = channel_z
         self.channel_s_plm: int = channel_s_plm
 
-        self.proj_s_input = LinearNoBias(channel_s, channel_s * 2, init="default")
-        self.proj_s_plm = LinearNoBias(channel_s_plm, channel_s * 2, init="default")
+        self.linear_s_input = LinearNoBias(channel_s, channel_s * 2, init="default")
+        # Assume the plm embedding is post-norm output.
+        self.linear_s_plm = LinearNoBias(channel_s_plm, channel_s * 2, init="default")
 
         self.blocks = torch.nn.ModuleList()
         for i in range(num_blocks):
@@ -145,7 +143,7 @@ class PLMModule(nn.Module):
         inter_mask = pair_mask & (~is_same_chain)
 
         # Initial linear projection
-        s = self.proj_s_plm(s_plm) + self.proj_s_input(s_input)
+        s = self.linear_s_plm(s_plm) + self.linear_s_input(s_input)
 
         # PLM Blocks
         blocks = [

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -129,7 +129,7 @@ class KFold(BaseFoldingModel):
             f_input,
             num_recycles,
             s_plm=s_plm,
-            attn_plm=attn_plm,
+            z_plm=attn_plm,
         )
         s_trunk = trunk_out["s_trunk"]
         z_trunk = trunk_out["z_trunk"]
@@ -245,7 +245,7 @@ class KFold(BaseFoldingModel):
             f_input,
             num_recycles,
             s_plm=s_plm,
-            attn_plm=attn_plm,
+            z_plm=attn_plm,
         )
         et = time.time()
         s_trunk = trunk_out["s_trunk"]

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -119,7 +119,7 @@ class KFold(BaseFoldingModel):
 
         s_inputs, s_init, z_init = self.input_embedder(f_input)
 
-        s_plm, attn_plm = self.sequence_encoder(f_input)
+        seq_emb, seq_attn = self.sequence_encoder(f_input)
 
         # Trunk with recycling
         trunk_out = self.trunk(
@@ -128,8 +128,8 @@ class KFold(BaseFoldingModel):
             z_init,
             f_input,
             num_recycles,
-            s_plm=s_plm,
-            z_plm=attn_plm,
+            seq_emb=seq_emb,
+            seq_attn=seq_attn,
         )
         s_trunk = trunk_out["s_trunk"]
         z_trunk = trunk_out["z_trunk"]
@@ -232,7 +232,7 @@ class KFold(BaseFoldingModel):
 
         # Sequence encoder
         st = time.time()
-        s_plm, attn_plm = self.sequence_encoder(f_input)
+        seq_emb, seq_attn = self.sequence_encoder(f_input)
         et = time.time()
         time_logs["sequence_encoder"] = et - st
 
@@ -244,8 +244,8 @@ class KFold(BaseFoldingModel):
             z_init,
             f_input,
             num_recycles,
-            s_plm=s_plm,
-            z_plm=attn_plm,
+            seq_emb=seq_emb,
+            seq_attn=seq_attn,
         )
         et = time.time()
         s_trunk = trunk_out["s_trunk"]
@@ -253,7 +253,7 @@ class KFold(BaseFoldingModel):
         time_logs["trunk"] = et - st
 
         dict_out = {
-            "s_plm": s_plm,
+            "seq_emb": seq_emb,
             "s_trunk": s_trunk,
             "z_trunk": z_trunk,
         }

--- a/src/kfold/model/modules/sequence_encoder/esmc.py
+++ b/src/kfold/model/modules/sequence_encoder/esmc.py
@@ -34,7 +34,7 @@ class ESMC(BaseSequenceEncoder):
         d_model: int = 1152
         n_heads: int = 18
         n_layers: int = 36
-        return_attn: bool = False
+        return_attn: bool = True
 
     def __init__(self, cfg: Config):
         super().__init__(cfg)
@@ -203,7 +203,11 @@ class ESMC(BaseSequenceEncoder):
         token_mask = f_input.token.pad_mask
         # mask out non-protein tokens
         token_mask = token_mask & f_input.token.is_protein
+        # attention mask: [B, Ntoken, Ntoken]
         attn_mask = token_mask.unsqueeze(-1) & token_mask.unsqueeze(-2)
+        # mask out attention between different chains
+        asym_id = f_input.token.asym_id
+        attn_mask &= asym_id.unsqueeze(-1) == asym_id.unsqueeze(-2)
 
         x = x * token_mask[..., None]
         attn = attn * attn_mask[..., None]

--- a/src/kfold/model/modules/sequence_encoder/esmc.py
+++ b/src/kfold/model/modules/sequence_encoder/esmc.py
@@ -138,7 +138,7 @@ class ESMC(BaseSequenceEncoder):
             x = torch.stack(x_list, dim=0)
 
             # normalize
-            x = self.transformer.norm(x)
+            x = self.transformer.norm(x).to(torch.bfloat16)
 
         # mask out invalid tokens
         pad_mask = f_input.token.pad_mask
@@ -186,9 +186,9 @@ class ESMC(BaseSequenceEncoder):
             for block in self.transformer.blocks:
                 _x, _attn_i = block(_x, _seq_id, _pos_id)
                 # [n_heads, seq_len, seq_len] -> [n_heads, n_tokens, n_tokens]
-                _attn_i = _attn_i.to(torch.bfloat16)
-                _attn_i = _attn_i[:, _seq_token_i, :][:, :, _seq_token_i]
-                _attn_list.append(_attn_i.permute(1, 2, 0))
+                _attn_i = _attn_i[:, _seq_token_i[:, None], _seq_token_i[None, :]]
+                _attn_i = _attn_i.permute(1, 2, 0)  # [n_tokens, n_tokens, n_heads]
+                _attn_list.append(_attn_i.to(torch.bfloat16))
 
             x_list.append(_x[_seq_token_i, :])
             attn_list.append(torch.cat(_attn_list, dim=-1))

--- a/src/kfold/model/modules/trunk/kfold_prime.py
+++ b/src/kfold/model/modules/trunk/kfold_prime.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.alphafold3.pairformer import PairformerStack
-from kfold.model.layers.kfold.plm_module import PLMModule
+from kfold.model.layers.kfold.plm_module import PLMEmbedder, PLMModule
 from kfold.model.layers.primitives import LayerNorm, LinearNoBias
 from kfold.utils.registry import TRUNK
 
@@ -26,10 +26,14 @@ class KFoldTrunkPrime(BaseTrunk):
             The token single embedding size.
         channel_z : int
             The token pairwise embedding size.
-        channel_s_plm : int
-            The token single embedding size for the PLM module.
-        channel_z_plm : int
-            The token attention map size for the PLM module.
+        channel_plm : int
+            The hidden dimension for the PLMModule.
+        channel_seq_emb : int
+            The sequence embedding size for the PLM module.
+        channel_seq_attn : int
+            The number of attention maps for the PLM module.
+        use_attn : bool
+            Whether to use attention in the PLM module.
         num_heads_attn : int, optional
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
@@ -44,8 +48,10 @@ class KFoldTrunkPrime(BaseTrunk):
         channel_z: int = 128
 
         # PLM dimensions.
-        channel_s_plm: int = 1152
-        channel_z_plm: int = 648
+        channel_plm: int = 1152
+        channel_seq_emb: int = 1152
+        channel_seq_attn: int = 648
+        use_attn: bool = True
 
         # plm module
         plm_module: PLMModuleConfig = dataclasses.field(default_factory=PLMModuleConfig)
@@ -64,11 +70,35 @@ class KFoldTrunkPrime(BaseTrunk):
         """Initialize the KFoldTrunkPrime module."""
         super().__init__(cfg, kernel_config)
 
+        # === PLM feature processing layers === #
+        self.layernorm_seq_emb = LayerNorm(cfg.channel_seq_emb, create_offset=False)
+
+        # Projections from PLM features to trunk features.
+        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
+        # we may want to have separate projections for s_plm and z_plm.
+        self.use_attn = cfg.use_attn
+        if self.use_attn:
+            self.proj_seq_attn_to_z_init = nn.Sequential(
+                LayerNorm(cfg.channel_seq_attn, create_offset=False),
+                LinearNoBias(cfg.channel_seq_attn, cfg.channel_z, init="relu"),
+                nn.ReLU(),
+                LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
+            )
+
+        # For the skip connection from PLM features to s_trunk output.
+        self.proj_seq_emb_to_s_trunk = LinearNoBias(
+            cfg.channel_seq_emb, cfg.channel_s, init="final"
+        )
+
         # === Priming pass before recycling === #
+        self.plm_embedder_prime: PLMEmbedder = PLMEmbedder(
+            channel_s_input=cfg.channel_s,
+            channel_seq_emb=cfg.channel_seq_emb,
+            channel_plm=cfg.channel_plm,
+        )
         self.plm_module_prime: PLMModule = PLMModule(
-            channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_s_plm=cfg.channel_s_plm,
+            channel_plm=cfg.channel_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -92,10 +122,14 @@ class KFoldTrunkPrime(BaseTrunk):
 
         # === Refine Module with recycling === #
         # PLM module
+        self.plm_embedder_refine: PLMEmbedder = PLMEmbedder(
+            channel_s_input=cfg.channel_s,
+            channel_seq_emb=cfg.channel_seq_emb,
+            channel_plm=cfg.channel_plm,
+        )
         self.plm_module_refine: PLMModule = PLMModule(
-            channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_s_plm=cfg.channel_s_plm,
+            channel_plm=cfg.channel_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -126,22 +160,6 @@ class KFoldTrunkPrime(BaseTrunk):
         self.layernorm_z = LayerNorm(cfg.channel_z)
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
-
-        # Projections from PLM features to trunk features.
-        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
-        # we may want to have separate projections for s_plm and z_plm.
-        self.proj_plm_to_z_init = nn.Sequential(
-            LayerNorm(cfg.channel_z_plm, create_offset=False),
-            LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
-            nn.ReLU(),
-            LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
-        )
-
-        # For the skip connection from PLM features to s_trunk output.
-        # Assume the plm embedding is post-norm output.
-        self.proj_plm_to_s_trunk = LinearNoBias(
-            cfg.channel_s_plm, cfg.channel_s, init="final"
-        )
 
         # Proteina-style register tokens (learnable sequence-level registers).
         self.num_register_tokens: int = cfg.num_register_tokens
@@ -226,38 +244,37 @@ class KFoldTrunkPrime(BaseTrunk):
         z_aug: torch.Tensor
             The augmented pair representation for distogram prediction
         """
-        if not self.training:
-            if z_init.shape[1] > self.chunk_threshold:
-                chunk_size_tri_attn = 128
-            else:
-                chunk_size_tri_attn = 512
-        else:
-            chunk_size_tri_attn = None
+        chunk_size_tri_attn = self._compute_chunk_size(s_inputs.shape[1])
 
         # Get PLM features
-        assert "s_plm" in kwargs, "PLM features s_plm must be provided in kwargs"
-        assert "z_plm" in kwargs, "PLM features z_plm must be provided in kwargs"
-        s_plm: torch.Tensor = kwargs["s_plm"]
-        z_plm: torch.Tensor = kwargs["z_plm"]
+        assert "seq_emb" in kwargs, "PLM features s_plm must be provided in kwargs"
+        assert "seq_attn" in kwargs, "PLM features z_plm must be provided in kwargs"
+        seq_emb: torch.Tensor = kwargs["seq_emb"]
+        seq_attn: torch.Tensor = kwargs["seq_attn"]
 
-        # Add z_plm to z_init before trunk.
-        z_init = z_init + self.proj_plm_to_z_init(z_plm)
+        # Layer norm on PLM features.
+        seq_emb = self.layernorm_seq_emb(seq_emb)
+
+        if self.use_attn:
+            # Feed attention maps to initialize z_init.
+            z_init = z_init + self.proj_seq_attn_to_z_init(seq_attn)
+        del seq_attn  # free memory
 
         # === Proteina-style register tokens (optional) ===
         mask = f_input.token.pad_mask
         asym_id = f_input.token.asym_id
-        s_inputs, s_init, s_plm, z_init, asym_id, mask = self._extend_registers(
-            s_inputs, s_init, s_plm, z_init, asym_id, mask
+        s_inputs, s_init, seq_emb, z_init, asym_id, mask = self._extend_registers(
+            s_inputs, s_init, seq_emb, z_init, asym_id, mask
         )
 
         # === Priming pass before recycling === #
+        s_plm_prime = self.plm_embedder_prime(s_inputs, seq_emb)
         s_prime, z_prime = self._run_trunk(
             plm_module=self.plm_module_prime,
             pairformer_module=self.pairformer_module_prime,
             s=s_init,
             z=z_init,
-            s_inputs=s_inputs,
-            s_plm=s_plm,
+            s_plm=s_plm_prime,
             asym_id=asym_id,
             mask=mask,
             chunk_size_tri_attn=chunk_size_tri_attn,
@@ -265,6 +282,7 @@ class KFoldTrunkPrime(BaseTrunk):
 
         # === Refining loop with recycling === #
         s_hat, z_hat = s_prime, z_prime
+        s_plm = self.plm_embedder_refine(s_inputs, seq_emb)
         s_bias = self.linear_s_prime(self.layernorm_s_prime(s_prime))
         z_bias = self.linear_z_prime(self.layernorm_z_prime(z_prime))
 
@@ -286,7 +304,6 @@ class KFoldTrunkPrime(BaseTrunk):
                     pairformer_module=self.pairformer_module_refine,
                     s=s,
                     z=z,
-                    s_inputs=s_inputs,
                     s_plm=s_plm,
                     asym_id=asym_id,
                     mask=mask,
@@ -294,7 +311,7 @@ class KFoldTrunkPrime(BaseTrunk):
                 )
 
         # Skip connection to s_trunk
-        s_hat = s_hat + self.proj_plm_to_s_trunk(s_plm)
+        s_hat = s_hat + self.proj_seq_emb_to_s_trunk(seq_emb)
 
         # Remove register tokens before returning.
         s_hat, z_hat, z_prime = self._undo_registers(s_hat, z_hat, z_prime)
@@ -307,7 +324,6 @@ class KFoldTrunkPrime(BaseTrunk):
         pairformer_module: PairformerStack,
         s: torch.Tensor,
         z: torch.Tensor,
-        s_inputs: torch.Tensor,
         s_plm: torch.Tensor,
         asym_id: torch.Tensor,
         mask: torch.Tensor,
@@ -316,9 +332,9 @@ class KFoldTrunkPrime(BaseTrunk):
         if self.is_compiled and not self.training:
             pairformer_module = pairformer_module._orig_mod  # noqa: SLF001
             plm_module = plm_module._orig_mod  # noqa: SLF001
+
         z = plm_module(
             z,
-            s_inputs,
             s_plm,
             asym_id,
             mask,
@@ -388,3 +404,13 @@ class KFoldTrunkPrime(BaseTrunk):
         if R <= 0:
             return s_trunk, z_trunk, z_prime
         return s_trunk[:, R:], z_trunk[:, R:, R:], z_prime[:, R:, R:]
+
+    def _compute_chunk_size(self, num_tokens: int) -> int | None:
+        """Compute chunk size for triangle attention based on the number of tokens."""
+        if not self.training:
+            if num_tokens > self.chunk_threshold:
+                return 128
+            else:
+                return 512
+        else:
+            return None

--- a/src/kfold/model/modules/trunk/kfold_prime.py
+++ b/src/kfold/model/modules/trunk/kfold_prime.py
@@ -78,11 +78,13 @@ class KFoldTrunkPrime(BaseTrunk):
         # we may want to have separate projections for s_plm and z_plm.
         self.use_attn = cfg.use_attn
         if self.use_attn:
+            # (Seonghwan) LayerNorm is applied for scalability to sequence length,
+            # as the scale of attention maps is reduced by sequence length.
             self.proj_seq_attn_to_z_init = nn.Sequential(
                 LayerNorm(cfg.channel_seq_attn, create_offset=False),
                 LinearNoBias(cfg.channel_seq_attn, cfg.channel_z, init="relu"),
                 nn.ReLU(),
-                LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
+                LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
             )
 
         # For the skip connection from PLM features to s_trunk output.

--- a/src/kfold/model/modules/trunk/kfold_prime.py
+++ b/src/kfold/model/modules/trunk/kfold_prime.py
@@ -116,38 +116,35 @@ class KFoldTrunkPrime(BaseTrunk):
             use_qk_norm=cfg.pairformer.use_qk_norm,
             blocks_per_ckpt=cfg.pairformer.blocks_per_ckpt,
         )
+
         # For recycling
-        self.linear_prime_s = nn.Sequential(
-            LayerNorm(cfg.channel_s),
-            LinearNoBias(cfg.channel_s, cfg.channel_s, init="final"),
-        )
-        self.linear_prime_z = nn.Sequential(
-            LayerNorm(cfg.channel_z),
-            LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
-        )
-        self.linear_recycle_s = nn.Sequential(
-            LayerNorm(cfg.channel_s),
-            LinearNoBias(cfg.channel_s, cfg.channel_s, init="final"),
-        )
-        self.linear_recycle_z = nn.Sequential(
-            LayerNorm(cfg.channel_z),
-            LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
-        )
+        self.layernorm_s_prime = LayerNorm(cfg.channel_s)
+        self.layernorm_z_prime = LayerNorm(cfg.channel_z)
+        self.linear_s_prime = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
+        self.linear_z_prime = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
+        self.layernorm_s = LayerNorm(cfg.channel_s)
+        self.layernorm_z = LayerNorm(cfg.channel_z)
+        self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
+        self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
         # Projections from PLM features to trunk features.
+        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
+        # we may want to have separate projections for s_plm and z_plm.
         self.proj_plm_to_z_init = nn.Sequential(
+            LayerNorm(cfg.channel_z_plm, create_offset=False),
             LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
             nn.ReLU(),
             LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
         )
 
         # For the skip connection from PLM features to s_trunk output.
+        # Assume the plm embedding is post-norm output.
         self.proj_plm_to_s_trunk = LinearNoBias(
             cfg.channel_s_plm, cfg.channel_s, init="final"
         )
 
         # Proteina-style register tokens (learnable sequence-level registers).
-        self.num_register_tokens: int = int(cfg.num_register_tokens)
+        self.num_register_tokens: int = cfg.num_register_tokens
         if self.num_register_tokens < 0:
             raise ValueError("num_register_tokens must be >= 0")
         if self.num_register_tokens > 0:
@@ -155,9 +152,7 @@ class KFoldTrunkPrime(BaseTrunk):
                 torch.empty(self.num_register_tokens, cfg.channel_s)
             )
             nn.init.normal_(
-                self.register_tokens,
-                mean=0.0,
-                std=float(cfg.register_token_init_std),
+                self.register_tokens, mean=0.0, std=float(cfg.register_token_init_std)
             )
         else:
             self.register_tokens = None
@@ -270,6 +265,8 @@ class KFoldTrunkPrime(BaseTrunk):
 
         # === Refining loop with recycling === #
         s_hat, z_hat = s_prime, z_prime
+        s_bias = self.linear_s_prime(self.layernorm_s_prime(s_prime))
+        z_bias = self.linear_z_prime(self.layernorm_z_prime(z_prime))
 
         for i in range(0, num_recycles + 1):
             enable_grad = self.training and i == num_recycles
@@ -278,10 +275,10 @@ class KFoldTrunkPrime(BaseTrunk):
                     torch.clear_autocast_cache()
 
                 # Recycle linear pass
-                s = s_hat + self.linear_prime_s(s_prime)
-                z = z_hat + self.linear_prime_z(z_prime)
-                s = s_init + self.linear_recycle_s(s)
-                z = z_init + self.linear_recycle_z(z)
+                s = s_hat + s_bias
+                z = z_hat + z_bias
+                s = s_init + self.linear_s(self.layernorm_s(s))
+                z = z_init + self.linear_z(self.layernorm_z(z))
 
                 # Trunk
                 s_hat, z_hat = self._run_trunk(

--- a/src/kfold/model/modules/trunk/kfold_prime.py
+++ b/src/kfold/model/modules/trunk/kfold_prime.py
@@ -26,6 +26,10 @@ class KFoldTrunkPrime(BaseTrunk):
             The token single embedding size.
         channel_z : int
             The token pairwise embedding size.
+        channel_s_plm : int
+            The token single embedding size for the PLM module.
+        channel_z_plm : int
+            The token attention map size for the PLM module.
         num_heads_attn : int, optional
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
@@ -39,6 +43,10 @@ class KFoldTrunkPrime(BaseTrunk):
         channel_s: int = 384
         channel_z: int = 128
 
+        # PLM dimensions.
+        channel_s_plm: int = 1152
+        channel_z_plm: int = 648
+
         # plm module
         plm_module: PLMModuleConfig = dataclasses.field(default_factory=PLMModuleConfig)
 
@@ -50,7 +58,6 @@ class KFoldTrunkPrime(BaseTrunk):
         register_token_init_std: float = 0.05
 
         # other options
-        blocks_per_ckpt: int | None = None
         tri_attn_chunk_threshold: int = 384
 
     def __init__(self, cfg: Config, kernel_config=None):
@@ -61,8 +68,7 @@ class KFoldTrunkPrime(BaseTrunk):
         self.plm_module_prime: PLMModule = PLMModule(
             channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_plm_input=cfg.plm_module.channel_plm_input,
-            channel_plm=cfg.plm_module.channel_plm,
+            channel_s_plm=cfg.channel_s_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -70,7 +76,7 @@ class KFoldTrunkPrime(BaseTrunk):
             dropout_z=cfg.plm_module.dropout_z,
             use_separate_projections=cfg.plm_module.use_separate_projections,
             use_qk_norm=cfg.plm_module.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.plm_module.blocks_per_ckpt,
         )
         # Pairformer module
         self.pairformer_module_prime: PairformerStack = PairformerStack(
@@ -81,7 +87,7 @@ class KFoldTrunkPrime(BaseTrunk):
             num_blocks=cfg.pairformer.num_blocks,
             dropout=cfg.pairformer.dropout,
             use_qk_norm=cfg.pairformer.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.pairformer.blocks_per_ckpt,
         )
 
         # === Refine Module with recycling === #
@@ -89,8 +95,7 @@ class KFoldTrunkPrime(BaseTrunk):
         self.plm_module_refine: PLMModule = PLMModule(
             channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_plm_input=cfg.plm_module.channel_plm_input,
-            channel_plm=cfg.plm_module.channel_plm,
+            channel_s_plm=cfg.channel_s_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -98,7 +103,7 @@ class KFoldTrunkPrime(BaseTrunk):
             dropout_z=cfg.plm_module.dropout_z,
             use_separate_projections=cfg.plm_module.use_separate_projections,
             use_qk_norm=cfg.plm_module.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.plm_module.blocks_per_ckpt,
         )
         # Pairformer module
         self.pairformer_module_refine: PairformerStack = PairformerStack(
@@ -109,7 +114,7 @@ class KFoldTrunkPrime(BaseTrunk):
             num_blocks=cfg.pairformer.num_blocks,
             dropout=cfg.pairformer.dropout,
             use_qk_norm=cfg.pairformer.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.pairformer.blocks_per_ckpt,
         )
         # For recycling
         self.linear_prime_s = nn.Sequential(
@@ -129,14 +134,17 @@ class KFoldTrunkPrime(BaseTrunk):
             LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
         )
 
-        # Final projection from PLM features to single features (skip connection)
-        self.proj_plm_to_s_trunk = nn.Sequential(
-            LayerNorm(cfg.plm_module.channel_plm_input, create_offset=False),
-            LinearNoBias(cfg.plm_module.channel_plm_input, cfg.channel_s, init="final"),
+        # Projections from PLM features to trunk features.
+        self.proj_plm_to_z_init = nn.Sequential(
+            LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
+            nn.ReLU(),
+            LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
         )
 
-        # Other options
-        self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
+        # For the skip connection from PLM features to s_trunk output.
+        self.proj_plm_to_s_trunk = LinearNoBias(
+            cfg.channel_s_plm, cfg.channel_s, init="final"
+        )
 
         # Proteina-style register tokens (learnable sequence-level registers).
         self.num_register_tokens: int = int(cfg.num_register_tokens)
@@ -153,6 +161,9 @@ class KFoldTrunkPrime(BaseTrunk):
             )
         else:
             self.register_tokens = None
+
+        # Other options
+        self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
 
     def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
@@ -230,7 +241,12 @@ class KFoldTrunkPrime(BaseTrunk):
 
         # Get PLM features
         assert "s_plm" in kwargs, "PLM features s_plm must be provided in kwargs"
+        assert "z_plm" in kwargs, "PLM features z_plm must be provided in kwargs"
         s_plm: torch.Tensor = kwargs["s_plm"]
+        z_plm: torch.Tensor = kwargs["z_plm"]
+
+        # Add z_plm to z_init before trunk.
+        z_init = z_init + self.proj_plm_to_z_init(z_plm)
 
         # === Proteina-style register tokens (optional) ===
         mask = f_input.token.pad_mask

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -100,11 +100,13 @@ class KFoldTrunk(BaseTrunk):
         # we may want to have separate projections for s_plm and z_plm.
         self.use_attn = cfg.use_attn
         if self.use_attn:
+            # (Seonghwan) LayerNorm is applied for scalability to sequence length,
+            # as the scale of attention maps is reduced by sequence length.
             self.proj_seq_attn_to_z_init = nn.Sequential(
                 LayerNorm(cfg.channel_seq_attn, create_offset=False),
                 LinearNoBias(cfg.channel_seq_attn, cfg.channel_z, init="relu"),
                 nn.ReLU(),
-                LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
+                LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
             )
 
         # For the skip connection from PLM features to s_trunk output.

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -120,7 +120,10 @@ class KFoldTrunk(BaseTrunk):
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
         # Projections from PLM features to trunk features.
+        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
+        # we may want to have separate projections for s_plm and z_plm.
         self.proj_plm_to_z_init = nn.Sequential(
+            LayerNorm(cfg.channel_z_plm, create_offset=False),
             LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
             nn.ReLU(),
             LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.alphafold3.pairformer import PairformerStack
-from kfold.model.layers.kfold.plm_module import PLMModule
+from kfold.model.layers.kfold.plm_module import PLMEmbedder, PLMModule
 from kfold.model.layers.primitives import LayerNorm, LinearNoBias
 from kfold.utils.registry import TRUNK
 
@@ -48,10 +48,14 @@ class KFoldTrunk(BaseTrunk):
             The token single embedding size.
         channel_z : int
             The token pairwise embedding size.
-        channel_s_plm : int
-            The token single embedding size for the PLM module.
-        channel_z_plm : int
-            The token attention map size for the PLM module.
+        channel_plm : int
+            The hidden dimension for the PLMModule.
+        channel_seq_emb : int
+            The sequence embedding size for the PLM module.
+        channel_seq_attn : int
+            The number of attention maps for the PLM module.
+        use_attn : bool
+            Whether to use attention in the PLM module.
         num_heads_attn : int, optional
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
@@ -66,8 +70,10 @@ class KFoldTrunk(BaseTrunk):
         channel_z: int = 128
 
         # PLM dimensions.
-        channel_s_plm: int = 1152
-        channel_z_plm: int = 648
+        channel_plm: int = 1152
+        channel_seq_emb: int = 1152
+        channel_seq_attn: int = 648
+        use_attn: bool = True
 
         # plm module
         plm_module: PLMModuleConfig = dataclasses.field(default_factory=PLMModuleConfig)
@@ -86,11 +92,35 @@ class KFoldTrunk(BaseTrunk):
         """Initialize the KFoldTrunk module."""
         super().__init__(cfg, kernel_config)
 
-        # PLM module
+        # === PLM feature processing layers === #
+        self.layernorm_seq_emb = LayerNorm(cfg.channel_seq_emb, create_offset=False)
+
+        # Projections from PLM features to trunk features.
+        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
+        # we may want to have separate projections for s_plm and z_plm.
+        self.use_attn = cfg.use_attn
+        if self.use_attn:
+            self.proj_seq_attn_to_z_init = nn.Sequential(
+                LayerNorm(cfg.channel_seq_attn, create_offset=False),
+                LinearNoBias(cfg.channel_seq_attn, cfg.channel_z, init="relu"),
+                nn.ReLU(),
+                LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
+            )
+
+        # For the skip connection from PLM features to s_trunk output.
+        self.proj_seq_emb_to_s_trunk = LinearNoBias(
+            cfg.channel_seq_emb, cfg.channel_s, init="final"
+        )
+
+        # === PLM Module === #
+        self.plm_embedder_refine: PLMEmbedder = PLMEmbedder(
+            channel_s_input=cfg.channel_s,
+            channel_seq_emb=cfg.channel_seq_emb,
+            channel_plm=cfg.channel_plm,
+        )
         self.plm_module: PLMModule = PLMModule(
-            channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_s_plm=cfg.channel_s_plm,
+            channel_plm=cfg.channel_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -101,7 +131,7 @@ class KFoldTrunk(BaseTrunk):
             blocks_per_ckpt=cfg.plm_module.blocks_per_ckpt,
         )
 
-        # Pairformer module
+        # === Pairformer Module === #
         self.pairformer_module: PairformerStack = PairformerStack(
             channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
@@ -113,27 +143,11 @@ class KFoldTrunk(BaseTrunk):
             blocks_per_ckpt=cfg.pairformer.blocks_per_ckpt,
         )
 
-        # For recycling
+        # === Recycling === #
         self.layernorm_s = LayerNorm(cfg.channel_s)
         self.layernorm_z = LayerNorm(cfg.channel_z)
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
-
-        # Projections from PLM features to trunk features.
-        # TODO: if we consider two separate plms for intra- and inter-chain attentions,
-        # we may want to have separate projections for s_plm and z_plm.
-        self.proj_plm_to_z_init = nn.Sequential(
-            LayerNorm(cfg.channel_z_plm, create_offset=False),
-            LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
-            nn.ReLU(),
-            LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
-        )
-
-        # For the skip connection from PLM features to s_trunk output.
-        # Assume the plm embedding is post-norm output.
-        self.proj_plm_to_s_trunk = LinearNoBias(
-            cfg.channel_s_plm, cfg.channel_s, init="final"
-        )
 
         # Proteina-style register tokens (learnable sequence-level registers).
         self.num_register_tokens: int = cfg.num_register_tokens
@@ -202,33 +216,33 @@ class KFoldTrunk(BaseTrunk):
         z_trunk: torch.Tensor
             The updated tensor of shape (B, L, L, c_z).
         """
-        if not self.training:
-            if z_init.shape[1] > self.chunk_threshold:
-                chunk_size_tri_attn = 128
-            else:
-                chunk_size_tri_attn = 512
-        else:
-            chunk_size_tri_attn = None
+        chunk_size_tri_attn = self._compute_chunk_size(s_inputs.shape[1])
 
         # Get PLM features
-        assert "s_plm" in kwargs, "PLM features s_plm must be provided in kwargs"
-        assert "z_plm" in kwargs, "PLM features z_plm must be provided in kwargs"
-        s_plm: torch.Tensor = kwargs["s_plm"]
-        z_plm: torch.Tensor = kwargs["z_plm"]
+        assert "seq_emb" in kwargs, "PLM features s_plm must be provided in kwargs"
+        assert "seq_attn" in kwargs, "PLM features z_plm must be provided in kwargs"
+        seq_emb: torch.Tensor = kwargs["seq_emb"]
+        seq_attn: torch.Tensor = kwargs["seq_attn"]
 
-        # Add z_plm to z_init before trunk.
-        z_init = z_init + self.proj_plm_to_z_init(z_plm)
+        # Layer norm on PLM features.
+        seq_emb = self.layernorm_seq_emb(seq_emb)
+
+        if self.use_attn:
+            # Feed attention maps to initialize z_init.
+            z_init = z_init + self.proj_seq_attn_to_z_init(seq_attn)
+        del seq_attn  # free memory
 
         # === Proteina-style register tokens (optional) ===
         mask = f_input.token.pad_mask
         asym_id = f_input.token.asym_id
-        s_inputs, s_init, s_plm, z_init, asym_id, mask = self._extend_registers(
-            s_inputs, s_init, s_plm, z_init, asym_id, mask
+        s_inputs, s_init, seq_emb, z_init, asym_id, mask = self._extend_registers(
+            s_inputs, s_init, seq_emb, z_init, asym_id, mask
         )
 
         # z_hat, s_hat = 0, 0
         s_hat = torch.zeros_like(s_init)
         z_hat = torch.zeros_like(z_init)
+        s_plm = self.plm_embedder_refine(s_inputs, seq_emb)
 
         for i in range(0, num_recycles + 1):
             enable_grad = self.training and i == num_recycles
@@ -242,7 +256,6 @@ class KFoldTrunk(BaseTrunk):
                 s_hat, z_hat = self._run_trunk(
                     s=s,
                     z=z,
-                    s_inputs=s_inputs,
                     s_plm=s_plm,
                     asym_id=asym_id,
                     mask=mask,
@@ -250,7 +263,7 @@ class KFoldTrunk(BaseTrunk):
                 )
 
         # Skip connection to s_trunk
-        s_hat = s_hat + self.proj_plm_to_s_trunk(s_plm)
+        s_hat = s_hat + self.proj_seq_emb_to_s_trunk(seq_emb)
 
         # Remove register tokens before returning.
         s_hat, z_hat = self._undo_registers(s_hat, z_hat)
@@ -260,7 +273,6 @@ class KFoldTrunk(BaseTrunk):
         self,
         s: torch.Tensor,
         z: torch.Tensor,
-        s_inputs: torch.Tensor,
         s_plm: torch.Tensor,
         asym_id: torch.Tensor,
         mask: torch.Tensor,
@@ -278,7 +290,6 @@ class KFoldTrunk(BaseTrunk):
 
         z = plm_module(
             z,
-            s_inputs,
             s_plm,
             asym_id,
             mask,
@@ -350,3 +361,13 @@ class KFoldTrunk(BaseTrunk):
         if R <= 0:
             return s_trunk, z_trunk
         return s_trunk[:, R:], z_trunk[:, R:, R:]
+
+    def _compute_chunk_size(self, num_tokens: int) -> int | None:
+        """Compute chunk size for triangle attention based on the number of tokens."""
+        if not self.training:
+            if num_tokens > self.chunk_threshold:
+                return 128
+            else:
+                return 512
+        else:
+            return None

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -130,13 +130,15 @@ class KFoldTrunk(BaseTrunk):
         )
 
         # For the skip connection from PLM features to s_trunk output.
+        # Assume the plm embedding is post-norm output.
         self.proj_plm_to_s_trunk = LinearNoBias(
             cfg.channel_s_plm, cfg.channel_s, init="final"
         )
 
         # Proteina-style register tokens (learnable sequence-level registers).
         self.num_register_tokens: int = cfg.num_register_tokens
-        assert self.num_register_tokens >= 0, "num_register_tokens must be non-negative"
+        if self.num_register_tokens < 0:
+            raise ValueError("num_register_tokens must be >= 0")
         if self.num_register_tokens > 0:
             self.register_tokens = nn.Parameter(
                 torch.empty(self.num_register_tokens, cfg.channel_s)

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -16,8 +16,6 @@ from .base import BaseTrunk
 
 @dataclasses.dataclass(kw_only=True)
 class PLMModuleConfig:
-    channel_plm_input: int = 2560
-    channel_plm: int = 512
     num_heads_attn: int = 16
     num_heads_tri_attn: int = 4
     num_blocks: int = 4
@@ -25,6 +23,7 @@ class PLMModuleConfig:
     dropout_z: float = 0.25
     use_separate_projections: bool = True
     use_qk_norm: bool = False
+    blocks_per_ckpt: int | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -35,6 +34,7 @@ class PairformerConfig:
     dropout: float = 0.25
     # Proteina-style QK normalization (LayerNorm on Q and K before head split)
     use_qk_norm: bool = False
+    blocks_per_ckpt: int | None = None
 
 
 @TRUNK.register()
@@ -48,6 +48,10 @@ class KFoldTrunk(BaseTrunk):
             The token single embedding size.
         channel_z : int
             The token pairwise embedding size.
+        channel_s_plm : int
+            The token single embedding size for the PLM module.
+        channel_z_plm : int
+            The token attention map size for the PLM module.
         num_heads_attn : int, optional
             The number of attention heads, by default 16
         num_heads_tri_attn : int, optional
@@ -61,9 +65,9 @@ class KFoldTrunk(BaseTrunk):
         channel_s: int = 384
         channel_z: int = 128
 
-        # Pre-trained language model options
-        use_seq_embedding: bool = True
-        use_struct_embedding: bool = False
+        # PLM dimensions.
+        channel_s_plm: int = 1152
+        channel_z_plm: int = 648
 
         # plm module
         plm_module: PLMModuleConfig = dataclasses.field(default_factory=PLMModuleConfig)
@@ -76,21 +80,17 @@ class KFoldTrunk(BaseTrunk):
         register_token_init_std: float = 0.05
 
         # other options
-        blocks_per_ckpt: int | None = None
         tri_attn_chunk_threshold: int = 384
 
     def __init__(self, cfg: Config, kernel_config=None):
         """Initialize the KFoldTrunk module."""
         super().__init__(cfg, kernel_config)
-        self.use_seq_embedding: bool = cfg.use_seq_embedding
-        self.use_struct_embedding: bool = cfg.use_struct_embedding
 
         # PLM module
         self.plm_module: PLMModule = PLMModule(
             channel_s=cfg.channel_s,
             channel_z=cfg.channel_z,
-            channel_plm_input=cfg.plm_module.channel_plm_input,
-            channel_plm=cfg.plm_module.channel_plm,
+            channel_s_plm=cfg.channel_s_plm,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -98,7 +98,7 @@ class KFoldTrunk(BaseTrunk):
             dropout_z=cfg.plm_module.dropout_z,
             use_separate_projections=cfg.plm_module.use_separate_projections,
             use_qk_norm=cfg.plm_module.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.plm_module.blocks_per_ckpt,
         )
 
         # Pairformer module
@@ -110,7 +110,7 @@ class KFoldTrunk(BaseTrunk):
             num_blocks=cfg.pairformer.num_blocks,
             dropout=cfg.pairformer.dropout,
             use_qk_norm=cfg.pairformer.use_qk_norm,
-            blocks_per_ckpt=cfg.blocks_per_ckpt,
+            blocks_per_ckpt=cfg.pairformer.blocks_per_ckpt,
         )
 
         # For recycling
@@ -119,12 +119,16 @@ class KFoldTrunk(BaseTrunk):
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
-        # Other options
-        self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
+        # Projections from PLM features to trunk features.
+        self.proj_plm_to_z_init = nn.Sequential(
+            LinearNoBias(cfg.channel_z_plm, cfg.channel_z, init="relu"),
+            nn.ReLU(),
+            LinearNoBias(cfg.channel_z, cfg.channel_z, init="default"),
+        )
 
-        self.proj_plm_to_s_trunk = nn.Sequential(
-            LayerNorm(cfg.plm_module.channel_plm_input, create_offset=False),
-            LinearNoBias(cfg.plm_module.channel_plm_input, cfg.channel_s, init="final"),
+        # For the skip connection from PLM features to s_trunk output.
+        self.proj_plm_to_s_trunk = LinearNoBias(
+            cfg.channel_s_plm, cfg.channel_s, init="final"
         )
 
         # Proteina-style register tokens (learnable sequence-level registers).
@@ -139,6 +143,9 @@ class KFoldTrunk(BaseTrunk):
             )
         else:
             self.register_tokens = None
+
+        # Other options
+        self.chunk_threshold: int = cfg.tri_attn_chunk_threshold
 
     def do_compile(self, mode: str = "default"):
         """Compile the trunk module."""
@@ -200,7 +207,12 @@ class KFoldTrunk(BaseTrunk):
 
         # Get PLM features
         assert "s_plm" in kwargs, "PLM features s_plm must be provided in kwargs"
+        assert "z_plm" in kwargs, "PLM features z_plm must be provided in kwargs"
         s_plm: torch.Tensor = kwargs["s_plm"]
+        z_plm: torch.Tensor = kwargs["z_plm"]
+
+        # Add z_plm to z_init before trunk.
+        z_init = z_init + self.proj_plm_to_z_init(z_plm)
 
         # === Proteina-style register tokens (optional) ===
         mask = f_input.token.pad_mask


### PR DESCRIPTION
This pull request introduces significant updates to the model configuration and implementation for the KFold protein folding models, focusing on improved integration of pre-trained language model (PLM) embeddings, attention handling, and resource management. The main changes include refactoring the PLM module to use new input/output dimensions, updating configuration files to align with these changes, and enhancing attention output and masking in the sequence encoder.

**Model architecture and configuration updates:**

* Refactored the `PLMModule` in `plm_module.py` to use `channel_s_plm` (1152) and updated all relevant projections and block definitions to match the new input/output dimensions. The module now processes PLM embeddings and single representations with separate linear layers, and block internals consistently use the new channel sizes.
* Updated all model configuration files (`kfold.yaml`, `kfold-prime.yaml`, and training configs) to set `channel_s_plm: 1152`, `channel_z_plm: 648`, and to remove obsolete `channel_plm_input` and `channel_plm` parameters. Also standardized `use_qk_norm` and `blocks_per_ckpt` settings, and set `num_register_tokens` to 0 or 8 as appropriate.

**Sequence encoder and attention output enhancements:**

* Changed `return_attn` to `true` in both the ESMC sequence encoder config and class, enabling attention output during forward passes. Improved attention output handling, including chain masking and proper data type conversion, for more accurate downstream usage.
* In `forward_attn`, added masking to restrict attention to tokens within the same chain and ensured attention values are properly masked and converted to `bfloat16`.

**Training and dataset configuration improvements:**

* Updated dataset weights in training configs to rebalance training data sources, increasing the proportion of `rcsb-train` and decreasing others for improved training focus.
* Increased `chunk_size` for smooth LDDT loss from 2 to 8 in `structure-only.yaml` to improve training efficiency.

**Code consistency and naming:**

* Changed references from `attn_plm` to `z_plm` in model calls for clarity and consistency with new architecture.
* Minor code cleanups, such as using `.chunk()` instead of `torch.chunk()` for tensor splitting and clarifying docstrings for input shapes. 

These updates collectively modernize the model's PLM integration, improve attention handling, and ensure all configurations and code are consistent with the new architecture.