### PR TITLE
memory efficient lddt loss

### DIFF
--- a/configs/train-ecsi-1.yaml
+++ b/configs/train-ecsi-1.yaml
@@ -27,6 +27,11 @@ train:
     batch_size: 1
     global_batch_size: 256
 
+  loss:
+    diffusion_loss:
+      smooth_lddt_loss:
+        chunk_size: 8
+
   data:
     max_tokens: 376
     ccd_path: /cache/wykim_lab/kfold_data/v260310/ccd-train.pkl

--- a/configs/train-ecsi-2.yaml
+++ b/configs/train-ecsi-2.yaml
@@ -27,13 +27,6 @@ train:
     batch_size: 1
     global_batch_size: 256
 
-  loss:
-    weights:
-      smooth_lddt: 1.0
-    diffusion_loss:
-      smooth_lddt_loss:
-        chunk_size: 1
-
   data:
     max_tokens: 632
     ccd_path: /cache/wykim_lab/kfold_data/v260310/ccd-train.pkl

--- a/configs/train-ecsi-3.yaml
+++ b/configs/train-ecsi-3.yaml
@@ -27,13 +27,6 @@ train:
     batch_size: 1
     global_batch_size: 256
 
-  loss:
-    weights:
-      smooth_lddt: 1.0
-    diffusion_loss:
-      smooth_lddt_loss:
-        chunk_size: 1
-
   data:
     max_tokens: 760
     ccd_path: /cache/wykim_lab/kfold_data/v260310/ccd-train.pkl

--- a/configs/train-edm-1.yaml
+++ b/configs/train-edm-1.yaml
@@ -27,6 +27,11 @@ train:
     batch_size: 1
     global_batch_size: 256
 
+  loss:
+    diffusion_loss:
+      smooth_lddt_loss:
+        chunk_size: 8
+
   data:
     max_tokens: 376
     ccd_path: /cache/wykim_lab/kfold_data/v260310/ccd-train.pkl

--- a/configs/train/stage_1.yaml
+++ b/configs/train/stage_1.yaml
@@ -11,15 +11,3 @@ data:
   max_chains: 20
   max_tokens: 384
   max_sequence_tokens: 768
-
-loss:
-  weights:
-    # global loss weights
-    distogram: 3e-2
-    diffusion: 4.0
-    confidence: 1e-4
-    # diffusion loss weights
-    smooth_lddt: 1. # 0 for fine-tuning (See Section 5.2 for the AF3 paper)
-    bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
-    # confidence loss weights
-    pae: 0.0 # 1 for final stage training

--- a/configs/train/stage_2.yaml
+++ b/configs/train/stage_2.yaml
@@ -14,12 +14,4 @@ data:
 
 loss:
   weights:
-    # global loss weights
-    distogram: 3e-2
-    diffusion: 4.0
-    confidence: 1e-4
-    # diffusion loss weights
-    smooth_lddt: 0.0 # 0 for fine-tuning (See Section 5.2 for the AF3 paper)
-    bond: 1.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
-    # confidence loss weights
-    pae: 0.0 # 1 for final stage training
+    bond: 1.0 # Turn on bond loss (See Section 5.2 for the AF3 paper)

--- a/configs/train/stage_3.yaml
+++ b/configs/train/stage_3.yaml
@@ -14,12 +14,4 @@ data:
 
 loss:
   weights:
-    # global loss weights
-    distogram: 3e-2
-    diffusion: 4.0
-    confidence: 1e-4
-    # diffusion loss weights
-    smooth_lddt: 0.0 # 0 for fine-tuning (See Section 5.2 for the AF3 paper)
-    bond: 1.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
-    # confidence loss weights
-    pae: 0.0 # 1 for final stage training
+    bond: 1.0 # Turn on bond loss (See Section 5.2 for the AF3 paper)

--- a/configs/train/structure-only.yaml
+++ b/configs/train/structure-only.yaml
@@ -107,7 +107,7 @@ loss:
     diffusion: 4.0
     confidence: 1e-4
     # diffusion loss weights
-    smooth_lddt: 1. # 0 for fine-tuning (See Section 5.2 for the AF3 paper)
+    smooth_lddt: 1.0
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     # confidence loss weights
     pae: 0.0 # 1 for final stage training
@@ -135,7 +135,8 @@ loss:
 
     # Smooth LDDT Loss
     smooth_lddt_loss:
-      chunk_size: 8 # in number of samples.
+      repr_atom_only: false # if True, use [Nrepr, N] instead of [N, N] for LDDT calculation.
+      chunk_size: 1 # in number of samples.
 
   # Confidence loss
   # TODO

--- a/docs/DATA_STRUCTURE.md
+++ b/docs/DATA_STRUCTURE.md
@@ -109,7 +109,7 @@ coords = atom_arr.coords  # Shape: (Ntoken, 24, 3)
 | `entity_id`     | `(Ntoken,)`   | Entity ID (1-indexed) |
 | `asym_id`       | `(Ntoken,)`   | Asym ID (1-indexed) |
 | `sym_id`        | `(Ntoken,)`   | Sym ID (1-indexed) |
-| `disto_index`   | `(Ntoken,)`   | Disto atom index (Cβ) |
+| `repr_index`   | `(Ntoken,)`   | Representative atom index (Cβ, C4/C2) |
 | `center_index`  | `(Ntoken,)`   | Center atom index (Cα) |
 | `num_atoms`     | `(Ntoken,)`   | Number of atoms in each token |
 | `is_standard`   | `(Ntoken,)`   | Whether the residue is standard |
@@ -202,15 +202,15 @@ You can get chain features from `kfold.data.types.model_input.TokenTensor`:
 | `entity_id`       | `(Ntoken,)`     | Entity ID (1-indexed) |
 | `asym_id`         | `(Ntoken,)`     | Asym ID (1-indexed) |
 | `sym_id`          | `(Ntoken,)`     | Sym ID (1-indexed) |
-| `center_index`    | `(Ntoken,)`     | Center atom index (Cα) |
-| `disto_index`     | `(Ntoken,)`     | Disto atom index (Cβ) |
+| `center_index`    | `(Ntoken,)`     | Center atom index (Cα, C1') |
+| `repr_index`     | `(Ntoken,)`     | Representative atom index (Cβ, C4/C2) |
 | `frames_index`    | `(Ntoken, 3)`   | Frame defining atom index, e.g., protein: (N, Cα, C) |
 | `frames_mask`     | `(Ntoken,)`     | Whether all frame atoms are resolved |
 | `pad_mask`        | `(Ntoken,)`     | Mask for valid tokens or padding |
-| `center_coords`   | `(Ntoken, 3)`   | Center atom coords (Cα) |
-| `disto_coords`    | `(Ntoken, 3)`   | Disto atom coords (Cβ) |
+| `center_coords`   | `(Ntoken, 3)`   | Center atom coords (Cα, C1') |
+| `repr_coords`    | `(Ntoken, 3)`   | Representative atom coords (Cβ, C4/C2) |
 | `center_mask`     | `(Ntoken,)`     | Whether center atom is present |
-| `disto_mask`      | `(Ntoken,)`     | Whether disto atom is present |
+| `repr_mask`      | `(Ntoken,)`     | Whether repr atom is present |
 
 
 ### Atom features

--- a/src/kfold/constants/atom.py
+++ b/src/kfold/constants/atom.py
@@ -172,8 +172,8 @@ RESIDUE_ATOMS: dict[ResidueName, tuple[AtomName, ...]] = {
 }
 
 
-# reference atom for each residue
-REF_ATOM: dict[ResidueName, AtomName] = {
+# center atom for each residue
+CENTER_ATOM: dict[ResidueName, AtomName] = {
     # protein
     ResidueName.ALA: AtomName.CA,
     ResidueName.ARG: AtomName.CA,
@@ -209,8 +209,8 @@ REF_ATOM: dict[ResidueName, AtomName] = {
     ResidueName.DT: AtomName.C1_PRIME,
     ResidueName.DN: AtomName.C1_PRIME,
 }
-REF_ATOM_INDEX: dict[ResidueName, int] = {
-    res: RESIDUE_ATOMS[res].index(atom) for res, atom in REF_ATOM.items()
+CENTER_ATOM_INDEX: dict[ResidueName, int] = {
+    res: RESIDUE_ATOMS[res].index(atom) for res, atom in CENTER_ATOM.items()
 }
 
 # pseudo-beta atom for each residue to compute distogram

--- a/src/kfold/data/pipelines/featurization.py
+++ b/src/kfold/data/pipelines/featurization.py
@@ -135,21 +135,18 @@ def to_folding_input(struct: TokenizedStructure) -> FoldingInput:
         token_dict["frames_mask"][tidx] = is_frame
 
     # Map atom indices to global atom indices
-    atom_offset = (
-        np.cumsum(token_dict["num_atoms"]) - token_dict["num_atoms"]
-    )  # [Ntoken,]
+    atom_offset = np.cumsum(token_dict["num_atoms"]) - token_dict["num_atoms"]
     token_dict["center_index"] = token_dict["center_index"] + atom_offset
-    token_dict["disto_index"] = token_dict["disto_index"] + atom_offset
+    token_dict["repr_index"] = token_dict["repr_index"] + atom_offset
     token_dict["frames_index"] = token_dict["frames_index"] + atom_offset[:, np.newaxis]
 
-    # add disto/center coords
-    # HACK: we assume there is only one holo coordinate set.
-    token_dict["disto_coords"] = atom_dict["label_coords"][token_dict["disto_index"]]
+    # Add center/representative atom coordinates
+    token_dict["repr_coords"] = atom_dict["label_coords"][token_dict["repr_index"]]
     token_dict["center_coords"] = atom_dict["label_coords"][token_dict["center_index"]]
 
-    # Masks indicating whether the center/disto atoms are resolved
+    # Masks indicating whether the center/repr atoms are resolved
     token_dict["center_mask"] = atom_dict["resolved_mask"][token_dict["center_index"]]
-    token_dict["disto_mask"] = atom_dict["resolved_mask"][token_dict["disto_index"]]
+    token_dict["repr_mask"] = atom_dict["resolved_mask"][token_dict["repr_index"]]
 
     # === Atom-level features ===
     # Make one-hot vector for atom types

--- a/src/kfold/data/pipelines/tokenization.py
+++ b/src/kfold/data/pipelines/tokenization.py
@@ -317,8 +317,8 @@ def tokenize_structure(
 
             if is_res_standard:
                 # Standard protein/dna/rna residues (including ambiguous residues)
-                ref_atom_idx: int = C.atom.REF_ATOM_INDEX[res_name]
-                disto_atom_idx: int = C.atom.PSEUDO_BETA_ATOM_INDEX[res_name]
+                center_atom_idx: int = C.atom.CENTER_ATOM_INDEX[res_name]
+                repr_atom_index: int = C.atom.PSEUDO_BETA_ATOM_INDEX[res_name]
                 struct.token.chain_type[g_tok_i] = chain_type_i
                 struct.token.entity_id[g_tok_i] = entity_id
                 struct.token.asym_id[g_tok_i] = asym_id
@@ -328,8 +328,8 @@ def tokenize_structure(
                 struct.token.residue_index[g_tok_i] = res_idx
                 struct.token.seq_token_index[g_tok_i] = seq_token_idx
                 struct.token.num_atoms[g_tok_i] = natoms
-                struct.token.center_index[g_tok_i] = ref_atom_idx
-                struct.token.disto_index[g_tok_i] = disto_atom_idx
+                struct.token.center_index[g_tok_i] = center_atom_idx
+                struct.token.repr_index[g_tok_i] = repr_atom_index
 
                 # Update atom existence mask
                 struct.atom.pad_mask[g_tok_i, :natoms] = True
@@ -355,7 +355,7 @@ def tokenize_structure(
                 struct.token.seq_token_index[st:end] = seq_token_idx
                 struct.token.num_atoms[st:end] = 1
                 struct.token.center_index[st:end] = 0
-                struct.token.disto_index[st:end] = 0
+                struct.token.repr_index[st:end] = 0
 
                 # Update atom existence mask
                 struct.atom.pad_mask[st:end, 0] = True

--- a/src/kfold/data/types/model_input.py
+++ b/src/kfold/data/types/model_input.py
@@ -197,8 +197,8 @@ class TokenTensor(TensorLayout):
     pocket_contact_type: torch.Tensor  # [Ntoken,], bool
 
     # For model training
-    center_coords: torch.Tensor  # [Ntoken, 3], long
-    repr_coords: torch.Tensor  # [Ntoken, 3], long
+    center_coords: torch.Tensor  # [Ntoken, 3], float32
+    repr_coords: torch.Tensor  # [Ntoken, 3], float32
     center_mask: torch.Tensor  # [Ntoken,], bool
     repr_mask: torch.Tensor  # [Ntoken,], bool
 

--- a/src/kfold/data/types/model_input.py
+++ b/src/kfold/data/types/model_input.py
@@ -158,7 +158,7 @@ class TokenTensor(TensorLayout):
         in the SequenceTensor.
     center_index: torch.Tensor (long)
         Center indices of shape [Ntoken,], Cα
-    disto_index: torch.Tensor (long)
+    repr_index: torch.Tensor (long)
         Representative atom indices of shape [Ntoken,], Cβ
     frames_index: torch.Tensor (long)
         Frame indices of shape [Ntoken, 3].
@@ -172,12 +172,12 @@ class TokenTensor(TensorLayout):
     # For model training
     center_coords: torch.Tensor (float32)
         Center coordinates of shape [Ntoken, 3].
-    disto_coords: torch.Tensor (float32)
+    repr_coords: torch.Tensor (float32)
         Representative atom center coordinates of shape [Ntoken, 3].
     center_mask: torch.Tensor (bool)
         Mask tensor of shape [Ntoken,], indicating center atom of tokens to be resolved.
-    disto_mask: torch.Tensor (bool)
-        Mask tensor of shape [Ntoken,], indicating disto atom of tokens to be resolved.
+    repr_mask: torch.Tensor (bool)
+        Mask tensor of shape [Ntoken,], indicating repr atom of tokens to be resolved.
     """
 
     chain_type: torch.Tensor  # [Ntoken,], long
@@ -190,7 +190,7 @@ class TokenTensor(TensorLayout):
     residue_index: torch.Tensor  # [Ntoken,], long
     seq_token_index: torch.Tensor  # [Ntoken,], long
     center_index: torch.Tensor  # [Ntoken,], long
-    disto_index: torch.Tensor  # [Ntoken,], long
+    repr_index: torch.Tensor  # [Ntoken,], long
     frames_index: torch.Tensor  # [Ntoken, 3], long
     frames_mask: torch.Tensor  # [Ntoken,], bool
     pad_mask: torch.Tensor  # [Ntoken,], bool
@@ -198,9 +198,9 @@ class TokenTensor(TensorLayout):
 
     # For model training
     center_coords: torch.Tensor  # [Ntoken, 3], long
-    disto_coords: torch.Tensor  # [Ntoken, 3], long
+    repr_coords: torch.Tensor  # [Ntoken, 3], long
     center_mask: torch.Tensor  # [Ntoken,], bool
-    disto_mask: torch.Tensor  # [Ntoken,], bool
+    repr_mask: torch.Tensor  # [Ntoken,], bool
 
     @property
     def layout_shape(self) -> tuple[int, ...]:
@@ -230,7 +230,7 @@ class TokenTensor(TensorLayout):
         check_tensor(
             self.residue_index, name="residue_index", dtype=torch.long, shape=shape
         )
-        check_tensor(self.disto_index, name="disto_index", dtype=torch.long, shape=shape)
+        check_tensor(self.repr_index, name="repr_index", dtype=torch.long, shape=shape)
         check_tensor(
             self.center_index, name="center_index", dtype=torch.long, shape=shape
         )
@@ -254,10 +254,10 @@ class TokenTensor(TensorLayout):
             shape=(*shape, 3),
         )
         check_tensor(
-            self.disto_coords, name="disto_coords", dtype=torch.float32, shape=(*shape, 3)
+            self.repr_coords, name="repr_coords", dtype=torch.float32, shape=(*shape, 3)
         )
         check_tensor(self.center_mask, name="center_mask", dtype=torch.bool, shape=shape)
-        check_tensor(self.disto_mask, name="disto_mask", dtype=torch.bool, shape=shape)
+        check_tensor(self.repr_mask, name="repr_mask", dtype=torch.bool, shape=shape)
 
     @cached_property
     def is_protein(self) -> torch.Tensor:
@@ -301,7 +301,7 @@ class TokenTensor(TensorLayout):
             "asym_id": -1,
             "sym_id": -1,
             "residue_index": -1,
-            "disto_index": -1,
+            "repr_index": -1,
             "center_index": -1,
             "frames_index": -1,
             "frames_mask": False,
@@ -309,9 +309,9 @@ class TokenTensor(TensorLayout):
             "pocket_contact_type": 0,
             # For model training
             "center_coords": 0.0,
-            "disto_coords": 0.0,
+            "repr_coords": 0.0,
             "center_mask": False,
-            "disto_mask": False,
+            "repr_mask": False,
         }
 
         fields = {}

--- a/src/kfold/data/types/tokenized.py
+++ b/src/kfold/data/types/tokenized.py
@@ -182,8 +182,8 @@ class TokenArray(PlainLayout[np.ndarray]):
         starting from 0.
     center_index: np.ndarray (int)
         Center atom index of shape [L,], used for center calculations.
-    disto_index: np.ndarray (int)
-        Distogram atom index of shape [L,], used for distogram calculations.
+    repr_index: np.ndarray (int)
+        Representative atom index of shape [L,], used for distogram calculations.
 
     Cached Properties
     -----------------
@@ -208,7 +208,7 @@ class TokenArray(PlainLayout[np.ndarray]):
     residue_index: np.ndarray  # [L,], int
     seq_token_index: np.ndarray  # [L,], int
     center_index: np.ndarray  # [L,], int
-    disto_index: np.ndarray  # [L,], int
+    repr_index: np.ndarray  # [L,], int
 
     @cached_property
     def layout_shape(self) -> tuple[int, ...]:
@@ -228,7 +228,7 @@ class TokenArray(PlainLayout[np.ndarray]):
             self.residue_index, name="residue_index", dtype=np.integer, shape=shape
         )
         check_array(self.center_index, name="center_index", dtype=np.integer, shape=shape)
-        check_array(self.disto_index, name="disto_index", dtype=np.integer, shape=shape)
+        check_array(self.repr_index, name="repr_index", dtype=np.integer, shape=shape)
 
     @cached_property
     def is_protein(self) -> np.ndarray:
@@ -264,7 +264,7 @@ class TokenArray(PlainLayout[np.ndarray]):
             sym_id=full_minus_one((num_tokens,)),
             num_atoms=full_minus_one((num_tokens,)),
             center_index=full_minus_one((num_tokens,)),
-            disto_index=full_minus_one((num_tokens,)),
+            repr_index=full_minus_one((num_tokens,)),
             is_standard=full_false((num_tokens,)),
         )
 

--- a/src/kfold/model/modules/input_embedder/kfold_embedder.py
+++ b/src/kfold/model/modules/input_embedder/kfold_embedder.py
@@ -211,9 +211,9 @@ class KFoldInputEmbedder(BaseInputEmbedder):
         """
         batch_index = torch.arange(f_input.batch_size, device=f_input.device)[:, None]
         # Extract apo C-beta coordinates and mask
-        center_index = f_input.token.disto_index
-        apo_coords = f_input.atom.apo_coords[batch_index, center_index]  # [B, L, 3]
-        mask = f_input.atom.apo_mask[batch_index, center_index]  # [B, L]
+        repr_index = f_input.token.repr_index
+        apo_coords = f_input.atom.apo_coords[batch_index, repr_index]  # [B, L, 3]
+        mask = f_input.atom.apo_mask[batch_index, repr_index]  # [B, L]
         pair_mask = mask[:, :, None] & mask[:, None, :]
 
         # Chain identity mask (no inter-chain apo distances)

--- a/src/kfold/training/loss/diffusion.py
+++ b/src/kfold/training/loss/diffusion.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import torch
 
 from kfold.data.types.model_input import FoldingInput
@@ -7,7 +9,7 @@ from kfold.utils.geometry.rigid_align import weighted_rigid_align
 
 def safe_cdist(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     """Compute pairwise distances between two sets of points."""
-    d = x[..., None, :] - y[..., None, :, :]  # [*, Lx, Ly, 3]
+    d = x[..., :, None, :] - y[..., None, :, :]  # [*, Lx, Ly, 3]
     return torch.sqrt(d.pow(2).sum(-1) + eps)
 
 
@@ -149,7 +151,7 @@ class WeightedMSELoss(torch.nn.Module):
                 )  # [B, N, L, 3]
 
         d_sq = ((x_pred - x_true) ** 2).sum(-1)  # [B, N, L]
-        mask_sum = mask.sum(-1).clamp(1)  # [B, 1]
+        mask_sum = mask.sum(-1).clamp(min=1)  # [B, 1]
         mse_loss = (1 / 3) * (w * d_sq).sum(-1) / mask_sum  # [B, N]
 
         return mse_loss
@@ -249,6 +251,7 @@ class SmoothLDDTLoss(torch.nn.Module):
         self,
         cutoff: float = 15.0,
         cutoff_nucleic_acid: float = 30.0,
+        repr_atom_only: bool = False,
         chunk_size: int | None = 1,
     ):
         """Initialize SmoothLDDTLoss.
@@ -259,90 +262,20 @@ class SmoothLDDTLoss(torch.nn.Module):
             The cutoff for non-nucleic acid atoms
         cutoff_nucleic_acid: float
             The cutoff for nucleic acid atoms
+        repr_atom_only: bool
+            Whether to compute LDDT loss using representative atoms instead of all atoms:
+            [Lrepr, L] instead of [L, L]. This is a memory-saving option that can be used
+            for larger chunk sizes. The representative atoms are defined as follows:
+            - For proteins: Cb atoms
+            - For nucleic acids: C4' atoms
+            - For ligands: all atoms
         """
 
         super().__init__()
         self.cutoff: float = cutoff
         self.cutoff_nucleic_acid: float = cutoff_nucleic_acid
+        self.repr_atom_only: bool = repr_atom_only
         self.chunk_size: int | None = chunk_size
-
-    def _chunk_forward(
-        self,
-        x_pred: torch.Tensor,
-        d_true: torch.Tensor,
-        pair_mask: torch.Tensor,
-    ) -> torch.Tensor:
-        # Line 1
-        d_pred = safe_cdist(x_pred, x_pred)  # [N, L, L]
-
-        # Line 2
-        d_true = d_true
-
-        # Line 3
-        d_diff = torch.abs(d_true - d_pred)  # [N, L, L]
-
-        # Line 4
-        eps = (1 / 4) * (
-            torch.sigmoid(0.5 - d_diff)
-            + torch.sigmoid(1.0 - d_diff)
-            + torch.sigmoid(2.0 - d_diff)
-            + torch.sigmoid(4.0 - d_diff)
-        )  # [B, L, L]
-
-        # Line 5: outside function (is_nucleotide = is_dna | is_rna)
-
-        # Line 6: outside function (pair_mask = ...)
-
-        # Line 7
-        n_pair = pair_mask.sum((-1, -2)).clamp(1)  # [N,]
-        lddt = (eps * pair_mask).sum((-1, -2)) / n_pair  # [N,]
-
-        # Line 8
-        lddt_loss = 1.0 - lddt  # [N,]
-        return lddt_loss
-
-    def _forward_single(
-        self,
-        x_pred: torch.Tensor,
-        x_true: torch.Tensor,
-        mask: torch.Tensor,
-        is_nucleotide: torch.Tensor,
-    ) -> list[torch.Tensor]:
-        N, L, _ = x_pred.shape
-        # Compute true pairwise distances
-        # NOTE: this is shared across all samples in the batch.
-        d_true = safe_cdist(x_true[0], x_true[0])  # [L, L]
-
-        # Create pair mask
-        pair_mask = mask[None, :] & mask[:, None]  # [L, L]
-
-        # Mask out self-term
-        pair_mask.diagonal(dim1=-2, dim2=-1).fill_(0)
-
-        # Mask out invalid distances
-        dist_mask = ((d_true < self.cutoff_nucleic_acid) & is_nucleotide[..., None]) | (
-            (d_true < self.cutoff) & (~is_nucleotide[..., None])
-        )  # [L, L]
-        pair_mask &= dist_mask
-
-        losses = []
-        if self.chunk_size is None:
-            losses.append(self._chunk_forward(x_pred, d_true, pair_mask))
-        else:
-            for i in range(0, N, self.chunk_size):
-                st, end = i, i + self.chunk_size
-                loss_chunk = checkpoint_section(
-                    self._chunk_forward,
-                    (
-                        x_pred[st:end],
-                        d_true,
-                        pair_mask,
-                    ),
-                    apply_ckpt=True,
-                    use_reentrant=False,
-                )
-                losses.append(loss_chunk)
-        return losses
 
     def forward(
         self,
@@ -381,6 +314,9 @@ class SmoothLDDTLoss(torch.nn.Module):
         batch_indices = torch.arange(B, device=f_input.device)[:, None]
         is_nucleotide = is_nucleotide[batch_indices, f_input.atom.token_index]
 
+        # Get representative atom indices if needed
+        repr_atom_index = f_input.token.repr_index
+
         losses = []
         for b_i in range(B):
             losses.extend(
@@ -389,8 +325,101 @@ class SmoothLDDTLoss(torch.nn.Module):
                     x_true[b_i],  # [N, L, 3]
                     mask[b_i],  # [L]
                     is_nucleotide[b_i],  # [L]
+                    repr_atom_index[b_i],  # [L]
                 )
             )
         lddt_loss = torch.cat(losses, dim=0)  # [B*N]
         lddt_loss = lddt_loss.view(B, N)  # [B, N]
+        return lddt_loss
+
+    def _forward_single(
+        self,
+        x_pred: torch.Tensor,
+        x_true: torch.Tensor,
+        mask: torch.Tensor,
+        is_nucleotide: torch.Tensor,
+        repr_atom_index: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        N, L, _ = x_pred.shape
+        # Compute true pairwise distances
+        # NOTE: pairwise distances of ground truth coordinates are shared across N.
+        x_true = x_true[0]
+        d_true = safe_cdist(x_true, x_true)  # [L, L]
+
+        # Create pair mask
+        pair_mask = mask[None, :] & mask[:, None]  # [L, L]
+        # Mask out self-term
+        pair_mask.diagonal(dim1=-2, dim2=-1).zero_()
+        # Mask out invalid distances
+        dist_mask = ((d_true < self.cutoff_nucleic_acid) & is_nucleotide[..., None]) | (
+            (d_true < self.cutoff) & (~is_nucleotide[..., None])
+        )
+        pair_mask &= dist_mask
+
+        if self.repr_atom_only:
+            # Extract representative atom indices
+            d_true = d_true[repr_atom_index]  # [L, L] -> [Lrepr, L]
+            pair_mask = pair_mask[repr_atom_index]  # [L, L] -> [Lrepr, L]
+
+        pair_mask = pair_mask.float()
+
+        loss_fn = partial(
+            self._chunk_forward,
+            d_true=d_true,  # [L, L] or [Lrepr, L]
+            pair_mask=pair_mask,  # [L, L] or [Lrepr, L]
+            repr_atom_index=repr_atom_index if self.repr_atom_only else None,
+        )
+
+        losses = []
+        if self.chunk_size is None:
+            losses.append(loss_fn(x_pred))  # [N,]
+        else:
+            for i in range(0, N, self.chunk_size):
+                st, end = i, i + self.chunk_size
+                x_chunk = x_pred[st:end]  # [chunk_size, L, 3]
+                loss_chunk = checkpoint_section(
+                    loss_fn, (x_chunk,), apply_ckpt=True, use_reentrant=False
+                )
+                losses.append(loss_chunk)
+        return losses
+
+    @staticmethod
+    def _chunk_forward(
+        x_pred: torch.Tensor,
+        d_true: torch.Tensor,
+        pair_mask: torch.Tensor,
+        repr_atom_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Line 1
+        if repr_atom_index is not None:
+            # Compute predicted distances between representative atoms and all atoms
+            x_pred_repr = x_pred[:, repr_atom_index]  # [N, Lrepr, 3]
+            d_pred = safe_cdist(x_pred_repr, x_pred)  # [N, Lrepr, L]
+        else:
+            # Compute predicted pairwise distances (original AF3)
+            d_pred = safe_cdist(x_pred, x_pred)  # [N, L, L]
+
+        # Line 2 (outside function): compute true pairwise distances
+
+        # Line 3
+        d_diff = torch.abs(d_pred - d_true[None, ...])  # [N, L, L]
+
+        # Line 4
+        lddt_score = (1 / 4) * (
+            torch.sigmoid(0.5 - d_diff)
+            + torch.sigmoid(1.0 - d_diff)
+            + torch.sigmoid(2.0 - d_diff)
+            + torch.sigmoid(4.0 - d_diff)
+        )  # [N, L, L]
+
+        # Line 5: outside function (is_nucleotide = is_dna | is_rna)
+
+        # Line 6: outside function (pair_mask = ...)
+
+        # Line 7
+        n_pair = pair_mask.sum((-1, -2)).clamp(min=1)  # scalar
+        lddt = (lddt_score * pair_mask[None, ...]).sum((-1, -2)) / n_pair  # [N,]
+
+        # Line 8
+        lddt_loss = 1.0 - lddt  # [N,]
         return lddt_loss

--- a/src/kfold/training/loss/diffusion.py
+++ b/src/kfold/training/loss/diffusion.py
@@ -341,32 +341,31 @@ class SmoothLDDTLoss(torch.nn.Module):
         repr_atom_index: torch.Tensor,
     ) -> list[torch.Tensor]:
         N, L, _ = x_pred.shape
-        # Compute true pairwise distances
         # NOTE: pairwise distances of ground truth coordinates are shared across N.
         x_true = x_true[0]
-        d_true = safe_cdist(x_true, x_true)  # [L, L]
 
         # Create pair mask
         pair_mask = mask[None, :] & mask[:, None]  # [L, L]
         # Mask out self-term
         pair_mask.diagonal(dim1=-2, dim2=-1).zero_()
-        # Mask out invalid distances
-        dist_mask = ((d_true < self.cutoff_nucleic_acid) & is_nucleotide[..., None]) | (
-            (d_true < self.cutoff) & (~is_nucleotide[..., None])
-        )
-        pair_mask &= dist_mask
 
         if self.repr_atom_only:
             # Extract representative atom indices
-            d_true = d_true[repr_atom_index]  # [L, L] -> [Lrepr, L]
+            d_true = safe_cdist(x_true[repr_atom_index], x_true)  # [Lrepr, L]
             pair_mask = pair_mask[repr_atom_index]  # [L, L] -> [Lrepr, L]
+            is_nucleotide = is_nucleotide[repr_atom_index]  # [L] -> [Lrepr]
+        else:
+            d_true = safe_cdist(x_true, x_true)  # [L, L]
 
-        pair_mask = pair_mask.float()
+        # Mask out invalid distances
+        pair_mask &= ((d_true < self.cutoff_nucleic_acid) & is_nucleotide[..., None]) | (
+            (d_true < self.cutoff) & (~is_nucleotide[..., None])
+        )  # [L, L] or [Lrepr, L]
 
         loss_fn = partial(
             self._chunk_forward,
             d_true=d_true,  # [L, L] or [Lrepr, L]
-            pair_mask=pair_mask,  # [L, L] or [Lrepr, L]
+            pair_mask=pair_mask.float(),  # [L, L] or [Lrepr, L]
             repr_atom_index=repr_atom_index if self.repr_atom_only else None,
         )
 

--- a/src/kfold/training/loss/distogram.py
+++ b/src/kfold/training/loss/distogram.py
@@ -38,31 +38,32 @@ class DistogramLoss(torch.nn.Module):
 
         Returns
         -------
-        disto_loss : torch.Tensor
+        distogram_loss : torch.Tensor
             The computed distogram loss of shape (B,).
         """
 
         with torch.autocast("cuda", enabled=False), torch.no_grad():
             boundaries: torch.Tensor = self.boundaries  # [num_bins - 1] # type: ignore
-            disto_coords = f_input.token.disto_coords
-            diff = disto_coords[..., None, :, :] - disto_coords[..., :, None, :]
-            pdist_disto = diff.norm(dim=-1)  # [B, Lt, Lt]
-            target_distogram = (pdist_disto.unsqueeze(-1) > boundaries).sum(dim=-1).long()
+            gt_coords = f_input.token.repr_coords
+            diff = gt_coords[..., None, :, :] - gt_coords[..., :, None, :]
+            d_repr = diff.norm(dim=-1)  # [B, Lt, Lt]
+            target_distogram = (d_repr.unsqueeze(-1) > boundaries).sum(dim=-1).long()
 
         # Compute the distogram loss
         B, L, L = target_distogram.shape
-        disto_loss = torch.nn.functional.cross_entropy(
+        distogram_loss = torch.nn.functional.cross_entropy(
             logits.view(B * L * L, self.num_bins),
             target_distogram.view(B * L * L),
             reduction="none",
         ).view(B, L, L)
 
         # Mask out invalid distogram
-        mask = f_input.token.disto_mask  # [B, Lt]
-        pair_mask = mask[:, None, :] & mask[:, :, None]  # [B, Lt, Lt]
+        mask = f_input.token.repr_mask  # [B, Lt]
+        pair_mask = mask[..., None, :] & mask[..., :, None]  # [B, Lt, Lt]
         pair_mask.diagonal(dim1=-2, dim2=-1).zero_()  # zero out diagonal
-        disto_loss = disto_loss * pair_mask  # [B, Lt, Lt]
+        pair_mask = pair_mask.float()
 
         # Compute mean loss
-        disto_loss = disto_loss.sum((-1, -2)) / pair_mask.sum((-1, -2)).clamp(1)  # [B,]
-        return disto_loss
+        sum_loss = (distogram_loss * pair_mask).sum((-1, -2))  # [B,]
+        n_valid = pair_mask.sum((-1, -2)).clamp(1)  # [B,]
+        return sum_loss / n_valid  # [B,]


### PR DESCRIPTION
This pull request refactors the naming and handling of representative atom indices and coordinates throughout the codebase, replacing the previous `disto_index` and `disto_coords` terminology with `repr_index` and `repr_coords`. It also updates related documentation and configuration files to match these changes, and simplifies loss configuration in several training YAML files. These updates improve clarity and consistency in atom feature representation, particularly for representative atoms used in distogram and LDDT calculations.

### Atom indexing and feature representation

* Renamed `disto_index` and `disto_coords` to `repr_index` and `repr_coords` in all relevant data types (`TokenTensor`, `TokenArray`, and associated methods), including masks and documentation. This clarifies that these fields represent the "representative atom" (e.g., Cβ, C4/C2) rather than a generic distogram atom.

* Updated documentation in `docs/DATA_STRUCTURE.md` to reflect the new naming and clarify the meaning of `repr_index` and `repr_coords` for both protein and nucleic acid residues.

* Changed atom constants: renamed `REF_ATOM` and `REF_ATOM_INDEX` to `CENTER_ATOM` and `CENTER_ATOM_INDEX` for clarity, distinguishing center atoms (e.g., Cα, C1') from representative atoms.

### Training configuration simplification

* Simplified loss configuration in training YAML files by removing or consolidating loss weights, especially for `smooth_lddt` and `bond` losses, and updating chunk size and parameters for LDDT loss.