### PR TITLE
hotfix: update to use ema as default

### DIFF
--- a/src/kfold/model/layers/alphafold3/diffusion.py
+++ b/src/kfold/model/layers/alphafold3/diffusion.py
@@ -23,7 +23,7 @@ class FourierEmbedding(nn.Module):
     Section 3.7 Algorithm 22 Fourier Embedding
     """
 
-    def __init__(self, channel: int, seed: int = 42):
+    def __init__(self, channel: int):
         """Initialize the Fourier Embeddings.
 
         Parameters
@@ -35,16 +35,14 @@ class FourierEmbedding(nn.Module):
 
         """
         super().__init__()
-
-        self.seed = seed
         generator = torch.Generator()
-        generator.manual_seed(seed)
+        generator.manual_seed(42)
 
         # Line 1: Randomly generate weight/bias once before training
         w = torch.randn(size=(1, channel), generator=generator)
         b = torch.randn(size=(1, channel), generator=generator)
-        self.w = nn.Parameter(w, requires_grad=False)
-        self.b = nn.Parameter(b, requires_grad=False)
+        self.register_buffer("w", w, persistent=False)
+        self.register_buffer("b", b, persistent=False)
 
     def forward(self, t_hat: torch.Tensor) -> torch.Tensor:
         """Forward pass.

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -357,7 +357,7 @@ class BaseFoldingModel(torch.nn.Module):
         cls,
         model_config: BaseFoldingModelConfig,
         ckpt_path: str | pathlib.Path,
-        use_ema: bool = False,
+        use_ema: bool = True,
         strict: bool = True,
     ) -> Self:
         """Load model from checkpoint."""
@@ -372,7 +372,13 @@ class BaseFoldingModel(torch.nn.Module):
             state_dict = ckpt
         elif use_ema:
             # Load EMA weights
-            state_dict = ckpt["ema"]
+            if "ema" not in ckpt:
+                raise KeyError(
+                    "EMA weights not found in checkpoint. "
+                    "Please set use_ema=False to load regular weights."
+                )
+            else:
+                state_dict = ckpt["ema"]["shadow_params"]
         else:
             # Load regular weights
             state_dict = ckpt["state_dict"]

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -318,12 +318,15 @@ class KFold(BaseFoldingModel):
             # If the sequence encoder is pretrained and not included in the state dict,
             # missing keys starting with "sequence_encoder." or "structure_encoder." are
             # allowed.
-            if missing_keys:
-                missing_keys = {
-                    key
-                    for key in missing_keys
-                    if not key.startswith(("sequence_encoder.", "structure_encoder."))
-                }
+            missing_keys = {
+                k
+                for k in missing_keys
+                if not k.startswith(("sequence_encoder.", "structure_encoder."))
+            }
+            # Skip some fourier-related keys that are changed from
+            # nn.Parameter(..., required_grad=False) to buffer. (Backward compatibility)
+            unexpected_keys = {k for k in unexpected_keys if ".fourier_emb." not in k}
+
             if missing_keys:
                 raise KeyError(f"Missing keys in state_dict: {missing_keys}")
             if unexpected_keys:


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the model loading and layer initialization logic, focusing on better handling of Fourier embedding parameters and checkpoint compatibility. The most important changes are grouped below:


**Checkpoint Loading Improvements:**
* Changed the default behavior of `from_checkpoint` to use Exponential Moving Average (EMA) weights by default (`use_ema=True`).

**Fourier Embedding Initialization and Backward Compatibility:**
* Changed the `FourierEmbedding` layer to always use a fixed random seed (42) internally, removing the `seed` parameter from its constructor. The weights and biases are now registered as non-persistent buffers instead of non-trainable parameters, improving checkpoint compatibility and preventing them from being saved as model parameters.
* Updated the model loading logic to ignore missing or unexpected keys related to `.fourier_emb.` when loading state dicts, ensuring backward compatibility with older checkpoints that stored these as parameters instead of buffers.