### PR TITLE
hotfix: change the ecsi config dtype: `rho` from int to float

### DIFF
--- a/src/kfold/model/modules/structure_module/kfold_ecsi.py
+++ b/src/kfold/model/modules/structure_module/kfold_ecsi.py
@@ -253,7 +253,7 @@ class KFoldECSI(BaseECSI):
         sigma_data: float = 16.0
         sigma_data_end: float = 16.0
         cov_xy: float = 128.0
-        rho: int = 7
+        rho: float = 0.7
         sampling_schedule_type: str = "piecewise_power"
         sampling_schedule_piecewise_power: float = 5.0
         P_mean: float = -1.2


### PR DESCRIPTION
This pull request makes a small but important change to the configuration of the `Config` class in `src/kfold/model/modules/structure_module/kfold_ecsi.py`. The type and value of the `rho` parameter have been updated to better reflect its intended use.

* Changed the `rho` parameter from an integer (`int`) with value `7` to a float (`float`) with value `0.7` in the `Config` class, improving type consistency and likely aligning with the underlying model requirements.