### PR TITLE
code clean and change some default values for easy configuration

### DIFF
--- a/src/kfold/config.py
+++ b/src/kfold/config.py
@@ -32,9 +32,7 @@ def load_config(
         config = OmegaConf.merge(config, overrides)
 
     config = _resolve_yaml_inheritance(config, Path(path).parent)
-    if override_registry_defaults:
-        config = _resolve_registry_defaults(config)
-        config = _sync_inference_apo_sampling_from_dataset(config)
+    config = _resolve_registry_defaults(config)
     return config
 
 
@@ -152,56 +150,3 @@ def _resolve_registry_defaults(config: DictConfig) -> DictConfig:
     container: dict = OmegaConf.to_container(config)
     resolved_container = _resolve_nested(container)
     return OmegaConf.create(resolved_container)
-
-
-def _sync_inference_apo_sampling_from_dataset(config: DictConfig) -> DictConfig:
-    """Sync ECSI inference apo sampling params from validation dataset config.
-
-    Motivation: avoid managing `model.structure_module.inference_apo_*` independently
-    from dataset `apo_init.*`. This keeps validation/inference behavior aligned with
-    the configured dataset apo initialization policy.
-
-    Policy:
-    - Pull from `train.data.val_datasets[0].apo_init` if available.
-    - Only populate `model.structure_module.inference_apo_*` when they are still at
-      their defaults (0.0 / None), so explicit user overrides remain respected.
-    """
-    try:
-        model_cfg = config.model
-        structure_cfg = model_cfg.structure_module
-        train_cfg = config.train
-        data_cfg = train_cfg.data
-        val_datasets = data_cfg.val_datasets
-    except Exception:
-        return config
-
-    if not val_datasets:
-        return config
-
-    try:
-        apo_init = val_datasets[0].apo_init
-        translation_scale = float(apo_init.translation_scale)
-        chain_com_sampling_radius = apo_init.chain_com_sampling_radius
-        if chain_com_sampling_radius is not None:
-            chain_com_sampling_radius = float(chain_com_sampling_radius)
-            # Mirror dataset behavior: translation_scale is forced to 0
-            # when radius is set.
-            translation_scale = 0.0
-    except Exception:
-        return config
-
-    # Only sync when the model-side values are left as defaults.
-    try:
-        if (
-            float(structure_cfg.inference_apo_translation_scale) == 0.0
-            and structure_cfg.inference_apo_chain_com_sampling_radius is None
-        ):
-            structure_cfg.inference_apo_translation_scale = translation_scale
-            structure_cfg.inference_apo_chain_com_sampling_radius = (
-                chain_com_sampling_radius
-            )
-    except Exception:
-        # If fields are missing or immutable, silently skip.
-        return config
-
-    return config

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -29,7 +29,6 @@ class BaseFoldingModelConfig:
     score_model: BaseConfig
     structure_module: BaseConfig
     distogram_head: BaseConfig
-    interaction_head: BaseConfig | None = None
     # confidence_head: Baseconfig
 
 
@@ -63,20 +62,16 @@ class BaseFoldingModel(torch.nn.Module):
         self.distogram_head: submodules.distogram_head.BaseDistogramHead = (
             Registry.instantiate(config.distogram_head)
         )
-        self.interaction_head: submodules.interaction_head.BaseInteractionHead | None = (
-            Registry.instantiate(config.interaction_head)
-            if config.interaction_head is not None
-            else None
-        )
-
         # self.confidence_head: submodules.confidence_head.BaseConfidenceHead = (
         #     Registry.instantiate(config.confidence_head)
         # )
 
         # Compile submodules
-        # NOTE: (SeonghwanSeo) This is very slow... Right now, just disable them.
-        self.trunk.compile(config.compile_trunk, config.compile_mode)
-        self.score_model.compile(config.compile_score_model, config.compile_mode)
+        compile_trunk = getattr(config, "compile_trunk", False)
+        compile_score_model = getattr(config, "compile_score_model", False)
+        compile_mode = getattr(config, "compile_mode", "default")
+        self.trunk.compile(compile_trunk, compile_mode)
+        self.score_model.compile(compile_score_model, compile_mode)
 
     def cast_to_bf16(self):
         """Cast model parameters to bfloat16 for faster inference."""
@@ -122,8 +117,6 @@ class BaseFoldingModel(torch.nn.Module):
             Whether to sample structures for confidence module training,
         train_structure_module : bool, optional
             Whether to train structure module, by default True
-        train_interaction_head : bool, optional
-            Whether to produce interaction logits, by default True
         train_confidence_module : bool, optional
             Whether to train confidence module, by default True
 
@@ -140,9 +133,6 @@ class BaseFoldingModel(torch.nn.Module):
             - distogram:
                 - logits: [B, Ltoken, Ltoken, Dd]
                     Distogram logits
-            - interaction:
-                - logits: [B, Ltoken, Ltoken, K]
-                    Interaction logits (K = num pair interaction types)
             - diffusion:
                 - loss_weights: [B, N_noise]
                     Weights for diffusion noise scale
@@ -218,11 +208,6 @@ class BaseFoldingModel(torch.nn.Module):
             # Distogram head
             dict_out["distogram"] = {
                 "logits": self.distogram_head(z_trunk),
-            }
-
-        if train_interaction_head and self.interaction_head is not None:
-            dict_out["interaction"] = {
-                "logits": self.interaction_head(z_trunk),
             }
 
         if train_structure_module:
@@ -309,12 +294,6 @@ class BaseFoldingModel(torch.nn.Module):
         et = time.time()
         time_logs["distogram_head"] = et - st
 
-        if self.interaction_head is not None:
-            st = time.time()
-            dict_out["interaction_logits"] = self.interaction_head(z_trunk)
-            et = time.time()
-            time_logs["interaction_head"] = et - st
-
         # Diffusion head
         # pred_atom_coords: [B, Nsample, La, 3]
         st = time.time()
@@ -384,8 +363,7 @@ class BaseFoldingModel(torch.nn.Module):
     ) -> Self:
         """Load model from checkpoint."""
         # Initialize model
-        model_cls = MAIN_MODULE[model_config._class_]
-        model: torch.nn.Module = model_cls(model_config)
+        model: torch.nn.Module = cls(model_config)
 
         # Load checkpoint
         ckpt = torch.load(ckpt_path, map_location="cpu")

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -178,8 +178,9 @@ class KFold(BaseFoldingModel):
                 distogram_dict["logits_aug"] = self.distogram_head(z_aug)
             dict_out["distogram"] = distogram_dict
 
-        if train_interaction_head and self.interaction_head is not None:
+        if train_interaction_head:
             # Interaction head
+            assert self.interaction_head is not None
             interaction_dict = {}
             interaction_dict["logits"] = self.interaction_head(z_trunk)
             dict_out["interaction"] = interaction_dict
@@ -286,7 +287,7 @@ class KFold(BaseFoldingModel):
         et = time.time()
         time_logs["distogram_head"] = et - st
 
-        if self.interaction_head is not None:
+        if hasattr(self, "interaction_head"):
             st = time.time()
             dict_out["interaction_logits"] = self.interaction_head(z_trunk)
             et = time.time()
@@ -334,10 +335,13 @@ class KFold(BaseFoldingModel):
             missing_keys = incompatible_keys.missing_keys
             unexpected_keys = incompatible_keys.unexpected_keys
             # If the sequence encoder is pretrained and not included in the state dict,
-            # we allow missing keys that start with "sequence_encoder.".
+            # missing keys starting with "sequence_encoder." or "structure_encoder." are
+            # allowed.
             if missing_keys:
                 missing_keys = {
-                    key for key in missing_keys if not key.startswith("sequence_encoder.")
+                    key
+                    for key in missing_keys
+                    if not key.startswith(("sequence_encoder.", "structure_encoder."))
                 }
             if missing_keys:
                 raise KeyError(f"Missing keys in state_dict: {missing_keys}")

--- a/src/kfold/model/modules/input_embedder/kfold_embedder.py
+++ b/src/kfold/model/modules/input_embedder/kfold_embedder.py
@@ -109,7 +109,7 @@ class KFoldInputEmbedder(BaseInputEmbedder):
         apo_min_dist: float = 2.0
         apo_max_dist: float = 49.0
         # Interaction-related parameters
-        use_interaction: bool = True
+        use_interaction: bool = False
         num_interaction_types: int = 8
         num_pair_interaction_types: int = 5
 

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -63,7 +63,7 @@ class AF3DiffusionModule(BaseScoreModel):
         atom_encoder_blocks: int = 3
         atom_encoder_heads: int = 4
         token_transformer_blocks: int = 24
-        token_transformer_heads: int = 8
+        token_transformer_heads: int = 16
         atom_decoder_blocks: int = 3
         atom_decoder_heads: int = 4
         conditioning_transition_layers: int = 2

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -923,7 +923,7 @@ class KFoldTrainingModule(pl.LightningModule):
         checkpoint["state_dict"] = {
             k: v
             for k, v in checkpoint["state_dict"].items()
-            if "sequence_encoder" not in k
+            if "sequence_encoder" not in k and "structure_encoder" not in k
         }
 
         # Remove '._orig_mod.' from checkpoint keys

--- a/src/kfold/utils/registry.py
+++ b/src/kfold/utils/registry.py
@@ -5,6 +5,8 @@ import typing
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+from omegaconf import OmegaConf
+
 C = TypeVar("C", bound=type[Any])
 ConfigT = TypeVar("ConfigT", bound="BaseConfig")
 
@@ -87,6 +89,10 @@ class Registry:
         """
         registry = cls.get_register(config._registry_)
         module_cls = registry[config._class_]
+        config_cls = registry.__config_dict__.get(config._class_, None)
+        if config_cls is not None:
+            base_config = OmegaConf.structured(config_cls)
+            config = OmegaConf.merge(base_config, config)
         return module_cls(config, **kwargs)
 
     def register(


### PR DESCRIPTION
This pull request refactors the model configuration and instantiation logic, removes the interaction head from the base model, and improves checkpoint handling and registry instantiation. The changes streamline the codebase, make model configuration more robust, and clarify handling of optional modules and checkpoint keys.

**Model architecture and configuration refactoring:**

* Removed the `interaction_head` from `BaseFoldingModelConfig` and the base model implementation, including related forward and sampling logic, simplifying the base model and making interaction head an optional feature in derived models. (`src/kfold/model/models/base.py`)
* Changed the default value of `use_interaction` in `kfold_embedder.py` to `False`, reflecting the removal of the interaction head from the base model. (`src/kfold/model/modules/input_embedder/kfold_embedder.py`)

**Model instantiation and registry improvements:**

* Improved the `Registry.instantiate` method to merge base config with user config using OmegaConf, ensuring robust and consistent configuration instantiation. (`src/kfold/utils/registry.py`
* Updated model loading logic in `from_checkpoint` to use the class directly, removing reliance on the `MAIN_MODULE` mapping. (`src/kfold/model/models/base.py`)

**Checkpoint and state dict handling:**

* Updated checkpoint saving and loading to ignore keys related to both `sequence_encoder` and `structure_encoder`, allowing for more flexible model loading and saving. (`src/kfold/training/training_module.py`, `src/kfold/model/models/kfold.py`)

**Miscellaneous improvements:**

* Increased `token_transformer_heads` from 8 to 16 in `af3_diffusion.py` for improved model capacity. (`src/kfold/model/modules/score_model/af3_diffusion.py`)
* Removed the `_sync_inference_apo_sampling_from_dataset` function and related logic from config loading, simplifying configuration inheritance. (`src/kfold/config.py`)

**Interaction head handling in derived models:**

* Updated `kfold.py` model logic to assert the presence of `interaction_head` when enabled, and use attribute checks for sampling, improving clarity and robustness for optional modules. (`src/kfold/model/models/kfold.py`)