### PR TITLE
Optimize model training

### DIFF
--- a/configs/model/af3.yaml
+++ b/configs/model/af3.yaml
@@ -2,11 +2,6 @@
 _registry_: "main_module"
 _class_: AlphaFold3
 
-# compilation settings
-compile_trunk: false
-compile_score_model: false
-compile_mode: 'default'
-
 # kernel settings
 kernel:
   cuequivariance: true

--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -6,11 +6,6 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
-# compilation settings
-compile_trunk: false
-compile_score_model: false
-compile_mode: "default"
-
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/kfold.yaml"

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -6,11 +6,6 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
-# compilation settings
-compile_trunk: false
-compile_score_model: false
-compile_mode: "default"
-
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/kfold.yaml"

--- a/configs/model/kfold-expanded-ecsi.yaml
+++ b/configs/model/kfold-expanded-ecsi.yaml
@@ -5,10 +5,6 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
-compile_trunk: false
-compile_score_model: false
-compile_mode: "default"
-
 input_embedder:
   _yaml_: "module/input_embedder/kfold.yaml"
 

--- a/configs/model/kfold-prime-ecsi.yaml
+++ b/configs/model/kfold-prime-ecsi.yaml
@@ -6,11 +6,6 @@ _class_: KFold
 kernel:
   cuequivariance: true
 
-# compilation settings
-compile_trunk: false
-compile_score_model: false
-compile_mode: "default"
-
 # Module configurations
 input_embedder:
   _yaml_: "module/input_embedder/kfold.yaml"

--- a/configs/model/module/structure_module/af3.yaml
+++ b/configs/model/module/structure_module/af3.yaml
@@ -10,4 +10,3 @@ gamma_0: 0.8
 gamma_min: 1.0
 noise_scale: 1.003
 step_scale: 1.5
-coordinate_augmentation: True

--- a/configs/train/structure-only.yaml
+++ b/configs/train/structure-only.yaml
@@ -138,6 +138,7 @@ loss:
     smooth_lddt_loss:
       repr_atom_only: false # if True, use [Nrepr, N] instead of [N, N] for LDDT calculation.
       chunk_size: 1 # in number of samples.
+      use_kernel: true
 
   # Confidence loss
   # TODO

--- a/configs/train/structure-only.yaml
+++ b/configs/train/structure-only.yaml
@@ -14,6 +14,12 @@ global_hparams:
   global_batch_size: 256
   num_global_steps_per_epoch: 1000
 
+# compilation settings
+compile:
+  enabled: false
+  mode: "default"
+  dynamic: false
+
 data:
   _registry_: "datamodule"
   _class_: TrainingDataModule

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -189,7 +189,7 @@ def main():
     model: KFold = KFold.from_checkpoint(
         args.config, args.checkpoint, override_args=args.override
     )
-    model = model.cast_to_bf16().eval().cuda()
+    model = model.bfloat16().eval().cuda()
     logger.info("Model loaded successfully.")
 
     # mmCIF writer

--- a/scripts/inference_multigpu.py
+++ b/scripts/inference_multigpu.py
@@ -190,7 +190,7 @@ def main():
         logger=False,
         callbacks=[inference_writer],
         enable_checkpointing=False,
-        precision="bf16-mixed",
+        precision="bf16-true",
         benchmark=False,
         deterministic=True,
     )
@@ -201,7 +201,7 @@ def main():
     model: KFold = KFold.from_checkpoint(
         args.config, args.checkpoint, override_args=args.override
     )
-    model = model.cast_to_bf16().eval()
+    model = model.bfloat16().eval().cuda()
     log_info("Model loaded successfully.")
 
     # === Run inference ===

--- a/src/kfold/data/types/model_input.py
+++ b/src/kfold/data/types/model_input.py
@@ -899,43 +899,6 @@ class FoldingInput:
             )
         return data_list
 
-    def get_atom_to_token(self) -> torch.Tensor:
-        """Return [Natom, Ntoken] or [B, Natom, Ntoken] dense mapping matrix
-        from atoms to tokens.
-        """
-        return self.atom_to_token
-
-    @cached_property
-    def atom_to_token(self) -> torch.Tensor:
-        """Return [Natom, Ntoken] or [B, Natom, Ntoken] dense mapping matrix
-        from atoms to tokens.
-        """
-
-        if not self.is_batched:
-            Natom = int(self.atom.pad_mask.sum().item())
-            atom_indices = torch.arange(Natom, device=self.device)
-            token_indices = self.atom.token_index[:Natom]
-            mapping = torch.zeros(
-                (self.num_atoms, self.num_tokens),
-                dtype=torch.float32,
-                device=self.device,
-            )
-            mapping[atom_indices, token_indices] = 1.0
-        else:
-            batch_size = self.chain.batch_size
-            num_atoms = self.atom.pad_mask.sum(dim=1).tolist()
-            mapping = torch.zeros(
-                (batch_size, self.num_atoms, self.num_tokens),
-                dtype=torch.float32,
-                device=self.device,
-            )
-            for b in range(batch_size):
-                Natom = num_atoms[b]
-                atom_indices = torch.arange(Natom, device=self.device)
-                token_indices = self.atom.token_index[b, :Natom]
-                mapping[b, atom_indices, token_indices] = 1.0
-        return mapping
-
     def __repr__(self) -> str:
         """FoldingInput summary representation."""
         device = self.device

--- a/src/kfold/inference/dataset.py
+++ b/src/kfold/inference/dataset.py
@@ -72,7 +72,7 @@ class InferenceDataset(torch.utils.data.Dataset):
     def pad_input(self, f_input: FoldingInput) -> FoldingInput:
         """Pad the folding input to multiple of 64"""
         # Pad num_tokens for CUDA efficiency.
-        num_tokens = next_multiple(f_input.num_tokens, 64)
+        num_tokens = next_multiple(f_input.num_tokens, 32)
         # Pad max_sequence length for CUDA efficiency.
         num_sequence_tokens = next_multiple(f_input.num_sequence_tokens, 64)
         # Pad num_atoms for local attention.

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -50,7 +50,7 @@ class KFoldInferenceClient(pl.LightningModule):
         self.inference_config: InferenceConfig = inference_config
         self.num_trunk_recycles: int = inference_config.num_recycles
         self.num_diffusion_steps: int = inference_config.num_steps
-        self.num_diffusion_samples: int = inference_config.num_samples
+        self.num_samples: int = inference_config.num_samples
 
         # Logger
         self._logger = logging.getLogger("KFoldInferenceClient")
@@ -65,7 +65,7 @@ class KFoldInferenceClient(pl.LightningModule):
             apo_dict,
             num_recycles=self.num_trunk_recycles,
             num_steps=self.num_diffusion_steps,
-            num_samples=self.num_diffusion_samples,
+            num_samples=self.num_samples,
         )
         return dict_out
 

--- a/src/kfold/inference/pl_client.py
+++ b/src/kfold/inference/pl_client.py
@@ -47,7 +47,6 @@ class KFoldInferenceClient(pl.LightningModule):
     ):
         super().__init__()
         self.model: KFold = model
-        self.model.cast_to_bf16()  # Use bfloat16 to save memory and speed up
         self.inference_config: InferenceConfig = inference_config
         self.num_trunk_recycles: int = inference_config.num_recycles
         self.num_diffusion_steps: int = inference_config.num_steps

--- a/src/kfold/model/layers/alphafold3/atom_transformer.py
+++ b/src/kfold/model/layers/alphafold3/atom_transformer.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
@@ -7,7 +8,11 @@ from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.primitives import LayerNorm, LinearNoBias
 
 from .diffusion_transformer import LocalTransformerStack
-from .utils import aggregate_atoms_to_tokens, broadcast_tokens_to_atoms, window_to_qk
+from .utils import (
+    aggregate_atoms_to_tokens,
+    broadcast_tokens_to_atoms,
+    build_atom_to_qk_fn,
+)
 
 
 class AtomEmbedder(nn.Module):
@@ -123,12 +128,14 @@ class AtomEmbedder(nn.Module):
             The atom pair representation
             shape [B, W, Lq, Lk, c_atompair]
         """
+        to_qk = build_atom_to_qk_fn(f_input.num_atoms, f_input.device)
+
         # Line 1: Initialize single conditioning
         c = self.embed_atom(f_input)  # [B, La, c_atom]
 
         # Line 2-6, Initialize pair representation
         # [B, W, Lq, Lk, c_atompair]
-        p = self.embed_atom_pairs(f_input)
+        p = self.embed_atom_pairs(f_input, to_qk)
 
         # LIne 7: Initialize atom single representation
         q = c  # [B, La, c_atom]
@@ -139,12 +146,12 @@ class AtomEmbedder(nn.Module):
             token_index = f_input.atom.token_index  # [B, La]
             # Line 9-10
             c = self.add_trunk_single_representation(c, s_trunk, token_index)
-            p = self.add_trunk_pair_conditioning(p, z, token_index)
+            p = self.add_trunk_pair_conditioning(p, z, token_index, to_qk)
         else:
             assert s_trunk is None and z is None
 
         # Line 13: Add atom-wise contributions to pair representation
-        c_q, c_k = window_to_qk(c, dim=-2)  # [B, W, Lq|Lk, c_atom]
+        c_q, c_k = to_qk(c, -2)  # [B, W, Lq|Lk, c_atom]
         p = p + self.linear_query(c_q)[..., :, None, :]
         p = p + self.linear_key(c_k)[..., None, :, :]
         # Line 14
@@ -160,27 +167,30 @@ class AtomEmbedder(nn.Module):
         c = c + self.embed_atom_name_chars(f_input.atom.ref_atom_name_chars.flatten(-2))
         return c
 
-    def embed_atom_pairs(self, f_input: FoldingInput) -> torch.Tensor:
+    def embed_atom_pairs(self, f_input: FoldingInput, to_qk: Callable) -> torch.Tensor:
         """Get atom pair representation from reference molecule conformer.
 
         Parameters
         ----------
         f_input : FoldingInputk
             The folding input.
+        atom_to_query: tuple[torch.Tensor, torch.Tensor]
+            The pre-computed atom to query indices for window attention.
 
         Returns
         -------
         p : torch.Tensor
             The atom pair representation, shape [B, W, Lq, Lk, c_atompair]
         """
+
         # Mask with residue identity
         uid = f_input.atom.ref_space_uid  # [B, La]
-        uid_q, uid_k = window_to_qk(uid, dim=-1)  # [B, W, Lq|Lk]
+        uid_q, uid_k = to_qk(uid, dim=-1)  # [B, W, Lq|Lk]
         v = uid_q[..., :, None] == uid_k[..., None, :]  # [B, W, Lq, Lk]
         v = v.float().unsqueeze(-1)  # [B, W, Lq, Lk, 1]
 
         ref_pos = f_input.atom.ref_pos  # [B, La, 3]
-        ref_pos_q, ref_pos_k = window_to_qk(ref_pos, dim=-2)  # [B, W, Lq|Lk, 3]
+        ref_pos_q, ref_pos_k = to_qk(ref_pos, dim=-2)  # [B, W, Lq|Lk, 3]
         # Shape: [B, W, Lq, Lk, 3], [B, W, Lq, Lk, 1]
         ref_d_offset = ref_pos_q[..., :, None, :] - ref_pos_k[..., None, :, :]
         ref_dsq_inv = 1.0 / (1.0 + ref_d_offset.pow(2).sum(-1, keepdim=True))
@@ -223,6 +233,7 @@ class AtomEmbedder(nn.Module):
         p: torch.Tensor,
         z: torch.Tensor,
         token_index: torch.Tensor,
+        to_qk: Callable,
     ) -> torch.Tensor:
         """Add trunk pair conditioning to atom pair representation.
         Parameters
@@ -248,7 +259,7 @@ class AtomEmbedder(nn.Module):
 
         # 2. Get Windowed Indices
         # [*, La] -> [*, W, Lq], [*, W, Lk]
-        idx_q, idx_k = window_to_qk(token_index, dim=-1)
+        idx_q, idx_k = to_qk(token_index, dim=-1)
         idx_q = idx_q.expand(*batch_shape, W, Lq)
         idx_k = idx_k.expand(*batch_shape, W, Lk)
 
@@ -470,6 +481,5 @@ class AtomAttentionDecoder(nn.Module):
         q = self.transformer(q, c_skip, p_skip, mask)
 
         # Line 3: Project atom representation to updated coordinates
-        with torch.autocast(a.device.type, enabled=False):
-            r_update = self.linear_q_to_r(self.layernorm_q(q.float()))  # [*, N, La, 3]
+        r_update = self.linear_q_to_r(self.layernorm_q(q))  # [*, N, La, 3]
         return r_update

--- a/src/kfold/model/layers/alphafold3/diffusion.py
+++ b/src/kfold/model/layers/alphafold3/diffusion.py
@@ -441,15 +441,24 @@ class DiffusionModule(nn.Module):
         # Already given as an input: r_noisy
 
         # === Local attention on atom-level and aggregate to coarse-grained token === #
+        # Add diffusion sample dimension
+        q = q.unsqueeze(-3)  # [B, 1, La, c_atom]
+        c = c.unsqueeze(-3)  # [B, 1, La, c_atom]
+        p = p.unsqueeze(-5)  # [B, 1, W, Lq, Lk, c_atompair]
+        atom_mask = atom_mask.unsqueeze(-2)  # [B, 1, La]
+        token_mask = token_mask.unsqueeze(-2)  # [B, 1, Lt]
+        token_index = token_index.unsqueeze(-2)  # [B, 1, La]
+
         # Line 3
         # NOTE: Add extra dimension for the number of diffusion samples, N.
+        r_noisy = r_noisy * atom_mask[..., None]
         a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
-            q.unsqueeze(1),  # [B, 1, La, c_atom]
-            c.unsqueeze(1),  # [B, 1, La, c_atom]
-            p.unsqueeze(1),  # [B, 1, W, Lq, Lk, c_atompair]
+            q,  # [B, 1, La, c_atom]
+            c,  # [B, 1, La, c_atom]
+            p,  # [B, 1, W, Lq, Lk, c_atompair]
             r_noisy=r_noisy,  # [B, N, La, 3]
-            token_index=token_index.unsqueeze(1),  # [B, 1, Lt]
-            mask=atom_mask.unsqueeze(1),  # [B, 1, La]
+            token_index=token_index,  # [B, 1, Lt]
+            mask=atom_mask,  # [B, 1, La]
             num_tokens=token_mask.shape[-1],
         )
 
@@ -461,6 +470,7 @@ class DiffusionModule(nn.Module):
 
         # === Full attention on token-level === #
         # Line 4
+        a = a.float()  # Convert to float32 for stability in residual connection.
         a = a + self.linear_s_to_a(self.layernorm_s(s))  # [B, N, Lt, c_token]
 
         # Line 5
@@ -468,7 +478,7 @@ class DiffusionModule(nn.Module):
             a,  # [B, N, Lt, c_token]
             s,  # [B, N, Lt, c_s]
             z,  # [B, 1, Lt, Lt, c_z]
-            mask=token_mask.unsqueeze(1),  # [B, 1, Lt]
+            mask=token_mask,  # [B, 1, Lt]
             use_cuequiv_kernels=use_cuequiv_kernels,
         )
 
@@ -482,10 +492,11 @@ class DiffusionModule(nn.Module):
             q_skip,  # [B, N, La, c_atom]
             c_skip,  # [B, 1, La, c_atom]
             p_skip,  # [B, 1, W, Lq, Lk, c_atompair]
-            token_index=token_index.unsqueeze(-2),  # [B, 1, Lt]
-            mask=atom_mask.unsqueeze(-2),  # [B, 1, La]
+            token_index=token_index,  # [B, 1, La]
+            mask=atom_mask,  # [B, 1, La]
         )  # -> [B, N, La, 3]
 
         # Line 8: Performed on StructureModule side.
+        r_update = r_update * atom_mask[..., None]  # Mask out padded atoms.
 
         return r_update

--- a/src/kfold/model/layers/alphafold3/diffusion_transformer.py
+++ b/src/kfold/model/layers/alphafold3/diffusion_transformer.py
@@ -7,7 +7,7 @@ from kfold.model.layers.primitives import AdaLN, Linear, LinearNoBias, SwiGLU
 from kfold.utils.checkpointing import checkpoint_blocks
 
 from .attention_pair_bias import CrossAttentionPairBias, SelfAttentionPairBias
-from .utils import window_to_qk
+from .utils import build_atom_to_qk_fn
 
 
 class ConditionedTransitionBlock(nn.Module):
@@ -267,11 +267,12 @@ class LocalTransformerStack(nn.Module):
         a : torch.Tensor
             The output single representation tensor (*, L, c_a)
         """
-        s_q, s_k = window_to_qk(s, dim=-2)
-        _, mask_k = window_to_qk(mask, dim=-1)
+        to_qk = build_atom_to_qk_fn(a.shape[-2], a.device)
+        s_q, s_k = to_qk(s, -2)
+        _, mask_k = to_qk(mask, -1)
 
         for block in self.blocks:
-            a_q, a_k = window_to_qk(a, dim=-2)  # [*, W, Lq/Lk, c_a]
+            a_q, a_k = to_qk(a, -2)  # [*, W, Lq/Lk, c_a]
             a_q = block(a_q, a_k, s_q, s_k, z, mask_k)
             a = a_q.flatten(-3, -2)  # [*, L, c_a]
         return a

--- a/src/kfold/model/layers/alphafold3/utils.py
+++ b/src/kfold/model/layers/alphafold3/utils.py
@@ -1,6 +1,6 @@
-import dataclasses
 import math
-from functools import lru_cache
+from collections.abc import Callable
+from functools import partial
 from typing import TypeVar, overload
 
 import torch
@@ -106,8 +106,65 @@ def aggregate_atoms_to_tokens(
 
 
 # === Local Attention Indexing === #
-def window_to_qk(
-    x: torch.Tensor, dim: int, window_size_queries: int = 32, window_size_keys: int = 128
+def build_atom_to_qk_fn(
+    length: int, device: str | torch.device
+) -> Callable[[torch.Tensor, int], tuple[torch.Tensor, torch.Tensor]]:
+    """Build indices for window-based local attention from atoms to query windows.
+
+    Parameters
+    ----------
+    length: int
+        The sequence length (number of atoms).
+    device: str | torch.device
+        The device on which to create the index tensors.
+
+    Returns
+    -------
+    Callable[[torch.Tensor, int], tuple[torch.Tensor, torch.Tensor]]
+        A function that takes an input tensor and a dimension, and returns the
+        query and key tensors for local attention.
+    """
+    Lq, Lk = 32, 128  # noqa
+    if length % 32 != 0:
+        raise ValueError("Length must be divisible by 32")
+
+    W: int = length // 32
+    half_block_size = 16
+    num_half_blocks = 2 * W
+    h = 8  # 128 // 16
+
+    # Block Logic
+    start_offset = -(h // 2) + 1
+    block_offsets = torch.arange(h, device=device) + start_offset
+    window_starts = torch.arange(W, device=device).unsqueeze(-1) * 2
+    block_indices = window_starts + block_offsets  # [W, h]
+
+    # Pad mask for out-of-bounds
+    pad_mask = (block_indices < 0) | (block_indices >= num_half_blocks)
+    # [W, h] -> [W, Lk]
+    pad_mask = pad_mask.repeat_interleave(half_block_size, dim=-1)
+
+    # Clamp block indices to valid range
+    block_indices = block_indices.clamp(min=0, max=num_half_blocks - 1)
+
+    # Expand block indices to atom indices
+    atom_offsets = torch.arange(half_block_size, device=device)
+
+    # Broadcasting to construct full [W, Lk] index matrix
+    gather_indices = (
+        block_indices[..., None] * half_block_size + atom_offsets[None, None, ...]
+    )
+    gather_indices = gather_indices.view(W, Lk)
+
+    func = partial(convert_atom_to_qk, gather_indices=gather_indices, pad_mask=pad_mask)
+    return func
+
+
+def convert_atom_to_qk(
+    x: torch.Tensor,
+    dim: int,
+    gather_indices: torch.Tensor,
+    pad_mask: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Window-based indexing for local attention.
 
@@ -120,154 +177,30 @@ def window_to_qk(
 
     Returns
     -------
-    tuple[torch.Tensor, torch.Tensor]
+    torch.Tensor
         Query tensor of shape [*, W, Lq, *]
+    torch.Tensor
         Key tensor of shape [*, W, Lk, *]
     """
-    length = x.shape[dim]
-    device = x.device
-    local_index = LocalAttentionIndex.create(
-        length, window_size_queries, window_size_keys, device
-    )
-    return local_index.to_qk(x, dim)
+    W = gather_indices.shape[0]
+    dim = dim % x.ndim
+
+    # Get query
+    x_q = x.unflatten(dim, sizes=(W, 32))
+
+    # Get keys using gather indices
+    x_k = x.index_select(dim, gather_indices.view(-1))
+    x_k = x_k.unflatten(dim, sizes=(W, 128))
+
+    # Apply Padding Mask
+    mask_shape = [1] * x_k.ndim
+    mask_shape[dim] = gather_indices.shape[0]  # W
+    mask_shape[dim + 1] = gather_indices.shape[1]  # Lk
+    x_k = x_k.masked_fill(pad_mask.view(*mask_shape), 0)
+    return x_q, x_k
 
 
-@dataclasses.dataclass(slots=True)
-class LocalAttentionIndex:
-    L: int
-    W: int
-    Lq: int
-    Lk: int
-    gather_indices: torch.Tensor
-    pad_mask: torch.Tensor
-
-    @classmethod
-    @lru_cache(maxsize=3)
-    def create(
-        cls,
-        length: int,
-        window_size_query: int = 32,
-        window_size_key: int = 128,
-        device: str | torch.device = "cpu",
-    ) -> "LocalAttentionIndex":
-        """Indexer for local attention."""
-        assert window_size_key % (window_size_query // 2) == 0
-        if length % window_size_query != 0:
-            raise ValueError(
-                "Length must be divisible by window size for keys."
-                f" Got length={length} and window_size_query={window_size_query}."
-            )
-        L: int = length
-        W: int = length // window_size_query
-        Lq: int = window_size_query
-        Lk: int = window_size_key
-
-        # Pre-calculate the gather indices once
-        # Shape: [W, Lk]
-        gather_indices, pad_mask = cls._build_gather_indices(W, Lq, Lk, device)
-        return cls(L, W, Lq, Lk, gather_indices, pad_mask)
-
-    @staticmethod
-    def _build_gather_indices(
-        W: int, Lq: int, Lk: int, device: str | torch.device
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Constructs the index map [W, Lk] mapping window rows to atom indices."""
-        half_block_size = Lq // 2
-        num_half_blocks = 2 * W
-        h = Lk // (Lq // 2)  # Number of half-blocks per key window
-
-        # Block Logic
-        start_offset = -(h // 2) + 1
-        block_offsets = torch.arange(h, device=device) + start_offset
-        window_starts = torch.arange(W, device=device).unsqueeze(-1) * 2
-        block_indices = window_starts + block_offsets  # [W, h]
-
-        # Pad mask for out-of-bounds
-        pad_mask = (block_indices < 0) | (block_indices >= num_half_blocks)
-        # [W, h] -> [W, Lk]
-        pad_mask = pad_mask.repeat_interleave(half_block_size, dim=-1)
-
-        # Clamp block indices to valid range
-        block_indices = block_indices.clamp(min=0, max=num_half_blocks - 1)
-
-        # Expand block indices to atom indices
-        atom_offsets = torch.arange(half_block_size, device=device)
-
-        # Broadcasting to construct full [W, Lk] index matrix
-        gather_indices = (
-            block_indices[..., None] * half_block_size + atom_offsets[None, None, ...]
-        )
-        gather_indices = gather_indices.view(W, Lk)
-
-        return gather_indices, pad_mask
-
-    def to_qk(self, x: torch.Tensor, dim: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Convert single tensor to query and key tensors.
-
-        Parameters
-        ----------
-        x: torch.Tensor
-            Input tensor of shape [*, L, *]
-        dim: int, optional
-            Dimension along which to unflatten into query/key windows.
-
-        Returns
-        -------
-        tuple[torch.Tensor, torch.Tensor]
-            Query tensor of shape [*, W, Lq, *]
-            Key tensor of shape [*, W, Lk, *]
-        """
-        return self.to_query(x, dim), self.to_key(x, dim)
-
-    def to_query(self, x: torch.Tensor, dim: int) -> torch.Tensor:
-        """Convert single tensor to query tensor.
-
-        Parameters
-        ----------
-        x: torch.Tensor
-            Input tensor of shape [*, L, *]
-        dim: int, optional
-            Dimension along which to unflatten into query/key windows.
-
-        Returns
-        -------
-        torch.Tensor
-            Query tensor of shape [*, W, Lq, *]
-        """
-        return x.unflatten(dim=dim, sizes=(self.W, self.Lq))
-
-    def to_key(self, x: torch.Tensor, dim: int = -2) -> torch.Tensor:
-        """Convert single tensor to key tensor using index gathering.
-
-        Parameters
-        ----------
-        x: torch.Tensor
-            Input tensor of shape [*, L, *]
-        dim: int, optional
-            Dimension along which to unflatten into query/key windows.
-
-        Returns
-        -------
-        torch.Tensor
-            Key tensor of shape [*, W, Lk, *]
-        """
-        # Normalize negative dimension index to a positive integer
-        dim = dim if dim >= 0 else x.ndim + dim
-
-        # 1. Advanced Indexing
-        indexer = [slice(None)] * x.ndim
-        indexer[dim] = self.gather_indices
-        keys = x[tuple(indexer)]
-
-        # 2. Apply Padding Mask
-        mask_shape = [1] * keys.ndim
-        mask_shape[dim] = self.W
-        mask_shape[dim + 1] = self.Lk
-        keys.masked_fill_(self.pad_mask.view(*mask_shape), 0)
-
-        return keys
-
-
+# === Centering and Random Augmentation === #
 def center_random_augmentation(
     coords: torch.Tensor,
     mask: torch.Tensor,

--- a/src/kfold/model/layers/kfold/atom_transformer.py
+++ b/src/kfold/model/layers/kfold/atom_transformer.py
@@ -1,8 +1,10 @@
+from collections.abc import Callable
+
 import torch
 
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.alphafold3.atom_transformer import AtomEmbedder
-from kfold.model.layers.alphafold3.utils import broadcast_tokens_to_atoms, window_to_qk
+from kfold.model.layers.alphafold3.utils import broadcast_tokens_to_atoms
 from kfold.model.layers.primitives import LinearNoBias
 
 
@@ -43,7 +45,7 @@ class AtomEmbedderWithApo(AtomEmbedder):
         self.embed_apo_inv_dist = LinearNoBias(1, channel_atompair, init="default")
         self.embed_apo_mask = LinearNoBias(1, channel_atompair, init="default")
 
-    def embed_atom_pairs(self, f_input: FoldingInput) -> torch.Tensor:
+    def embed_atom_pairs(self, f_input: FoldingInput, to_qk: Callable) -> torch.Tensor:
         """Get atom pair representation from reference molecule conformer and
         apo conformer.
 
@@ -57,11 +59,11 @@ class AtomEmbedderWithApo(AtomEmbedder):
         p : torch.Tensor
             The atom pair representation, shape [B, W, Lq, Lk, c_atompair]
         """
-        p = super().embed_atom_pairs(f_input)  # [B, W, Lq, Lk, c_atompair]
-        p = p + self.apo_embedding(f_input)
+        p = super().embed_atom_pairs(f_input, to_qk)  # [B, W, Lq, Lk, c_atompair]
+        p = p + self.apo_embedding(f_input, to_qk)
         return p
 
-    def apo_embedding(self, f_input: FoldingInput) -> torch.Tensor:
+    def apo_embedding(self, f_input: FoldingInput, to_qk: Callable) -> torch.Tensor:
         """Get apo conformer embedding
 
         Parameters
@@ -75,14 +77,14 @@ class AtomEmbedderWithApo(AtomEmbedder):
             The apo conformer embedding, shape [B, W, Lq, Lk, c_atompair]
         """
         # Mask unresolved apo atoms
-        mask_q, mask_k = window_to_qk(f_input.atom.apo_mask, dim=-1)
+        mask_q, mask_k = to_qk(f_input.atom.apo_mask, dim=-1)
         v = mask_q[..., :, None] & mask_k[..., None, :]
 
         # Mask with chain identity (Apo structure is defined per chain)
         asym_id = broadcast_tokens_to_atoms(
             f_input.token.asym_id.unsqueeze(-1), f_input.atom.token_index
         ).squeeze(-1)  # [B, La]
-        asym_id_q, asym_id_k = window_to_qk(asym_id, dim=-1)
+        asym_id_q, asym_id_k = to_qk(asym_id, dim=-1)
         v &= asym_id_q[..., :, None] == asym_id_k[..., None, :]  # [B, W, Lq, Lk]
 
         # Mask with distance cutoff in sequence (10 neighbor residues)
@@ -92,17 +94,17 @@ class AtomEmbedderWithApo(AtomEmbedder):
         residue_idx = broadcast_tokens_to_atoms(
             f_input.token.residue_index.unsqueeze(-1), f_input.atom.token_index
         ).squeeze(-1)  # [B, La]
-        residx_q, residx_k = window_to_qk(residue_idx, dim=-1)
+        residx_q, residx_k = to_qk(residue_idx, dim=-1)
         v &= abs(residx_q[..., :, None] - residx_k[..., None, :]) <= 5
 
         # Final apo mask
         v = v.float().unsqueeze(-1)  # [B, W, Lq, Lk, 1]
 
+        # Shape: [B, La, 3] -> [B, W, Lq, 3], [B, W, Lk, 3]
+        apo_pos_q, apo_pos_k = to_qk(f_input.atom.apo_coords, dim=-2)
         with torch.autocast(v.device.type, enabled=False):
             # NOTE: (SeonghwanSeo) Since apo structure is much larger than ref_pos,
             # d_inv is adopted instead of d_inv_sq for better representation.
-            # Shape: [B, La, 3] -> [B, W, Lq, 3], [B, W, Lk, 3]
-            apo_pos_q, apo_pos_k = window_to_qk(f_input.atom.apo_coords, dim=-2)
             # Shape: [B, W, Lq, Lk, 3], [B, W, Lq, Lk, 1]
             apo_d_offset = apo_pos_q[..., :, None, :] - apo_pos_k[..., None, :, :]
             apo_d_inv = 1.0 / (1.0 + apo_d_offset.norm(dim=-1, keepdim=True))

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -76,7 +76,7 @@ class BaseFoldingModel(torch.nn.Module):
         f_input: FoldingInput,
         num_recycles: int = 3,
         num_steps: int = 20,
-        num_diffusion_samples: int = 1,
+        num_samples: int = 1,
         diffusion_batch_size: int = 48,
         sample_structures: bool = True,
         train_structure_module: bool = True,
@@ -96,7 +96,7 @@ class BaseFoldingModel(torch.nn.Module):
         num_steps : int
             Number of diffusion steps to sample structures:
             Used for validation and confidence module training.
-        num_diffusion_samples : int
+        num_samples : int
             Number of diffusion samples to sample structures for
             confidence module training.
 
@@ -187,8 +187,7 @@ class BaseFoldingModel(torch.nn.Module):
                 s_trunk=s_trunk.detach(),
                 z_trunk=z_trunk.detach(),
                 num_steps=num_steps,
-                num_diffusion_samples=num_diffusion_samples,
-                max_parallel_samples=None,
+                num_samples=num_samples,
             )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
             dict_out["sample"] = {
                 "coordinates": coordinates,
@@ -225,7 +224,7 @@ class BaseFoldingModel(torch.nn.Module):
         f_input: FoldingInput,
         num_recycles: int = 10,
         num_steps: int = 200,
-        num_diffusion_samples: int = 5,
+        num_samples: int = 5,
         return_traj: bool = False,
     ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
         """Forward pass of KFold model for model training.
@@ -238,7 +237,7 @@ class BaseFoldingModel(torch.nn.Module):
             Number of recycling cycles in trunk.
         num_steps : int
             Number of diffusion steps for training.
-        num_diffusion_samples : int
+        num_samples : int
             Number of diffusion samples for training.
         return_traj : bool, optional
             Whether to return sampling trajectories.
@@ -293,7 +292,7 @@ class BaseFoldingModel(torch.nn.Module):
                 s_trunk,
                 z_trunk,
                 num_steps,
-                num_diffusion_samples,
+                num_samples,
                 return_traj=return_traj,
             )
         )

--- a/src/kfold/model/models/base.py
+++ b/src/kfold/model/models/base.py
@@ -20,9 +20,6 @@ class KernelConfig:
 @dataclasses.dataclass(kw_only=True)
 class BaseFoldingModelConfig:
     _class_: str = "BaseFoldingModel"
-    compile_trunk: bool = False
-    compile_score_model: bool = False
-    compile_mode: str = "default"
     kernel: KernelConfig
     input_embedder: BaseConfig
     trunk: BaseConfig
@@ -66,19 +63,13 @@ class BaseFoldingModel(torch.nn.Module):
         #     Registry.instantiate(config.confidence_head)
         # )
 
-        # Compile submodules
-        compile_trunk = getattr(config, "compile_trunk", False)
-        compile_score_model = getattr(config, "compile_score_model", False)
-        compile_mode = getattr(config, "compile_mode", "default")
-        self.trunk.compile(compile_trunk, compile_mode)
-        self.score_model.compile(compile_score_model, compile_mode)
-
-    def cast_to_bf16(self) -> Self:
-        """Cast model parameters to bfloat16 for faster inference."""
-        self.input_embedder = self.input_embedder.to(torch.bfloat16)
-        self.trunk = self.trunk.to(torch.bfloat16)
-        self.distogram_head = self.distogram_head.to(torch.bfloat16)
-        return self
+    def do_compile(self, mode: str = "default", dynamic: bool = False):
+        """Compile the trunk and score model."""
+        kwargs = {"mode": mode, "dynamic": dynamic}
+        self.trunk.do_compile(**kwargs)
+        self.score_model.do_compile(**kwargs)
+        # self.input_embedder = torch.compile(self.input_embedder, *kwargs)
+        # self.distogram_head = torch.compile(self.distogram_head, *kwargs)
 
     def forward(
         self,
@@ -190,16 +181,15 @@ class BaseFoldingModel(torch.nn.Module):
             # diffusion module training. Instead, we construct cache inside
             # sample_structure method if necessary.
             self.score_model.eval()
-            with torch.no_grad(), torch.autocast("cuda", dtype=torch.float32):
-                coordinates = self.structure_module.sample_structure(
-                    f_input=f_input,
-                    s_inputs=s_inputs.detach(),
-                    s_trunk=s_trunk.detach(),
-                    z_trunk=z_trunk.detach(),
-                    num_steps=num_steps,
-                    num_diffusion_samples=num_diffusion_samples,
-                    max_parallel_samples=None,
-                )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
+            coordinates = self.structure_module.sample_structure(
+                f_input=f_input,
+                s_inputs=s_inputs.detach(),
+                s_trunk=s_trunk.detach(),
+                z_trunk=z_trunk.detach(),
+                num_steps=num_steps,
+                num_diffusion_samples=num_diffusion_samples,
+                max_parallel_samples=None,
+            )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
             dict_out["sample"] = {
                 "coordinates": coordinates,
             }
@@ -213,14 +203,13 @@ class BaseFoldingModel(torch.nn.Module):
         if train_structure_module:
             # Diffusion head
             self.score_model.train()
-            with torch.autocast("cuda", dtype=torch.float32):
-                dict_out["diffusion"] = self.structure_module.training_step(
-                    f_input,
-                    s_inputs,
-                    s_trunk,
-                    z_trunk,
-                    diffusion_batch_size,
-                )
+            dict_out["diffusion"] = self.structure_module.training_step(
+                f_input,
+                s_inputs,
+                s_trunk,
+                z_trunk,
+                diffusion_batch_size,
+            )
 
         if train_confidence_module:
             # TODO: implement confidence prediction with mini-rollout
@@ -297,18 +286,17 @@ class BaseFoldingModel(torch.nn.Module):
         # Diffusion head
         # pred_atom_coords: [B, Nsample, La, 3]
         st = time.time()
-        with torch.autocast("cuda", dtype=torch.float32):
-            dict_out.update(
-                self.structure_module.sample_structure(
-                    f_input,
-                    s_inputs,
-                    s_trunk,
-                    z_trunk,
-                    num_steps,
-                    num_diffusion_samples,
-                    return_traj=return_traj,
-                )
+        dict_out.update(
+            self.structure_module.sample_structure(
+                f_input,
+                s_inputs,
+                s_trunk,
+                z_trunk,
+                num_steps,
+                num_diffusion_samples,
+                return_traj=return_traj,
             )
+        )
         et = time.time()
         time_logs["diffusion_head"] = et - st
 

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -97,7 +97,7 @@ class KFold(BaseFoldingModel):
         f_input: FoldingInput,
         num_recycles: int = 3,
         num_steps: int = 20,
-        num_diffusion_samples: int = 1,
+        num_samples: int = 1,
         diffusion_batch_size: int = 48,
         sample_structures: bool = True,
         train_structure_module: bool = True,
@@ -117,7 +117,7 @@ class KFold(BaseFoldingModel):
         num_steps : int
             Number of diffusion steps to sample structures:
             Used for validation and confidence module training.
-        num_diffusion_samples : int
+        num_samples : int
             Number of diffusion samples to sample structures for
             confidence module training.
 
@@ -211,8 +211,7 @@ class KFold(BaseFoldingModel):
                 s_trunk=s_trunk.detach(),
                 z_trunk=z_trunk.detach(),
                 num_steps=num_steps,
-                num_diffusion_samples=num_diffusion_samples,
-                max_parallel_samples=None,
+                num_samples=num_samples,
             )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
             sample_dict = {"coordinates": coordinates}
             dict_out["sample"] = sample_dict
@@ -253,7 +252,7 @@ class KFold(BaseFoldingModel):
         f_input: FoldingInput,
         num_recycles: int = 10,
         num_steps: int = 200,
-        num_diffusion_samples: int = 5,
+        num_samples: int = 5,
         return_traj: bool = False,
     ) -> tuple[dict[str, torch.Tensor], dict[str, float]]:
         """Forward pass of KFold model for model training.
@@ -266,7 +265,7 @@ class KFold(BaseFoldingModel):
             Number of recycling cycles in trunk.
         num_steps : int
             Number of diffusion steps for training.
-        num_diffusion_samples : int
+        num_samples : int
             Number of diffusion samples for training.
         return_traj : bool, optional
             Whether to return sampling trajectories.
@@ -340,7 +339,7 @@ class KFold(BaseFoldingModel):
                 s_trunk,
                 z_trunk,
                 num_steps,
-                num_diffusion_samples,
+                num_samples,
                 return_traj=return_traj,
             )
         )

--- a/src/kfold/model/models/kfold.py
+++ b/src/kfold/model/models/kfold.py
@@ -1,6 +1,5 @@
 import time
 from collections.abc import Mapping
-from typing import Self
 
 import torch
 
@@ -27,13 +26,6 @@ class KFold(BaseFoldingModel):
         self.structure_encoder: submodules.structure_encoder.BaseStructureEncoder = (
             Registry.instantiate(config.structure_encoder)
         )
-
-    def cast_to_bf16(self) -> Self:
-        """Cast model parameters to bfloat16 for faster inference."""
-        super().cast_to_bf16()
-        self.sequence_encoder = self.sequence_encoder.cast_to_bf16()
-        self.structure_encoder = self.structure_encoder.cast_to_bf16()
-        return self
 
     def inference(
         self,
@@ -213,16 +205,15 @@ class KFold(BaseFoldingModel):
             # diffusion module training. Instead, we construct cache inside
             # sample_structure method if necessary.
             self.score_model.eval()
-            with torch.no_grad(), torch.autocast("cuda", dtype=torch.float32):
-                coordinates = self.structure_module.sample_structure(
-                    f_input=f_input,
-                    s_inputs=s_inputs.detach(),
-                    s_trunk=s_trunk.detach(),
-                    z_trunk=z_trunk.detach(),
-                    num_steps=num_steps,
-                    num_diffusion_samples=num_diffusion_samples,
-                    max_parallel_samples=None,
-                )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
+            coordinates = self.structure_module.sample_structure(
+                f_input=f_input,
+                s_inputs=s_inputs.detach(),
+                s_trunk=s_trunk.detach(),
+                z_trunk=z_trunk.detach(),
+                num_steps=num_steps,
+                num_diffusion_samples=num_diffusion_samples,
+                max_parallel_samples=None,
+            )["sample_coordinates"]  # [B, N_samples, Ltoken, 3]
             sample_dict = {"coordinates": coordinates}
             dict_out["sample"] = sample_dict
 
@@ -239,14 +230,13 @@ class KFold(BaseFoldingModel):
         if train_structure_module:
             # Diffusion head
             self.score_model.train()
-            with torch.autocast("cuda", dtype=torch.float32):
-                diffusion_dict = self.structure_module.training_step(
-                    f_input,
-                    s_inputs,
-                    s_trunk,
-                    z_trunk,
-                    diffusion_batch_size,
-                )
+            diffusion_dict = self.structure_module.training_step(
+                f_input,
+                s_inputs,
+                s_trunk,
+                z_trunk,
+                diffusion_batch_size,
+            )
             dict_out["diffusion"] = diffusion_dict
 
         if train_confidence_module:
@@ -343,18 +333,17 @@ class KFold(BaseFoldingModel):
         # Diffusion head
         # pred_atom_coords: [B, Nsample, La, 3]
         st = time.time()
-        with torch.autocast("cuda", dtype=torch.float32):
-            dict_out.update(
-                self.structure_module.sample_structure(
-                    f_input,
-                    s_inputs,
-                    s_trunk,
-                    z_trunk,
-                    num_steps,
-                    num_diffusion_samples,
-                    return_traj=return_traj,
-                )
+        dict_out.update(
+            self.structure_module.sample_structure(
+                f_input,
+                s_inputs,
+                s_trunk,
+                z_trunk,
+                num_steps,
+                num_diffusion_samples,
+                return_traj=return_traj,
             )
+        )
         et = time.time()
         time_logs["diffusion_head"] = et - st
 

--- a/src/kfold/model/modules/input_embedder/kfold_embedder.py
+++ b/src/kfold/model/modules/input_embedder/kfold_embedder.py
@@ -215,7 +215,7 @@ class KFoldInputEmbedder(BaseInputEmbedder):
         pair_mask = pair_mask & chain_mask
 
         # Pair representation: pairwise distance RBF
-        with torch.autocast("cuda", enabled=False), torch.no_grad():
+        with torch.autocast(apo_coords.device.type, enabled=False), torch.no_grad():
             diff = apo_coords[..., :, None, :] - apo_coords[..., None, :, :]
             pdist = torch.norm(diff, dim=-1)  # [B, L, L]
             pdist_map = self.distmap(pdist)  # [B, L, L, num_bin]

--- a/src/kfold/model/modules/score_model/af3_diffusion.py
+++ b/src/kfold/model/modules/score_model/af3_diffusion.py
@@ -71,14 +71,9 @@ class AF3DiffusionModule(BaseScoreModel):
             blocks_per_ckpt=cfg.blocks_per_ckpt,
         )
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
-        self.diffusion_stack = torch.compile(
-            self.diffusion_stack,
-            mode="default",  # reduce-overhead mode has issues on DDP.
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+        self.diffusion_stack = torch.compile(self.diffusion_stack, **kwargs)
 
     @property
     def _diffusion_stack(self) -> DiffusionModule:

--- a/src/kfold/model/modules/score_model/base.py
+++ b/src/kfold/model/modules/score_model/base.py
@@ -18,13 +18,12 @@ class BaseScoreModel(torch.nn.Module, ABC):
         self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
-    def compile(self, compile: bool = True, mode: str = "default"):
+    def do_compile(self, **kwargs):
         """Compile the score model module."""
-        if compile:
-            self.do_compile(mode)
-            self.is_compiled = True
+        self._compile(**kwargs)
+        self.is_compiled = True
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the

--- a/src/kfold/model/modules/sequence_encoder/base.py
+++ b/src/kfold/model/modules/sequence_encoder/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Self
 
 import torch
 
@@ -39,7 +38,3 @@ class BaseSequenceEncoder(torch.nn.Module, ABC):
             Tensor of shape (B, Ntoken, Ntoken, N*H) containing attention weights,
             where N is number of layers and H is number of heads.
         """
-
-    def cast_to_bf16(self) -> Self:
-        """Cast model parameters to bfloat16 for faster inference."""
-        return self.to(dtype=torch.bfloat16)

--- a/src/kfold/model/modules/structure_encoder/base.py
+++ b/src/kfold/model/modules/structure_encoder/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Self
 
 import torch
 
@@ -39,7 +38,3 @@ class BaseStructureEncoder(torch.nn.Module, ABC):
             Tensor of shape (B, Ntoken, Ntoken, N*H) containing attention weights,
             where N is number of layers and H is number of heads.
         """
-
-    def cast_to_bf16(self) -> Self:
-        """Cast model parameters to bfloat16 for faster inference."""
-        return self.to(dtype=torch.bfloat16)

--- a/src/kfold/model/modules/structure_encoder/unitok.py
+++ b/src/kfold/model/modules/structure_encoder/unitok.py
@@ -1,5 +1,3 @@
-from typing import Self
-
 import torch
 
 from kfold.data.types.model_input import FoldingInput
@@ -67,11 +65,6 @@ class UniTok(BaseStructureEncoder):
             return 0
         else:
             return self.cfg.n_heads * self.cfg.n_layers
-
-    def cast_to_bf16(self) -> Self:
-        """Cast model parameters to bfloat16 for faster inference."""
-        self.backbone = self.backbone.to(torch.bfloat16)
-        return self
 
     def tokenize(
         self, aatypes: torch.Tensor, coords: torch.Tensor

--- a/src/kfold/model/modules/structure_module/af3_edm.py
+++ b/src/kfold/model/modules/structure_module/af3_edm.py
@@ -44,9 +44,6 @@ class AF3SampleDiffusion(BaseEDM):
             The noise scale, by default 1.003.
         step_scale : float, optional
             The step scale, by default 1.5.
-        coordinate_augmentation : bool, optional
-            Whether to use coordinate augmentation, by default True.
-            This may be useful for non-equivariant score models.
         """
 
         sigma_min: float = 0.0004
@@ -59,7 +56,6 @@ class AF3SampleDiffusion(BaseEDM):
         gamma_min: float = 1.0
         noise_scale: float = 1.003
         step_scale: float = 1.5
-        coordinate_augmentation: bool = True
 
     def __init__(self, cfg: Config, score_model: AF3DiffusionModule):
         """Initialize the atom diffusion module."""
@@ -75,13 +71,7 @@ class AF3SampleDiffusion(BaseEDM):
         self.gamma_min: float = cfg.gamma_min
         self.noise_scale: float = cfg.noise_scale
         self.step_scale: float = cfg.step_scale
-        self.coordinate_augmentation: bool = cfg.coordinate_augmentation
-
-        self.random_augmentation = CenterRandomAugmentation(
-            centering=True,
-            augmentation=self.coordinate_augmentation,
-            s_trans=1.0,  # not used when augmentation is False
-        )
+        self.random_augmentation = CenterRandomAugmentation(s_trans=1.0)
 
     # === EDM diffusion coefficients === #
     def c_skip(self, sigma: _ScalarOrTensor) -> _ScalarOrTensor:

--- a/src/kfold/model/modules/structure_module/af3_edm.py
+++ b/src/kfold/model/modules/structure_module/af3_edm.py
@@ -116,7 +116,7 @@ class AF3SampleDiffusion(BaseEDM):
         B = f_input.batch_size
         N = num_samples
         La = f_input.num_atoms
-        return torch.randn((B, N, La, 3), device=f_input.device)
+        return torch.randn((B, N, La, 3), device=f_input.device, dtype=torch.float32)
 
     # === For model training === #
     def forward_train(
@@ -224,7 +224,8 @@ class AF3SampleDiffusion(BaseEDM):
         mask : torch.Tensor
             The atom mask. Shape (B, La).
         """
-        return x_0 + t_hat[:, :, None, None] * x_T  # (B, N, La, 3)
+        with torch.autocast(device_type="cuda", enabled=False):
+            return x_0 + t_hat[:, :, None, None] * x_T  # (B, N, La, 3)
 
     # === For sampling === #
     def sample_structure(
@@ -305,6 +306,7 @@ class AF3SampleDiffusion(BaseEDM):
 
             # Line 11
             x = x_noisy + self.step_scale * dt * delta
+            x.masked_fill_(~mask[:, :, :, None], 0.0)  # apply atom mask
 
         sample_out: dict[str, torch.Tensor] = {
             "sample_coordinates": x,

--- a/src/kfold/model/modules/structure_module/base.py
+++ b/src/kfold/model/modules/structure_module/base.py
@@ -271,9 +271,11 @@ class BaseEDM(BaseStructureModule):
 
         # sample xt via interpolation
         x_t = self.interpolate(x_prior, x_gt, t_hat, mask)
+        # NOTE: here we use masked_fill_ to avoid bf16 casting.
+        x_t.masked_fill_(~mask[:, None, :, None], 0.0)
 
         x_0_hat = self.forward_train(
-            x_t=x_t,  # [B, N, La, 3]
+            x_t=x_t.float(),  # [B, N, La, 3]
             t_hat=t_hat,  # [B, N]
             f_input=f_input,
             s_inputs=s_inputs,  # [B, Lt, c_s]

--- a/src/kfold/model/modules/trunk/af3_trunk.py
+++ b/src/kfold/model/modules/trunk/af3_trunk.py
@@ -78,18 +78,13 @@ class AF3PairformerTrunk(BaseTrunk):
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
-        self.pairformer_module = torch.compile(
-            self.pairformer_module,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+        self.pairformer_module = torch.compile(self.pairformer_module, **kwargs)
 
     def forward(
         self,

--- a/src/kfold/model/modules/trunk/base.py
+++ b/src/kfold/model/modules/trunk/base.py
@@ -21,13 +21,12 @@ class BaseTrunk(torch.nn.Module, ABC):
         self.kernel_config = kernel_config
         self.is_compiled: bool = False
 
-    def compile(self, compile: bool = True, mode: str = "default"):
+    def do_compile(self, **kwargs):
         """Compile the trunk module."""
-        if compile:
-            self.do_compile(mode)
-            self.is_compiled = True
+        self._compile(**kwargs)
+        self.is_compiled = True
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the

--- a/src/kfold/model/modules/trunk/kfold_prime.py
+++ b/src/kfold/model/modules/trunk/kfold_prime.py
@@ -175,36 +175,20 @@ class KFoldTrunkPrime(BaseTrunk):
         else:
             self.register_tokens = None
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
-        self.plm_module_prime = torch.compile(
-            self.plm_module_prime,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+        self.plm_module_prime = torch.compile(self.plm_module_prime, **kwargs)
         self.pairformer_module_prime = torch.compile(
-            self.pairformer_module_prime,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
-        self.plm_module_refine = torch.compile(
-            self.plm_module_refine,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+            self.pairformer_module_prime, **kwargs
+        )
+        self.plm_module_refine = torch.compile(self.plm_module_refine, **kwargs)
         self.pairformer_module_refine = torch.compile(
-            self.pairformer_module_refine,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+            self.pairformer_module_refine, **kwargs
+        )
 
     def forward(
         self,

--- a/src/kfold/model/modules/trunk/kfold_trunk.py
+++ b/src/kfold/model/modules/trunk/kfold_trunk.py
@@ -163,24 +163,14 @@ class KFoldTrunk(BaseTrunk):
         else:
             self.register_tokens = None
 
-    def do_compile(self, mode: str = "default"):
+    def _compile(self, **kwargs):
         """Compile the trunk module."""
         # NOTE: you should compile the submodules inside the trunk
         # since the computation graph is changed depending on the
         # number of recycling steps. Thus, compile the sub module
         # instead of the whole trunk module.
-        self.plm_module = torch.compile(
-            self.plm_module,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
-        self.pairformer_module = torch.compile(
-            self.pairformer_module,
-            mode=mode,
-            dynamic=False,
-            fullgraph=False,
-        )  # type: ignore
+        self.plm_module = torch.compile(self.plm_module, **kwargs)
+        self.pairformer_module = torch.compile(self.pairformer_module, **kwargs)
 
     def forward(
         self,

--- a/src/kfold/training/loss/diffusion.py
+++ b/src/kfold/training/loss/diffusion.py
@@ -5,6 +5,7 @@ import torch
 from kfold.data.types.model_input import FoldingInput
 from kfold.utils.checkpointing import checkpoint_section
 from kfold.utils.geometry.rigid_align import weighted_rigid_align
+from kfold.utils.kernels.cdist import cdist as kernel_cdist
 
 
 def safe_cdist(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
@@ -253,6 +254,7 @@ class SmoothLDDTLoss(torch.nn.Module):
         cutoff_nucleic_acid: float = 30.0,
         repr_atom_only: bool = False,
         chunk_size: int | None = 1,
+        use_kernel: bool = False,
     ):
         """Initialize SmoothLDDTLoss.
 
@@ -269,6 +271,10 @@ class SmoothLDDTLoss(torch.nn.Module):
             - For proteins: Cb atoms
             - For nucleic acids: C4' atoms
             - For ligands: all atoms
+        chunk_size: int | None
+            The chunk size for computing LDDT loss.
+        use_kernel: bool
+            Whether to use triton implementation for pairwise distance calculation.
         """
 
         super().__init__()
@@ -276,6 +282,7 @@ class SmoothLDDTLoss(torch.nn.Module):
         self.cutoff_nucleic_acid: float = cutoff_nucleic_acid
         self.repr_atom_only: bool = repr_atom_only
         self.chunk_size: int | None = chunk_size
+        self.use_kernel: bool = use_kernel
 
     def forward(
         self,
@@ -339,6 +346,7 @@ class SmoothLDDTLoss(torch.nn.Module):
         mask: torch.Tensor,
         is_nucleotide: torch.Tensor,
         repr_atom_index: torch.Tensor,
+        use_kernel: bool = False,
     ) -> list[torch.Tensor]:
         N, L, _ = x_pred.shape
         # NOTE: pairwise distances of ground truth coordinates are shared across N.
@@ -349,13 +357,15 @@ class SmoothLDDTLoss(torch.nn.Module):
         # Mask out self-term
         pair_mask.diagonal(dim1=-2, dim2=-1).zero_()
 
+        _cdist = kernel_cdist if self.use_kernel else safe_cdist
+
         if self.repr_atom_only:
             # Extract representative atom indices
-            d_true = safe_cdist(x_true[repr_atom_index], x_true)  # [Lrepr, L]
+            d_true = _cdist(x_true[repr_atom_index], x_true)  # [Lrepr, L]
             pair_mask = pair_mask[repr_atom_index]  # [L, L] -> [Lrepr, L]
             is_nucleotide = is_nucleotide[repr_atom_index]  # [L] -> [Lrepr]
         else:
-            d_true = safe_cdist(x_true, x_true)  # [L, L]
+            d_true = _cdist(x_true, x_true)  # [L, L]
 
         # Mask out invalid distances
         pair_mask &= ((d_true < self.cutoff_nucleic_acid) & is_nucleotide[..., None]) | (
@@ -367,6 +377,7 @@ class SmoothLDDTLoss(torch.nn.Module):
             d_true=d_true,  # [L, L] or [Lrepr, L]
             pair_mask=pair_mask.float(),  # [L, L] or [Lrepr, L]
             repr_atom_index=repr_atom_index if self.repr_atom_only else None,
+            use_kernel=self.use_kernel,
         )
 
         losses = []
@@ -388,15 +399,18 @@ class SmoothLDDTLoss(torch.nn.Module):
         d_true: torch.Tensor,
         pair_mask: torch.Tensor,
         repr_atom_index: torch.Tensor | None = None,
+        use_kernel: bool = False,
     ) -> torch.Tensor:
+        _cdist = kernel_cdist if use_kernel else safe_cdist
+
         # Line 1
         if repr_atom_index is not None:
             # Compute predicted distances between representative atoms and all atoms
             x_pred_repr = x_pred[:, repr_atom_index]  # [N, Lrepr, 3]
-            d_pred = safe_cdist(x_pred_repr, x_pred)  # [N, Lrepr, L]
+            d_pred = _cdist(x_pred_repr, x_pred)  # [N, Lrepr, L]
         else:
             # Compute predicted pairwise distances (original AF3)
-            d_pred = safe_cdist(x_pred, x_pred)  # [N, L, L]
+            d_pred = _cdist(x_pred, x_pred)  # [N, L, L]
 
         # Line 2 (outside function): compute true pairwise distances
 

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -46,6 +46,7 @@ class TrainConfig:
     name: str
     out_dir: str
     seed: int
+    compile: "CompileConfig"
     training: "TrainingConfig"
     validation: "ValidationConfig"
     optimizer: "OptimizerConfig"
@@ -133,6 +134,13 @@ class LossConfig(_Config):
     confidence_loss: Any
 
 
+@dataclasses.dataclass(kw_only=True)
+class CompileConfig(_Config):
+    enabled: bool = False
+    mode: str = "default"
+    dynamic: bool = False
+
+
 class KFoldTrainingModule(pl.LightningModule):
     def __init__(self, config: DictConfig):
         super().__init__()
@@ -148,6 +156,7 @@ class KFoldTrainingModule(pl.LightningModule):
             self.config.optimizer
         )
         self.loss_config: LossConfig = LossConfig.from_dict(self.config.loss)
+        self.compile_config: CompileConfig = CompileConfig.from_dict(self.config.compile)
 
         # Save hyperparameters
         self.save_hyperparameters(to_dict(self.global_config))
@@ -165,6 +174,12 @@ class KFoldTrainingModule(pl.LightningModule):
         model_config: KFoldConfig = self.global_config.model
         model_cls = MAIN_MODULE[model_config._class_]
         self.model: KFold = model_cls(model_config)
+
+        # Compile
+        if self.compile_config.enabled:
+            self.model.do_compile(
+                mode=self.compile_config.mode, dynamic=self.compile_config.dynamic
+            )
 
         # Freeze parts of the model if needed
         self.freeze_submodules()

--- a/src/kfold/utils/kernels/cdist.py
+++ b/src/kfold/utils/kernels/cdist.py
@@ -1,0 +1,328 @@
+import torch
+import triton
+import triton.language as tl
+
+
+def cdist(x: torch.Tensor, y: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Compute pairwise distances safely using Triton."""
+    assert x.shape[:-2] == y.shape[:-2], "Batch dimensions must match"
+    return CdistTriton.apply(x, y, eps)
+
+
+# ---------------------------------------------------------------------------
+# 1. Triton Forward Kernel
+# ---------------------------------------------------------------------------
+@triton.jit
+def _cdist_fwd_kernel(
+    x_ptr,
+    y_ptr,
+    dist_ptr,
+    stride_xb,
+    stride_xm,
+    stride_xd,
+    stride_yb,
+    stride_yn,
+    stride_yd,
+    stride_db,
+    stride_dm,
+    stride_dn,
+    M,
+    N,
+    eps,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b_idx = tl.program_id(0)
+    m_idx = tl.program_id(1)
+    n_idx = tl.program_id(2)
+
+    offs_m = m_idx * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = n_idx * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+
+    # Calculate base pointers for the current batch
+    x_base = x_ptr + b_idx * stride_xb
+    y_base = y_ptr + b_idx * stride_yb
+    dist_base = dist_ptr + b_idx * stride_db
+
+    # Load coordinates for x (shape: [BLOCK_M])
+    x_x = tl.load(x_base + offs_m * stride_xm + 0 * stride_xd, mask=mask_m, other=0.0)
+    x_y = tl.load(x_base + offs_m * stride_xm + 1 * stride_xd, mask=mask_m, other=0.0)
+    x_z = tl.load(x_base + offs_m * stride_xm + 2 * stride_xd, mask=mask_m, other=0.0)
+
+    # Load coordinates for y (shape: [BLOCK_N])
+    y_x = tl.load(y_base + offs_n * stride_yn + 0 * stride_yd, mask=mask_n, other=0.0)
+    y_y = tl.load(y_base + offs_n * stride_yn + 1 * stride_yd, mask=mask_n, other=0.0)
+    y_z = tl.load(y_base + offs_n * stride_yn + 2 * stride_yd, mask=mask_n, other=0.0)
+
+    # Compute differences via broadcasting in SRAM
+    dx = x_x[:, None] - y_x[None, :]
+    dy = x_y[:, None] - y_y[None, :]
+    dz = x_z[:, None] - y_z[None, :]
+
+    # Calculate safe distance
+    sq_dist = dx * dx + dy * dy + dz * dz
+    dist = tl.sqrt(sq_dist + eps)
+
+    # Store results to HBM
+    offs_d = offs_m[:, None] * stride_dm + offs_n[None, :] * stride_dn
+    mask_d = mask_m[:, None] & mask_n[None, :]
+    tl.store(dist_base + offs_d, dist, mask=mask_d)
+
+
+# ---------------------------------------------------------------------------
+# 2. Triton Backward Kernels (X and Y separately to avoid atomic operations)
+# ---------------------------------------------------------------------------
+@triton.jit
+def _cdist_bwd_x_kernel(
+    x_ptr,
+    y_ptr,
+    dist_ptr,
+    grad_out_ptr,
+    grad_x_ptr,
+    stride_xb,
+    stride_xm,
+    stride_xd,
+    stride_yb,
+    stride_yn,
+    stride_yd,
+    stride_db,
+    stride_dm,
+    stride_dn,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b_idx = tl.program_id(0)
+    m_idx = tl.program_id(1)
+
+    offs_m = m_idx * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask_m = offs_m < M
+
+    x_base = x_ptr + b_idx * stride_xb
+    y_base = y_ptr + b_idx * stride_yb
+    dist_base = dist_ptr + b_idx * stride_db
+    grad_out_base = grad_out_ptr + b_idx * stride_db
+    grad_x_base = grad_x_ptr + b_idx * stride_xb
+
+    x_x = tl.load(x_base + offs_m * stride_xm + 0 * stride_xd, mask=mask_m, other=0.0)
+    x_y = tl.load(x_base + offs_m * stride_xm + 1 * stride_xd, mask=mask_m, other=0.0)
+    x_z = tl.load(x_base + offs_m * stride_xm + 2 * stride_xd, mask=mask_m, other=0.0)
+
+    grad_xx_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    grad_xy_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+    grad_xz_acc = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    for n in range(0, N, BLOCK_N):
+        offs_n = n + tl.arange(0, BLOCK_N)
+        mask_n = offs_n < N
+
+        y_x = tl.load(y_base + offs_n * stride_yn + 0 * stride_yd, mask=mask_n, other=0.0)
+        y_y = tl.load(y_base + offs_n * stride_yn + 1 * stride_yd, mask=mask_n, other=0.0)
+        y_z = tl.load(y_base + offs_n * stride_yn + 2 * stride_yd, mask=mask_n, other=0.0)
+
+        offs_d = offs_m[:, None] * stride_dm + offs_n[None, :] * stride_dn
+        mask_d = mask_m[:, None] & mask_n[None, :]
+
+        # other=1.0 avoids division by zero for out-of-bounds elements
+        dist = tl.load(dist_base + offs_d, mask=mask_d, other=1.0)
+        grad_out = tl.load(grad_out_base + offs_d, mask=mask_d, other=0.0)
+
+        dx = x_x[:, None] - y_x[None, :]
+        dy = x_y[:, None] - y_y[None, :]
+        dz = x_z[:, None] - y_z[None, :]
+
+        grad_factor = grad_out / dist
+        grad_xx_acc += tl.sum(grad_factor * dx, axis=1)
+        grad_xy_acc += tl.sum(grad_factor * dy, axis=1)
+        grad_xz_acc += tl.sum(grad_factor * dz, axis=1)
+
+    tl.store(grad_x_base + offs_m * stride_xm + 0 * stride_xd, grad_xx_acc, mask=mask_m)
+    tl.store(grad_x_base + offs_m * stride_xm + 1 * stride_xd, grad_xy_acc, mask=mask_m)
+    tl.store(grad_x_base + offs_m * stride_xm + 2 * stride_xd, grad_xz_acc, mask=mask_m)
+
+
+@triton.jit
+def _cdist_bwd_y_kernel(
+    x_ptr,
+    y_ptr,
+    dist_ptr,
+    grad_out_ptr,
+    grad_y_ptr,
+    stride_xb,
+    stride_xm,
+    stride_xd,
+    stride_yb,
+    stride_yn,
+    stride_yd,
+    stride_db,
+    stride_dm,
+    stride_dn,
+    M,
+    N,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    b_idx = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    offs_n = n_idx * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+
+    x_base = x_ptr + b_idx * stride_xb
+    y_base = y_ptr + b_idx * stride_yb
+    dist_base = dist_ptr + b_idx * stride_db
+    grad_out_base = grad_out_ptr + b_idx * stride_db
+    grad_y_base = grad_y_ptr + b_idx * stride_yb
+
+    y_x = tl.load(y_base + offs_n * stride_yn + 0 * stride_yd, mask=mask_n, other=0.0)
+    y_y = tl.load(y_base + offs_n * stride_yn + 1 * stride_yd, mask=mask_n, other=0.0)
+    y_z = tl.load(y_base + offs_n * stride_yn + 2 * stride_yd, mask=mask_n, other=0.0)
+
+    grad_yx_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+    grad_yy_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+    grad_yz_acc = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+    for m in range(0, M, BLOCK_M):
+        offs_m = m + tl.arange(0, BLOCK_M)
+        mask_m = offs_m < M
+
+        x_x = tl.load(x_base + offs_m * stride_xm + 0 * stride_xd, mask=mask_m, other=0.0)
+        x_y = tl.load(x_base + offs_m * stride_xm + 1 * stride_xd, mask=mask_m, other=0.0)
+        x_z = tl.load(x_base + offs_m * stride_xm + 2 * stride_xd, mask=mask_m, other=0.0)
+
+        offs_d = offs_m[:, None] * stride_dm + offs_n[None, :] * stride_dn
+        mask_d = mask_m[:, None] & mask_n[None, :]
+
+        dist = tl.load(dist_base + offs_d, mask=mask_d, other=1.0)
+        grad_out = tl.load(grad_out_base + offs_d, mask=mask_d, other=0.0)
+
+        # Derivative for y is (y - x) / dist
+        dx = y_x[None, :] - x_x[:, None]
+        dy = y_y[None, :] - x_y[:, None]
+        dz = y_z[None, :] - x_z[:, None]
+
+        grad_factor = grad_out / dist
+        grad_yx_acc += tl.sum(grad_factor * dx, axis=0)
+        grad_yy_acc += tl.sum(grad_factor * dy, axis=0)
+        grad_yz_acc += tl.sum(grad_factor * dz, axis=0)
+
+    tl.store(grad_y_base + offs_n * stride_yn + 0 * stride_yd, grad_yx_acc, mask=mask_n)
+    tl.store(grad_y_base + offs_n * stride_yn + 1 * stride_yd, grad_yy_acc, mask=mask_n)
+    tl.store(grad_y_base + offs_n * stride_yn + 2 * stride_yd, grad_yz_acc, mask=mask_n)
+
+
+# ---------------------------------------------------------------------------
+# 3. PyTorch Autograd Wrapper
+# ---------------------------------------------------------------------------
+class CdistTriton(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, y, eps=1e-8):
+        x = x.contiguous()
+        y = y.contiguous()
+
+        x_shape = x.shape
+        y_shape = y.shape
+        batch_shape = x_shape[:-2]
+
+        # Flatten any batch dimensions to 3D: [B, M/N, 3]
+        x_flat = x.view(-1, x_shape[-2], 3)
+        y_flat = y.view(-1, y_shape[-2], 3)
+
+        B, M, _ = x_flat.shape
+        _, N, _ = y_flat.shape
+
+        dist_flat = torch.empty((B, M, N), device=x.device, dtype=x.dtype)
+
+        grid = lambda meta: (  # noqa
+            B,
+            triton.cdiv(M, meta["BLOCK_M"]),
+            triton.cdiv(N, meta["BLOCK_N"]),
+        )
+
+        _cdist_fwd_kernel[grid](
+            x_flat,
+            y_flat,
+            dist_flat,
+            x_flat.stride(0),
+            x_flat.stride(1),
+            x_flat.stride(2),
+            y_flat.stride(0),
+            y_flat.stride(1),
+            y_flat.stride(2),
+            dist_flat.stride(0),
+            dist_flat.stride(1),
+            dist_flat.stride(2),
+            M,
+            N,
+            eps,
+            BLOCK_M=64,
+            BLOCK_N=64,
+        )
+
+        ctx.save_for_backward(x_flat, y_flat, dist_flat)
+        ctx.x_shape = x_shape
+        ctx.y_shape = y_shape
+
+        out_shape = batch_shape + (x_shape[-2], y_shape[-2])
+        return dist_flat.view(out_shape)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x_flat, y_flat, dist_flat = ctx.saved_tensors
+        grad_out = grad_out.contiguous().view_as(dist_flat)
+
+        B, M, _ = x_flat.shape
+        _, N, _ = y_flat.shape
+
+        grad_x = torch.empty_like(x_flat)
+        grad_y = torch.empty_like(y_flat)
+
+        grid_x = lambda meta: (B, triton.cdiv(M, meta["BLOCK_M"]))  # noqa
+        _cdist_bwd_x_kernel[grid_x](
+            x_flat,
+            y_flat,
+            dist_flat,
+            grad_out,
+            grad_x,
+            x_flat.stride(0),
+            x_flat.stride(1),
+            x_flat.stride(2),
+            y_flat.stride(0),
+            y_flat.stride(1),
+            y_flat.stride(2),
+            dist_flat.stride(0),
+            dist_flat.stride(1),
+            dist_flat.stride(2),
+            M,
+            N,
+            BLOCK_M=64,
+            BLOCK_N=64,
+        )
+
+        grid_y = lambda meta: (B, triton.cdiv(N, meta["BLOCK_N"]))  # noqa
+        _cdist_bwd_y_kernel[grid_y](
+            x_flat,
+            y_flat,
+            dist_flat,
+            grad_out,
+            grad_y,
+            x_flat.stride(0),
+            x_flat.stride(1),
+            x_flat.stride(2),
+            y_flat.stride(0),
+            y_flat.stride(1),
+            y_flat.stride(2),
+            dist_flat.stride(0),
+            dist_flat.stride(1),
+            dist_flat.stride(2),
+            M,
+            N,
+            BLOCK_M=64,
+            BLOCK_N=64,
+        )
+
+        return grad_x.view(ctx.x_shape), grad_y.view(ctx.y_shape), None

--- a/tests/test_cdist_kernel.py
+++ b/tests/test_cdist_kernel.py
@@ -1,0 +1,98 @@
+import torch
+import triton
+import triton.testing
+
+from kfold.utils.kernels.cdist import cdist
+
+
+def test_correctness():
+    # Set random seed for reproducibility
+    torch.manual_seed(42)
+
+    # Define tensor dimensions: Batch, N, M
+    B, N, M = 1, 5000, 5000
+    eps = 1e-8
+
+    print("=== Correctness Test ===")
+
+    # Initialize tensors
+    x = torch.randn((B, N, 3), device="cuda", dtype=torch.float32) * 100
+    y = torch.randn((B, M, 3), device="cuda", dtype=torch.float32) * 100
+    x_pt = x.clone().requires_grad_(True)
+    y_pt = y.clone().requires_grad_(True)
+    x_tr = x.clone().requires_grad_(True)
+    y_tr = y.clone().requires_grad_(True)
+
+    # Forward pass: PyTorch baseline
+    # Creates an intermediate tensor of shape [B, N, M, 3]
+    diff = x_pt.unsqueeze(2) - y_pt.unsqueeze(1)
+    dist_pt = torch.sqrt(torch.sum(diff**2, dim=-1) + eps)
+
+    # Forward pass: Triton kernel
+    dist_tr = cdist(x_tr, y_tr, eps)
+
+    # Check forward pass correctness (allow small floating point tolerance)
+    fwd_match = torch.allclose(dist_pt, dist_tr, atol=1e-5, rtol=1e-5)
+    print(f"Forward Pass Match: {fwd_match}")
+    if not fwd_match:
+        print(f"Max diff (Forward): {torch.max(torch.abs(dist_pt - dist_tr)).item()}")
+
+    # Create a random gradient output for the backward pass
+    grad_out = torch.randn_like(dist_pt)
+
+    # Backward pass: PyTorch baseline
+    dist_pt.backward(grad_out)
+
+    # Backward pass: Triton kernel
+    dist_tr.backward(grad_out)
+
+    # Check backward pass correctness for both x and y gradients
+    bwd_x_match = torch.allclose(x_pt.grad, x_tr.grad, atol=1e-4, rtol=1e-4)
+    bwd_y_match = torch.allclose(y_pt.grad, y_tr.grad, atol=1e-4, rtol=1e-4)
+
+    print(f"Backward Pass Match (x grad): {bwd_x_match}")
+    print(f"Backward Pass Match (y grad): {bwd_y_match}")
+
+
+def benchmark_performance():
+    # Use larger dimensions to clearly see the memory bandwidth bottleneck in PyTorch
+    Latom = 384 * 24
+    B, N, M = 8, Latom, Latom
+    # chunk_size = 8  # gradient checkpointing
+    eps = 1e-8
+
+    print("\n=== Performance Benchmark of cdist(x, y) ===")
+
+    x = torch.randn((B, N, 3), device="cuda", dtype=torch.float32, requires_grad=True)
+    y = torch.randn((B, M, 3), device="cuda", dtype=torch.float32, requires_grad=True)
+    print(f"Input tensors: x shape {x.shape}, y shape {y.shape}")
+
+    grad_out = torch.randn((B, N, M), device="cuda", dtype=torch.float32)
+
+    # Define baseline PyTorch function
+    def run_pytorch():
+        diff = x.unsqueeze(2) - y.unsqueeze(1)
+        dist = torch.sqrt(torch.sum(diff**2, dim=-1) + eps)
+        dist.backward(grad_out)
+
+    # Define Triton function
+    def run_triton():
+        dist = cdist(x, y, eps)
+        dist.backward(grad_out)
+
+    print("\nRunning PyTorch benchmark on cdist(x, y)...")
+    for i in range(5):
+        print(f"Run {i + 1}/5...")
+        pt_ms = triton.testing.do_bench(run_pytorch, quantiles=[0.5, 0.2, 0.8])
+        print(f"PyTorch Baseline: {pt_ms[0]:.3f} ms")
+
+        # Benchmark Triton
+        tr_ms = triton.testing.do_bench(run_triton, quantiles=[0.5, 0.2, 0.8])
+        print(f"Triton Fused Kernel: {tr_ms[0]:.3f} ms")
+
+        print(f"Speedup: {pt_ms[0] / tr_ms[0]:.2f}x faster")
+
+
+if __name__ == "__main__":
+    test_correctness()
+    benchmark_performance()


### PR DESCRIPTION
This PR aims to improve training efficiency.

**Triton Kernel for `cdist`**
Now the smooth lddt loss is computed using our custom `cdist()`, which is different from vanilla `torch.cdist` which is numerically unstable. This reduces the memory requirement and computational cost.

**Enable bfloat16 context for diffusion model**
* Previously, our model enforce float32 context for diffusion model. Instead, I change this to bfloat16, while keeping float32 for attention, to reduce both computational cost and node-communication overhead.

**Model Compile**
* Now the compilation config is moved to `train.compile`.
* `LocalAttentionIndex` is removed. Instead, implement the code which return the `to_qk(...)` callable function for local attention indexing, which is more *torch-compile-friendly*.