### PR TITLE
Hotfix - some bugfixes and update training settings

### DIFF
--- a/configs/dataset/sair.yaml
+++ b/configs/dataset/sair.yaml
@@ -13,7 +13,7 @@ sampler: null
 cropper:
   _registry_: "data_cropper"
   _class_: MultiAnchorCropper
-  max_anchors: 2
+  max_anchors: 1
   w_contiguous: 0.0
   w_spatial: 0.0
   w_spatial_interface: 1.0

--- a/configs/train/stage_1.yaml
+++ b/configs/train/stage_1.yaml
@@ -10,7 +10,7 @@ global_hparams:
 data:
   max_chains: 20
   max_tokens: 384
-  max_sequence_tokens: 1024
+  max_sequence_tokens: 768
 
 loss:
   weights:

--- a/configs/train/stage_2.yaml
+++ b/configs/train/stage_2.yaml
@@ -10,7 +10,7 @@ global_hparams:
 data:
   max_chains: 20
   max_tokens: 640
-  max_sequence_tokens: 1280
+  max_sequence_tokens: 1024
 
 loss:
   weights:

--- a/configs/train/stage_3.yaml
+++ b/configs/train/stage_3.yaml
@@ -10,7 +10,7 @@ global_hparams:
 data:
   max_chains: 20
   max_tokens: 768
-  max_sequence_tokens: 1536
+  max_sequence_tokens: 1280
 
 loss:
   weights:

--- a/scripts/inference_multigpu.py
+++ b/scripts/inference_multigpu.py
@@ -137,9 +137,7 @@ def main():
         num_samples=args.num_samples,
         seed=args.seed,
     )
-    inference_client = KFoldInferenceClient(
-        model, inference_config, save_dir=args.out_dir
-    )
+    inference_client = KFoldInferenceClient(model, inference_config)
     inference_writer = KFoldPredictionWriter(args.out_dir)
 
     # Construct PyTorch Lightning trainer

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 import lightning.pytorch as pl
-import numpy as np
 import torch
 from lightning.pytorch.callbacks import BasePredictionWriter
 
@@ -45,13 +44,11 @@ class KFoldInferenceClient(pl.LightningModule):
         self,
         model: KFold,
         inference_config: InferenceConfig,
-        save_dir: str | pathlib.Path = pathlib.Path("./inference_results/"),
     ):
         super().__init__()
         self.model: KFold = model
+        self.model.cast_to_bf16()  # Use bfloat16 to save memory and speed up
         self.inference_config: InferenceConfig = inference_config
-        self.save_dir: pathlib.Path = pathlib.Path(save_dir)
-        self.save_dir.mkdir(parents=True, exist_ok=True)
 
         # Logger
         self._logger = logging.getLogger("KFoldInferenceClient")
@@ -76,7 +73,7 @@ class KFoldInferenceClient(pl.LightningModule):
     def predict_step(
         self,
         batch: tuple[Query, RefStructure, FoldingInput, dict[int, dict]],
-    ) -> tuple[Query, RefStructure, dict[str, np.ndarray]] | None:
+    ) -> tuple[Query, RefStructure, dict[str, torch.Tensor]]:
         """Predict step for inference.
 
         Parameters
@@ -88,7 +85,7 @@ class KFoldInferenceClient(pl.LightningModule):
             - dict: a dictionary for apo structure tokenization.
         """
         if batch is None:
-            return  # Skip empty batch (occured by processing error)
+            return None  # Skip empty batch (occured by processing error)
 
         cfg = self.inference_config
         num_trunk_recycles = cfg.num_recycles
@@ -124,18 +121,21 @@ class KFoldInferenceClient(pl.LightningModule):
             )
         except RuntimeError as e:  # catch out of memory exceptions
             if "out of memory" in str(e):
-                print("**WARNING**: ran out of memory, skipping batch")
+                name = query.name
+                size = f_input.num_tokens
+                self._logger.error(
+                    f"Out of memory error for {name} ({size} tokens). "
+                    f"Skipping this input."
+                )
                 gc.collect()
                 torch.cuda.empty_cache()
-                return
+                return None  # type: ignore[return-value]
             else:
                 raise e
 
-        # Remove batch dimension and move to CPU for saving
-        model_out = {
-            k: v.squeeze(0).to(dtype=torch.float32, device="cpu").numpy()
-            for k, v in model_out.items()
-        }
+        # Remove batch dimension from outputs
+        model_out = {k: v.squeeze(0) for k, v in model_out.items()}
+
         return query, ref_struct, model_out
 
 
@@ -153,15 +153,15 @@ class KFoldPredictionWriter(BasePredictionWriter):
         # Logger
         self.logger = logging.getLogger("KFoldPredictionWriter")
 
-    def write_on_batch_end(
+    def write_on_batch_end(  # type: ignore[override]
         self,
-        trainer,
-        pl_module,
-        prediction,
-        batch_indices,
-        batch,
-        batch_idx,
-        dataloader_idx,
+        trainer: pl.Trainer,
+        pl_module: KFoldInferenceClient,
+        prediction: tuple[Query, RefStructure, dict[str, torch.Tensor]],
+        batch_indices: list[int],
+        batch: list[tuple[Query, RefStructure, FoldingInput, dict[int, dict]]],
+        batch_idx: int,
+        dataloader_idx: int,
     ):
         """
         Lightning calls this automatically after each predict_step.
@@ -189,12 +189,16 @@ class KFoldPredictionWriter(BasePredictionWriter):
             self.logger.error(f"Error saving apo for {name}: {e}")
 
         # 3. Save Diffusion Samples
-        sample_coords = model_out["sample_coordinates"]
         num_atoms = ref_struct.num_atoms
-        coords_np = sample_coords[:, :num_atoms, :]
+        sample_coords = model_out["sample_coordinates"][:, :num_atoms]
+        coords_np = sample_coords.cpu().numpy()
         for i, coord in enumerate(coords_np):
             try:
                 save_path = save_dir / f"sample-{i}.cif"
                 self.writer.write_new_coords(ref_struct, coord, save_path)
             except Exception as e:
                 self.logger.error(f"Error saving sample {i} for {name}: {e}")
+
+        # Free up memory
+        model_out.clear()
+        del model_out, sample_coords, coords_np

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -137,8 +137,8 @@ class KFold(BaseFoldingModel):
         # Trunk with recycling
         trunk_out = self.trunk(
             s_inputs,
-            s_init,
-            z_init,
+            s_init.float(),
+            z_init.float(),
             f_input,
             num_recycles,
             seq_emb=seq_emb,
@@ -260,8 +260,8 @@ class KFold(BaseFoldingModel):
         st = time.time()
         trunk_out: dict[str, torch.Tensor] = self.trunk(
             s_inputs,
-            s_init,
-            z_init,
+            s_init.float(),
+            z_init.float(),
             f_input,
             num_recycles,
             seq_emb=seq_emb,

--- a/src/kfold/training/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/dataset/cropper/multi_anchor.py
@@ -26,8 +26,8 @@ thereby encouraging the learning of global structural transitions.
     - Selects N anchor tokens (default: 4) and partitions the total token budget.
     - The first anchor is sampled based on chain bias or uniformly.
     - Subsequent anchors are sampled from resolved tokens within a defined
-      radius (default: 100 Å) of previous anchors to ensure partial connectivity
-      while maximizing coverage.
+      radius of previous anchors to ensure partial connectivity while maximizing
+      coverage.
 
 3. Spatial Interface Cropping (Multi-Anchor):
     - Selects anchors specifically from tokens involved in chain interfaces.
@@ -89,7 +89,7 @@ class MultiAnchorCropper(BaseCropper):
         anchor_distribution: str = "exponential"
         min_anchors: int = 1
         max_anchors: int = 1
-        max_anchor_distance: float = 50.0
+        max_anchor_distance: float = 25.0
 
     def __init__(self, config: Config):
         self.config = config

--- a/src/kfold/training/dataset/datamodule.py
+++ b/src/kfold/training/dataset/datamodule.py
@@ -81,6 +81,7 @@ class TrainingDataModule(pl.LightningDataModule):
             ccd=self.ccd,
             max_chains=self.config.max_chains,
             max_tokens=self.config.max_tokens,
+            max_sequence_tokens=self.config.max_sequence_tokens,
             safe_load=self.config.safe_load,
         )
         # Print dataset info

--- a/src/kfold/training/dataset/dataset.py
+++ b/src/kfold/training/dataset/dataset.py
@@ -717,8 +717,10 @@ class TrainingDataset(SafeLoadingDataset):
         self.max_sequence_tokens: int = max_sequence_tokens
 
         assert max_sequence_tokens >= max_tokens + (max_chains * 2), (
-            "max_sequence_tokens should be greater than max_tokens to accommodate "
-            "additional sequence tokens for PLM input."
+            f"max_sequence_tokens should be greater than max_tokens to accommodate "
+            f"additional sequence tokens for PLM input."
+            f" (max_sequence_tokens={max_sequence_tokens}, max_tokens={max_tokens}, "
+            f"max_chains={max_chains})"
         )  # +2 tokens per chain for [CLS] and [SEP]
 
         assert config.cropper is not None, "Cropper config must be provided."
@@ -873,10 +875,10 @@ class MultiTrainingDataset(torch.utils.data.Dataset):
         self,
         configs: list[TrainingDatasetConfig],
         ccd: CCD,
+        max_chains: int,
+        max_tokens: int,
+        max_sequence_tokens: int,
         safe_load: bool = True,
-        max_chains: int = 20,
-        max_tokens: int = 384,
-        max_sequence_tokens: int = 768,
     ) -> None:
         """
         Parameters
@@ -885,8 +887,6 @@ class MultiTrainingDataset(torch.utils.data.Dataset):
             List of dataset configurations.
         ccd: CCD
             CCD database
-        safe_load : bool
-            Whether to retry loading on failure.
         max_chains : int
             Maximum number of chains per sample.
         max_tokens : int
@@ -894,6 +894,8 @@ class MultiTrainingDataset(torch.utils.data.Dataset):
         max_sequence_tokens : int
             Maximum number of sequence tokens per sample,
             limiting the entire input size of PLM module.
+        safe_load : bool
+            Whether to retry loading on failure.
 
         Notes
         -----


### PR DESCRIPTION
This PR fixes some bugs in the script.

1. force `s_trunk` and `z_trunk` to fp32 instead of bf16
2. fix the bug which the `max_sequence_tokens` in `config.yaml` is not reflected.

And update some default settings in cropping for model training.
1. Reduce the max distance btw anchors from 50A to 25A
2. For SAIR, change the number of anchors from 2 to 1.
