### PR TITLE
Stochastic sequence masking per recycling & add rna seq encoder

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -9,11 +9,14 @@ kernel_cuequivariance: true
 input_embedder:
   _yaml_: "module/input_embedder.yaml"
 
-sequence_encoder:
-  _yaml_: "module/sequence_encoder.yaml"
+protein_sequence_encoder:
+  _yaml_: "module/protein_sequence_encoder.yaml"
 
-structure_encoder:
-  _yaml_: "module/structure_encoder.yaml"
+protein_structure_encoder:
+  _yaml_: "module/protein_structure_encoder.yaml"
+
+rna_sequence_encoder:
+  _yaml_: "module/rna_sequence_encoder.yaml"
 
 trunk:
   _yaml_: "module/trunk.yaml"

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -9,11 +9,14 @@ kernel_cuequivariance: true
 input_embedder:
   _yaml_: "module/input_embedder.yaml"
 
-sequence_encoder:
-  _yaml_: "module/sequence_encoder.yaml"
+protein_sequence_encoder:
+  _yaml_: "module/protein_sequence_encoder.yaml"
 
-structure_encoder:
-  _yaml_: "module/structure_encoder.yaml"
+protein_structure_encoder:
+  _yaml_: "module/protein_structure_encoder.yaml"
+
+rna_sequence_encoder:
+  _yaml_: "module/rna_sequence_encoder.yaml"
 
 trunk:
   _yaml_: "module/trunk.yaml"

--- a/configs/model/module/protein_sequence_encoder.yaml
+++ b/configs/model/module/protein_sequence_encoder.yaml
@@ -1,0 +1,8 @@
+_registry_: "sequence_encoder"
+_class_: "SequenceEncoder"
+path: ???
+chain_type: 'protein'
+vocab_size: 64
+d_model: 2304
+n_heads: 36
+n_layers: 48

--- a/configs/model/module/protein_structure_encoder.yaml
+++ b/configs/model/module/protein_structure_encoder.yaml
@@ -4,6 +4,7 @@ path: ???
 fa_tok_path: ???
 bb_tok_path: ???
 encoder_path: ???
+chain_type: 'protein'
 d_model: 2560
 n_heads: 33
 n_layers: 40

--- a/configs/model/module/rna_sequence_encoder.yaml
+++ b/configs/model/module/rna_sequence_encoder.yaml
@@ -1,7 +1,9 @@
 _registry_: "sequence_encoder"
 _class_: "SequenceEncoder"
 path: ???
+chain_type: 'rna'
 vocab_size: 64
-d_model: 2304
-n_heads: 36
-n_layers: 48
+d_model: 960
+n_heads: 15
+n_layers: 30
+use_moe: true

--- a/configs/model/module/trunk.yaml
+++ b/configs/model/module/trunk.yaml
@@ -7,7 +7,7 @@ channel_plm: 768
 plm_module:
   num_heads_attn: 16
   num_heads_tri_attn: 4
-  num_blocks: 4
+  num_blocks: 2
   dropout_plm: 0.15
   dropout_z: 0.25
   blocks_per_ckpt: null

--- a/configs/train-ecsi-debug.yaml
+++ b/configs/train-ecsi-debug.yaml
@@ -1,8 +1,10 @@
 model:
   _yaml_: "model/kfold-ecsi.yaml"
-  sequence_encoder:
+  protein_sequence_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_seq_3b.pth
-  structure_encoder:
+  rna_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/rna_seq_300m.pth
+  protein_structure_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_struct_3b.pth
   trunk:
     plm_module:

--- a/configs/train-ecsi-mini.yaml
+++ b/configs/train-ecsi-mini.yaml
@@ -1,8 +1,10 @@
 model:
   _yaml_: "model/kfold-ecsi.yaml"
-  sequence_encoder:
+  protein_sequence_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_seq_3b.pth
-  structure_encoder:
+  rna_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/rna_seq_300m.pth
+  protein_structure_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_struct_3b.pth
   trunk:
     plm_module:

--- a/configs/train-edm-mini.yaml
+++ b/configs/train-edm-mini.yaml
@@ -1,8 +1,10 @@
 model:
   _yaml_: "model/kfold-edm.yaml"
-  sequence_encoder:
+  protein_sequence_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_seq_3b.pth
-  structure_encoder:
+  rna_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/rna_seq_300m.pth
+  protein_structure_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_struct_3b.pth
   trunk:
     plm_module:

--- a/configs/train-edm-tiny.yaml
+++ b/configs/train-edm-tiny.yaml
@@ -1,8 +1,10 @@
 model:
   _yaml_: "model/kfold-edm.yaml"
-  sequence_encoder:
+  protein_sequence_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_seq_3b.pth
-  structure_encoder:
+  rna_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/rna_seq_300m.pth
+  protein_structure_encoder:
     path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_struct_3b.pth
   trunk:
     plm_module:

--- a/configs/train/stage_1.yaml
+++ b/configs/train/stage_1.yaml
@@ -8,7 +8,7 @@ global_hparams:
 data:
   max_chains: 20
   max_tokens: 384
-  max_sequence_tokens: 512
+  max_sequence_tokens: 448
 
   ccd_path: /cache/wykim_lab/kfold_data/v260522/ccd-train.pkl
   train_datasets:

--- a/src/kfold/model/layers/folding/plm_module.py
+++ b/src/kfold/model/layers/folding/plm_module.py
@@ -21,70 +21,6 @@ from .attention_pair_bias import SelfAttentionPairBias
 from .transition import Transition
 
 
-class PLMInputEmbedder(nn.Module):
-    """
-    Separated embedder of PLMModule to avoid redundant computation across recycling steps.
-    """
-
-    def __init__(
-        self,
-        channel_seq_emb: int,
-        channel_seq_attn: int,
-        channel_struct_emb: int,
-        channel_z: int = 128,
-    ) -> None:
-        super().__init__()
-        # Initialize with uniform weights.
-        self.layernorm_seq = LayerNorm(channel_seq_emb, create_offset=False)
-        self.layernorm_struct = LayerNorm(channel_struct_emb, create_offset=False)
-
-        # Attention embedding projection to initialize pair representations.
-        # NOTE (Seonghwan): LayerNorm is applied for scalability to sequence length,
-        # as the scale of attention maps is reduced by sequence length.
-        self.proj_seq_attn = nn.Sequential(
-            LayerNorm(channel_seq_attn, create_offset=False),
-            LinearNoBias(channel_seq_attn, channel_z, init="relu"),
-            nn.ReLU(),
-            LinearNoBias(channel_z, channel_z, init="final"),
-        )
-
-    def forward(
-        self,
-        seq_emb: torch.Tensor,
-        seq_attn: torch.Tensor,
-        struct_emb: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Perform the forward pass.
-
-        Parameters
-        ----------
-        s_input : torch.Tensor
-            The input single representations
-        seq_emb : torch.Tensor
-            The hidden states from the sequence encoder
-            of shape (B, L, channel_seq)
-        seq_attn : torch.Tensor
-            The attention maps from the sequence encoder
-            of shape (B, L, num_layer_seq_attn, channel_seq_attn)
-        struct_emb : torch.Tensor
-            The structure embeddings of shape (B, L, channel_struct)
-
-        Returns
-        -------
-        s_plm: torch.Tensor
-            The fused single representations of shape (B, L, C_plm)
-        z_plm: torch.Tensor
-            The initial pair representations of shape (B, L, L, C_z)
-        """
-        # Compute s_plm
-        seq_emb = self.layernorm_seq(seq_emb)
-        struct_emb = self.layernorm_struct(struct_emb)
-        s_plm = torch.cat([seq_emb, struct_emb], dim=-1)
-        # Compute z_plm for initializing pair representations.
-        z_plm = self.proj_seq_attn(seq_attn.flatten(-2))
-        return s_plm, z_plm
-
-
 class PairwiseProdDiff(nn.Module):
     """Convert single embeddings to pairwise embeddings.
     Inspired by ESMFold's implementation.
@@ -131,7 +67,6 @@ class PLMModule(nn.Module):
     def __init__(
         self,
         channel_s_inputs: int = 384,
-        channel_plm_inputs: int = 2688,
         channel_plm: int = 768,
         channel_z: int = 128,
         num_heads_attn: int = 16,
@@ -143,7 +78,6 @@ class PLMModule(nn.Module):
     ) -> None:
         super().__init__()
         self.linear_s_inputs = LinearNoBias(channel_s_inputs, channel_plm)
-        self.linear_plm_inputs = LinearNoBias(channel_plm_inputs, channel_plm)
         self.blocks = torch.nn.ModuleList()
         for i in range(num_blocks):
             self.blocks.append(
@@ -163,7 +97,7 @@ class PLMModule(nn.Module):
         self,
         z: torch.Tensor,
         s_inputs: torch.Tensor,
-        plm_inputs: torch.Tensor,
+        s_plm: torch.Tensor,
         asym_id: torch.Tensor,
         mask: torch.Tensor,
         use_cuequiv_kernels: bool = False,
@@ -176,7 +110,7 @@ class PLMModule(nn.Module):
             The pair representations of shape (B, L, L, C_z)
         s_inputs : torch.Tensor
             The input single representations of shape (B, L, C_s)
-        plm_inputs : torch.Tensor
+        s_plm : torch.Tensor
             The sequence embeddings from PLM of shape (B, L, C_s_plm)
         asym_id : torch.Tensor
             The asymmetry IDs of shape (B, L)
@@ -191,7 +125,7 @@ class PLMModule(nn.Module):
             The updated pair representations
         """
         # Fuse inputs to get initial s_plm.
-        s_plm = self.linear_s_inputs(s_inputs) + self.linear_plm_inputs(plm_inputs)
+        s_plm = s_plm + self.linear_s_inputs(s_inputs)
 
         # Create masks
         pair_mask = mask[..., None] & mask[..., None, :]

--- a/src/kfold/model/layers/seq_enc/blocks.py
+++ b/src/kfold/model/layers/seq_enc/blocks.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .attention import MultiHeadAttention
+from .moe import MoEFFN
 
 
 class SwiGLU(nn.Module):
@@ -37,16 +38,20 @@ class TransformerBlock(nn.Module):
         n_heads: int,
         expansion_ratio: float = 4.0,
         residue_scaling_factor: float = 1,
+        use_moe: bool = False,
     ):
         super().__init__()
         self.attn = MultiHeadAttention(d_model, n_heads)
-        d_ffn = swiglu_correction_fn(expansion_ratio, d_model)
-        self.ffn = nn.Sequential(
-            nn.LayerNorm(d_model),
-            nn.Linear(d_model, d_ffn * 2, bias=False),
-            SwiGLU(),
-            nn.Linear(d_ffn, d_model, bias=False),
-        )
+        if use_moe:
+            self.ffn = MoEFFN(d_model, expansion_ratio)
+        else:
+            d_ffn = swiglu_correction_fn(expansion_ratio, d_model)
+            self.ffn = nn.Sequential(
+                nn.LayerNorm(d_model),
+                nn.Linear(d_model, d_ffn * 2, bias=False),
+                SwiGLU(),
+                nn.Linear(d_ffn, d_model, bias=False),
+            )
         self.scaling_factor: float = residue_scaling_factor
 
     def forward(

--- a/src/kfold/model/layers/seq_enc/moe.py
+++ b/src/kfold/model/layers/seq_enc/moe.py
@@ -1,0 +1,185 @@
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def swiglu_correction_fn(expansion_ratio: float, d_model: int) -> int:
+    # set hidden dimesion to nearest multiple of 256 after expansion ratio
+    return int(((expansion_ratio * d_model) + 255) // 256 * 256)
+
+
+class MoEFFN(nn.Module):
+    """
+    Sparse MoE FFN with optional shared experts (DeepSeek-MoE / Qwen-MoE style).
+
+    Layout (default for this project):
+        num_routed_experts = 8   (router selects top_k of these per token)
+        top_k = 2                (routed experts active per token)
+        => total experts        = 8 + 1 = 9
+           active experts/token = 2 routed + 1 shared = 3
+
+    Switch Transformer (Fedus et al., JMLR 2022) load balancing aux loss:
+        For N routed experts and a batch of T tokens:
+            f_i = fraction of tokens routed to expert i (non-diff)
+            P_i = mean of router softmax prob for expert i over the batch (diff)
+            L_aux = N * Σ_i (f_i * P_i)        (computed per layer)
+        Gradient flows only through P_i. Final scaling by alpha is applied
+        once at the LightningModule level after summing across all layers.
+
+    `last_aux_loss` is populated on every forward and consumed by the
+    enclosing TransformerStack.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        expansion_ratio: float,
+        num_routed_experts: int = 4,
+        top_k: int = 1,
+        capacity_factor: float = 2.0,
+    ):
+        super().__init__()
+        assert num_routed_experts >= 1
+        self.d_model = d_model
+        self.num_routed = num_routed_experts
+        self.top_k = top_k
+        assert 1 <= top_k <= self.num_routed, (
+            f"top_k ({top_k}) must be in [1, num_routed={self.num_routed}]"
+        )
+        self.capacity_factor: float = capacity_factor
+
+        # Pre-FFN LayerNorm (matches dense ffn structure)
+        self.norm = nn.LayerNorm(d_model)
+
+        # Router (no bias, as in Switch Transformer / Mixtral)
+        # routing='modality': router is unused but kept as a no-op nn.Linear
+        # so the module's state_dict layout stays stable across routing modes.
+        self.router = nn.Linear(d_model, self.num_routed, bias=False)
+
+        # Stacked routed expert weights — single big parameters for batched
+        # bmm in the vectorized forward path. ffn_type='swiglu', bias=False:
+        #   per-expert: Linear(d, 2h) -> SwiGLU -> Linear(h, d)
+        # Stacked:
+        #   w13: (E, 2h, d)   [first Linear]
+        #   w2:  (E, d, h)    [second Linear]
+        self.h_dim: int = swiglu_correction_fn(expansion_ratio, d_model)
+        self.w13_stacked = nn.Parameter(
+            torch.empty(self.num_routed, 2 * self.h_dim, d_model)
+        )
+        self.w2_stacked = nn.Parameter(torch.empty(self.num_routed, d_model, self.h_dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        orig_shape = x.shape
+        x_flat = x.reshape(-1, self.d_model)
+
+        h = self.norm(x_flat)  # (T, D)
+
+        # Routing (run on ALL positions — no correctness issue, Mixtral/Qwen2 style)
+        router_logits = self.router(h)  # (T, N)
+        router_probs = F.softmax(router_logits, dim=-1)  # (T, N), differentiable
+
+        # Top-k selection (k routed experts per token)
+        top_probs, top_idx = torch.topk(router_probs, self.top_k, dim=-1)  # (T, k)
+        # Renormalize so the routed-expert weights sum to 1 (Mixtral-style)
+        top_probs = top_probs / (top_probs.sum(dim=-1, keepdim=True) + 1e-9)
+
+        # Determine dtype for the routed expert dispatch buffer.
+        # Under bf16-mixed autocast, the LayerNorm output `h` stays in fp32
+        # while expert Linear outputs are bf16. We must allocate buffers in
+        # the autocast dtype so index_add_ (strict on dtype) succeeds.
+        if torch.is_autocast_enabled():
+            out_dtype = torch.get_autocast_gpu_dtype()
+        else:
+            out_dtype = h.dtype
+
+        # Dispatch tokens to their selected routed experts.
+        out = self._dispatch_vectorized(h, top_idx, top_probs, out_dtype)
+
+        return out.view(orig_shape)
+
+    def _dispatch_vectorized(
+        self,
+        h: torch.Tensor,
+        top_idx: torch.Tensor,
+        top_probs: torch.Tensor,
+        out_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """
+        Vectorized routed-expert dispatch using padded capacity grouped bmm:
+        """
+        T = h.shape[0]
+        D = self.d_model
+        E = self.num_routed
+        K = self.top_k
+        device = h.device
+
+        # ---- Flatten (T, k) routing into (T*k,) per-slot tensors -------
+        flat_top_idx = top_idx.reshape(-1)  # (T*k,)
+        flat_top_probs = top_probs.reshape(-1)  # (T*k,)
+        # Original token index for each (token, slot) pair.
+        flat_token_src = (
+            torch.arange(T, device=device).unsqueeze(-1).expand(T, K).reshape(-1)
+        )  # (T*k,)
+
+        # ---- Sort slots by expert id so each expert's slots are contiguous ----
+        order = flat_top_idx.argsort()
+        sorted_expert = flat_top_idx[order]  # (T*k,)
+        sorted_token_src = flat_token_src[order]  # (T*k,)
+        sorted_weights = flat_top_probs[order]  # (T*k,)
+
+        # ---- Per-expert offsets via bincount + cumsum ----
+        counts = torch.bincount(sorted_expert, minlength=E)  # (E,)
+        offsets = counts.cumsum(0) - counts  # (E,) start of each expert's chunk
+
+        # Position of each sorted slot within its expert's bucket.
+        positions_in_bucket = (
+            torch.arange(T * K, device=device) - offsets[sorted_expert]
+        )  # (T*k,)
+
+        # ---- Compute capacity (rounded up to multiple of 8) ----
+        # Using a Python int derived from a symbolic T: under dynamic=True,
+        # this stays symbolic in the compile graph (no recompile per shape).
+        capacity = math.ceil(T * K / E * self.capacity_factor / 8) * 8
+        capacity = max(capacity, 8)  # never zero
+
+        # ---- Identify overflow + clamp positions to safe range ----
+        overflow_mask = positions_in_bucket >= capacity
+        positions_clamped = positions_in_bucket.clamp(max=capacity - 1)
+        # Effective dispatch weight: zero for overflowed slots → drops them.
+        valid_mask = (~overflow_mask).to(h.dtype)  # (T*k,)
+        eff_weights = sorted_weights * valid_mask
+
+        # ---- Build dispatch buffer (E, capacity, D) via index_add_ ----
+        flat_buf_idx = sorted_expert * capacity + positions_clamped  # (T*k,)
+        src_h = h.index_select(0, sorted_token_src)  # (T*k, D)
+        # Zero out overflow contributions BEFORE the index_add to avoid
+        # corrupting the legitimate (capacity-1) cell on collision.
+        src_h_masked = src_h * valid_mask.unsqueeze(-1).to(h.dtype)
+        buf_flat = torch.zeros(E * capacity, D, dtype=h.dtype, device=device)
+        buf_flat.index_add_(0, flat_buf_idx, src_h_masked)
+        buf = buf_flat.view(E, capacity, D)  # (E, capacity, D)
+
+        # ---- Batched expert forward (single big bmm × 2) ----
+        # buf: (E, capacity, D)
+        # w13_stacked: (E, 2h, D)  →  transpose → (E, D, 2h)
+        # bmm:       (E, capacity, D) @ (E, D, 2h)  →  (E, capacity, 2h)
+        gate_up = torch.bmm(buf, self.w13_stacked.transpose(-1, -2))  # (E, capacity, 2h)
+        g, u = gate_up.chunk(2, dim=-1)
+        activated = F.silu(g) * u  # (E, capacity, h)
+        # w2_stacked: (E, D, h) → transpose → (E, h, D)
+        out_buf = torch.bmm(
+            activated, self.w2_stacked.transpose(-1, -2)
+        )  # (E, capacity, D)
+
+        # ---- Unpermute: gather expert outputs back into per-slot order ----
+        out_buf_flat = out_buf.reshape(E * capacity, D)  # (E*capacity, D)
+        gathered = out_buf_flat.index_select(0, flat_buf_idx)  # (T*k, D)
+        # Apply per-slot weight (top_prob * valid_mask) — overflow → zero.
+        weighted = gathered.to(out_dtype) * eff_weights.unsqueeze(-1).to(out_dtype)
+
+        # ---- Scatter weighted outputs back to (T, D) ----
+        out = torch.zeros(T, D, dtype=out_dtype, device=device)
+        out.index_add_(0, sorted_token_src, weighted)
+        return out

--- a/src/kfold/model/layers/seq_enc/transformer_stack.py
+++ b/src/kfold/model/layers/seq_enc/transformer_stack.py
@@ -13,6 +13,7 @@ class TransformerStack(torch.nn.Module):
         n_layers: int,
         scale_residue: bool = True,
         expansion_ratio: float = 8 / 3,
+        use_moe: bool = False,
     ):
         super().__init__()
         self.d_model: int = d_model
@@ -28,6 +29,7 @@ class TransformerStack(torch.nn.Module):
                         math.sqrt(n_layers / 36) if scale_residue else 1.0
                     ),
                     expansion_ratio=expansion_ratio,
+                    use_moe=use_moe,
                 )
                 for _ in range(n_layers)
             ]

--- a/src/kfold/model/model.py
+++ b/src/kfold/model/model.py
@@ -8,7 +8,6 @@ from typing import Self
 import torch
 
 from kfold.data.types.model_input import FoldingInput
-from kfold.model.layers.folding.plm_module import PLMInputEmbedder
 from kfold.utils.registry import MAIN_MODULE, BaseConfig, Registry
 
 logger = logging.getLogger(__name__)
@@ -23,8 +22,9 @@ class KFoldConfig:
 
     # Sub-module configurations
     input_embedder: BaseConfig
-    sequence_encoder: BaseConfig
-    structure_encoder: BaseConfig
+    protein_sequence_encoder: BaseConfig
+    protein_structure_encoder: BaseConfig
+    rna_sequence_encoder: BaseConfig
     trunk: BaseConfig
     score_model: BaseConfig
     diffusion_head: BaseConfig
@@ -50,19 +50,17 @@ class KFold(torch.nn.Module):
 
         # Initialize trunk
         self.input_embedder = Registry.instantiate(config.input_embedder)
-        self.sequence_encoder = Registry.instantiate(config.sequence_encoder)
-        self.structure_encoder = Registry.instantiate(config.structure_encoder)
-        seq_enc, struct_enc = self.sequence_encoder, self.structure_encoder
-        self.plm_input_embedder: PLMInputEmbedder = PLMInputEmbedder(
-            channel_seq_emb=seq_enc.d_model,
-            channel_seq_attn=seq_enc.n_layers * seq_enc.n_heads,
-            channel_struct_emb=struct_enc.d_model,
-        )
+
+        prot_seq_enc = Registry.instantiate(config.protein_sequence_encoder)
+        rna_seq_enc = Registry.instantiate(config.rna_sequence_encoder)
+        prot_struct_enc = Registry.instantiate(config.protein_structure_encoder)
 
         # Initialize trunk
         self.trunk = Registry.instantiate(
             config.trunk,
-            channel_plm_inputs=(seq_enc.d_model + struct_enc.d_model),
+            protein_sequence_encoder=prot_seq_enc,
+            rna_sequence_encoder=rna_seq_enc,
+            protein_structure_encoder=prot_struct_enc,
             kernel_config=kernel_config,
         )
 
@@ -151,7 +149,9 @@ class KFold(torch.nn.Module):
             aatypes, coords = apo_info["aatypes"], apo_info["coords"]
             seq_st, seq_ed, apo_st, apo_ed = apo_info["mapping"]
             seq_sl, apo_sl = slice(seq_st, seq_ed), slice(apo_st, apo_ed)
-            bb_ids, fa_ids = self.structure_encoder.tokenize(aatypes, coords)
+            bb_ids, fa_ids = self.trunk.protein_structure_encoder.tokenize(
+                aatypes, coords
+            )
             f_input.sequence.bb_struct_token_id[0, seq_sl] = bb_ids[apo_sl]
             f_input.sequence.fa_struct_token_id[0, seq_sl] = fa_ids[apo_sl]
 
@@ -224,25 +224,6 @@ class KFold(torch.nn.Module):
         et = time.time()
         time_logs["input_embedder"] = et - st
 
-        # Sequence encoder
-        st = time.time()
-        seq_emb, seq_attn = self.sequence_encoder(f_input)
-        et = time.time()
-        time_logs["sequence_encoder"] = et - st
-
-        # Structure encoder
-        st = time.time()
-        struct_emb = self.structure_encoder(f_input)
-        et = time.time()
-        time_logs["structure_encoder"] = et - st
-
-        st = time.time()
-        plm_inputs, plm_attn = self.plm_input_embedder(seq_emb, seq_attn, struct_emb)
-        z_init += plm_attn  # add PLM attention bias to pair representation
-        del seq_emb, seq_attn, struct_emb, plm_attn  # free up memory
-        et = time.time()
-        time_logs["plm_input_embedder"] = et - st
-
         # Trunk with recycling
         st = time.time()
         s_trunk, z_trunk = self.trunk(
@@ -251,7 +232,6 @@ class KFold(torch.nn.Module):
             z_init,
             f_input,
             num_recycles,
-            plm_inputs=plm_inputs,
         )
         et = time.time()
         time_logs["trunk"] = et - st
@@ -259,11 +239,9 @@ class KFold(torch.nn.Module):
         if return_embeddings:
             dict_out["trunk"] = {
                 "s_inputs": s_inputs,
-                "plm_inputs": plm_inputs,
                 "s_trunk": s_trunk,
                 "z_trunk": z_trunk,
             }
-        del plm_inputs  # free up memory
 
         # Distogram head
         st = time.time()
@@ -395,13 +373,6 @@ class KFold(torch.nn.Module):
         # NOTE: cast to float32 for numerical stability in training.
         s_inputs, s_init, z_init = s_inputs.float(), s_init.float(), z_init.float()
 
-        # Get PLM input embeddings
-        seq_emb, seq_attn = self.sequence_encoder(f_input)
-        struct_emb = self.structure_encoder(f_input)
-        plm_inputs, plm_attn = self.plm_input_embedder(seq_emb, seq_attn, struct_emb)
-        z_init = z_init + plm_attn  # add PLM attention bias to pair representation
-        del seq_emb, seq_attn, struct_emb, plm_attn  # free up memory
-
         # Trunk with recycling
         s_trunk, z_trunk = self.trunk(
             s_inputs,
@@ -409,7 +380,6 @@ class KFold(torch.nn.Module):
             z_init,
             f_input,
             num_recycles,
-            plm_inputs=plm_inputs,
         )
 
         if train_structure_module:
@@ -557,7 +527,13 @@ class KFold(torch.nn.Module):
             missing_keys = {
                 k
                 for k in missing_keys
-                if not k.startswith(("sequence_encoder.", "structure_encoder."))
+                if not k.startswith(
+                    (
+                        "trunk.protein_sequence_encoder.",
+                        "trunk.rna_sequence_encoder.",
+                        "trunk.protein_structure_encoder.",
+                    )
+                )
             }
             if missing_keys:
                 raise KeyError(f"Missing keys in state_dict: {missing_keys}")

--- a/src/kfold/model/modules/sequence_encoder.py
+++ b/src/kfold/model/modules/sequence_encoder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import torch
 
-from kfold.constants.sequence import MASK_TOKEN_INDEX
+from kfold.constants.sequence import MASK_TOKEN_INDEX, PAD_TOKEN_INDEX
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.seq_enc.transformer_stack import TransformerStack
 from kfold.utils.registry import SEQUENCE_ENCODER, BaseConfig
@@ -17,6 +17,8 @@ class SequenceEncoder(torch.nn.Module):
         ----------
         path: str
             Path to pretrained weights.
+        chain_type: str
+            Type of sequence chain to encode. Must be one of "protein", "dna", or "rna".
         vocab_size: int
             Size of the input token vocabulary.
         d_model: int
@@ -25,21 +27,32 @@ class SequenceEncoder(torch.nn.Module):
             Number of attention heads in the transformer.
         n_layers: int
             Number of transformer layers.
+        use_moe: bool
+            Whether to use Mixture of Experts (MoE) FFN layers instead of dense FFN.
         """
 
         path: str  # Path to pretrained weights.
         vocab_size: int = 64
+        chain_type: str = "protein"
         d_model: int = 1152
         n_heads: int = 18
         n_layers: int = 36
+        use_moe: bool = False
 
     def __init__(self, cfg: Config):
         super().__init__()
         self.cfg: SequenceEncoder.Config = cfg
+        self.chain_type = cfg.chain_type
 
         # Create model components
         self.embed = torch.nn.Embedding(cfg.vocab_size, cfg.d_model)
-        self.transformer = TransformerStack(cfg.d_model, cfg.n_heads, cfg.n_layers)
+        self.transformer = TransformerStack(
+            cfg.d_model, cfg.n_heads, cfg.n_layers, use_moe=cfg.use_moe
+        )
+
+        # Convert to bfloat16
+        self.embed = self.embed.to(torch.bfloat16)
+        self.transformer = self.transformer.to(torch.bfloat16)
 
         # Load pretrained weights
         state_dict = torch.load(cfg.path, map_location="cpu")
@@ -48,10 +61,6 @@ class SequenceEncoder(torch.nn.Module):
         }
         self.load_state_dict(state_dict)
         del state_dict
-
-        # Convert to bfloat16
-        self.embed = self.embed.to(torch.bfloat16)
-        self.transformer = self.transformer.to(torch.bfloat16)
 
         # Set to eval mode
         self.eval()
@@ -63,6 +72,12 @@ class SequenceEncoder(torch.nn.Module):
         # generate multiple diverse predictions for the same input by adjusting
         # the evolutionary signal.
         self.mask_token_id: int = MASK_TOKEN_INDEX
+        self.pad_token_id: int = PAD_TOKEN_INDEX
+
+    def train(self, mode: bool = True):
+        """Ensure the module remains in eval mode regardless of parent state."""
+        super().train(False)
+        return self
 
     @property
     def n_layers(self) -> int:
@@ -76,13 +91,19 @@ class SequenceEncoder(torch.nn.Module):
     def n_heads(self) -> int:
         return self.cfg.n_heads
 
-    def forward(self, f_input: FoldingInput) -> tuple[torch.Tensor, torch.Tensor]:
+    def forward(
+        self,
+        f_input: FoldingInput,
+        mask_ratio: float = 0.15,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass of sequence representation module.
 
         Parameters
         ----------
         f_input: FoldingInput
             The input features
+        mask_ratio: float
+            The ratio of tokens to mask for MLM during inference. Default is 0.15.
 
         Returns
         -------
@@ -98,24 +119,35 @@ class SequenceEncoder(torch.nn.Module):
             torch.autocast(f_input.device.type, dtype=torch.bfloat16),
             torch.no_grad(),
         ):
-            return self._forward(f_input)
+            return self._forward(f_input, mask_ratio)
 
-    def prepare_emb_mask(self, f_input: FoldingInput) -> torch.Tensor:
+    def get_seq_mask(self, f_input: FoldingInput) -> torch.Tensor:
         """Prepare output mask"""
-        return f_input.token.pad_mask & f_input.token.is_protein
+        if self.chain_type == "protein":
+            return f_input.sequence.pad_mask & f_input.sequence.is_protein
+        elif self.chain_type == "dna":
+            return f_input.sequence.pad_mask & f_input.sequence.is_dna
+        elif self.chain_type == "rna":
+            return f_input.sequence.pad_mask & f_input.sequence.is_rna
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
 
-    def prepare_out_attn_mask(
-        self, f_input: FoldingInput, token_mask: torch.Tensor
-    ) -> torch.Tensor:
-        """Prepare output attention mask"""
-        # attention mask: [B, Ntoken, Ntoken]
-        attn_mask = token_mask.unsqueeze(-1) & token_mask.unsqueeze(-2)
-        # mask out attention between different chains
-        asym_id = f_input.token.asym_id
-        attn_mask &= asym_id.unsqueeze(-1) == asym_id.unsqueeze(-2)
-        return attn_mask
+    def get_token_mask(self, f_input: FoldingInput) -> torch.Tensor:
+        """Prepare output mask"""
+        if self.chain_type == "protein":
+            return f_input.token.pad_mask & f_input.token.is_protein
+        elif self.chain_type == "dna":
+            return f_input.token.pad_mask & f_input.token.is_dna
+        elif self.chain_type == "rna":
+            return f_input.token.pad_mask & f_input.token.is_rna
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
 
-    def _forward(self, f_input: FoldingInput) -> tuple[torch.Tensor, torch.Tensor]:
+    def _forward(
+        self,
+        f_input: FoldingInput,
+        mask_ratio: float = 0.15,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward pass of sequence representation module.
 
         Parameters
@@ -140,7 +172,16 @@ class SequenceEncoder(torch.nn.Module):
         input_ids = f_input.sequence.seq_token_id
         seq_id = f_input.sequence.asym_id
         pos_id = f_input.sequence.pos_id
-        mlm_mask = f_input.sequence.mlm_mask
+
+        # === Mask out invalid sequence tokens === #
+        seq_mask = self.get_seq_mask(f_input)
+        seq_id = seq_id.masked_fill(~seq_mask, -1)
+        input_ids = input_ids.masked_fill(~seq_mask, self.pad_token_id)
+
+        # === MLM masking === #
+        mlm_mask = torch.rand(input_ids.shape, device=input_ids.device) < mask_ratio
+        mlm_mask &= seq_mask  # Only mask valid tokens
+        input_ids = input_ids.masked_fill(mlm_mask, self.mask_token_id)
 
         # sequence -> token index mapping
         seq_token_idx = f_input.token.seq_token_index.clamp(min=0)  # [B, n_tokens]
@@ -148,9 +189,6 @@ class SequenceEncoder(torch.nn.Module):
         b_idx = torch.arange(B, device=device)[:, None, None]
         row_idx = seq_token_idx[:, :, None]
         col_idx = seq_token_idx[:, None, :]
-
-        # === MLM masking === #
-        input_ids = input_ids.masked_fill(mlm_mask, self.mask_token_id)
 
         # === Forward pass === #
         x = self.embed(input_ids)
@@ -166,9 +204,12 @@ class SequenceEncoder(torch.nn.Module):
         x_out = x.gather(1, seq_token_idx[..., None].expand(-1, -1, D))
 
         # Mask out invalid tokens
-        token_mask = self.prepare_emb_mask(f_input)
-        attn_mask = self.prepare_out_attn_mask(f_input, token_mask)
+        token_mask = self.get_token_mask(f_input)
         x_out.masked_fill_(~token_mask[..., None], 0.0)
-        attn_out.masked_fill_(~attn_mask[..., None, None], 0.0)
+
+        pair_mask = token_mask.unsqueeze(-1) & token_mask.unsqueeze(-2)
+        asym_id = f_input.token.asym_id
+        pair_mask &= asym_id.unsqueeze(-1) == asym_id.unsqueeze(-2)
+        attn_out.masked_fill_(~pair_mask[..., None, None], 0.0)
 
         return x_out, attn_out

--- a/src/kfold/model/modules/structure_encoder.py
+++ b/src/kfold/model/modules/structure_encoder.py
@@ -33,19 +33,21 @@ class StructureEncoder(torch.nn.Module):
         ----------
         path: str
             Path to pretrained weights.
+        chain_type: str
+            Type of sequence chain to encode. Must be one of "protein", "dna", or "rna".
         d_model: int
             Dimension of token embeddings and transformer hidden states.
         n_heads: int
             Number of attention heads in the transformer.
         n_layers: int
             Number of transformer layers.
-
         """
 
+        path: str | None = None
         fa_tok_path: str | None = None
         bb_tok_path: str | None = None
         encoder_path: str | None = None
-        path: str | None = None
+        chain_type: str = "protein"
         d_model: int = 2560
         n_layers: int = 33
         n_heads: int = 40
@@ -53,13 +55,14 @@ class StructureEncoder(torch.nn.Module):
     def __init__(self, cfg: Config):
         super().__init__()
         self.cfg: StructureEncoder.Config = cfg
+        self.chain_type = cfg.chain_type
 
         # Create model components
         # TODO: replace to hf hub link.
         if cfg.path is not None:
-            self.bb_tok = BackboneTokenizer()
-            self.fa_tok = FullAtomTokenizer()
-            self.encoder = ProteinNetEncoder()
+            self.bb_tok = BackboneTokenizer().to(torch.bfloat16)
+            self.fa_tok = FullAtomTokenizer().to(torch.bfloat16)
+            self.encoder = ProteinNetEncoder().to(torch.bfloat16)
             state_dict = torch.load(cfg.path, map_location="cpu")
             self.load_state_dict(state_dict, strict=True)
         else:
@@ -72,11 +75,10 @@ class StructureEncoder(torch.nn.Module):
             self.bb_tok = BackboneTokenizer.from_pretrained(cfg.bb_tok_path)
             self.fa_tok = FullAtomTokenizer.from_pretrained(cfg.fa_tok_path)
             self.encoder = ProteinNetEncoder.from_pretrained(cfg.encoder_path)
-
-        # Set to bfloat16
-        self.bb_tok = self.bb_tok.to(torch.bfloat16)
-        self.fa_tok = self.fa_tok.to(torch.bfloat16)
-        self.encoder = self.encoder.to(torch.bfloat16)
+            # Set to bfloat16
+            self.bb_tok = self.bb_tok.to(torch.bfloat16)
+            self.fa_tok = self.fa_tok.to(torch.bfloat16)
+            self.encoder = self.encoder.to(torch.bfloat16)
 
         # Set to eval mode
         self.eval()
@@ -252,6 +254,13 @@ class StructureEncoder(torch.nn.Module):
         ):
             return self._forward(f_input)
 
+    def get_seq_mask(self, f_input: FoldingInput) -> torch.Tensor:
+        """Prepare output mask"""
+        if self.chain_type == "protein":
+            return f_input.sequence.pad_mask & f_input.sequence.is_protein
+        else:
+            raise ValueError(f"Unsupported chain type: {self.chain_type}")
+
     def _forward(self, f_input: FoldingInput) -> torch.Tensor:
         """Forward pass of sequence representation module.
 
@@ -274,7 +283,8 @@ class StructureEncoder(torch.nn.Module):
         # HACK: (Seonghwan) Since we use the shared sequence vocab for both sequence
         # and structure encoder, structure encoder does not have vocab ids for
         # dna and rna tokens. We set those to 0 to prevent out-of-vocab errors.
-        seq_token_ids = seq_token_ids.masked_fill(~f_input.sequence.is_protein, 0)
+        seq_mask = self.get_seq_mask(f_input)
+        seq_token_ids = seq_token_ids.masked_fill(~seq_mask, 0)
 
         seq_id = f_input.sequence.asym_id
         pos_id = f_input.sequence.pos_id

--- a/src/kfold/model/modules/trunk.py
+++ b/src/kfold/model/modules/trunk.py
@@ -1,13 +1,17 @@
 """KFold trunk module."""
 
 import dataclasses
+from functools import partial
 
 import torch
 
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.folding.pairformer import PairformerStack
 from kfold.model.layers.folding.plm_module import PLMModule
+from kfold.model.modules.sequence_encoder import SequenceEncoder
+from kfold.model.modules.structure_encoder import StructureEncoder
 from kfold.model.primitives import LayerNorm, LinearNoBias
+from kfold.model.primitives.utils import add
 from kfold.utils.registry import TRUNK, BaseConfig
 
 
@@ -68,7 +72,9 @@ class Trunk(torch.nn.Module):
     def __init__(
         self,
         cfg: Config,
-        channel_plm_inputs: int,
+        protein_sequence_encoder: SequenceEncoder,
+        rna_sequence_encoder: SequenceEncoder,
+        protein_structure_encoder: StructureEncoder,
         kernel_config=None,
     ):
         """Initialize the KFoldTrunk module."""
@@ -77,12 +83,57 @@ class Trunk(torch.nn.Module):
         self.kernel_config: dict = kernel_config or {}
         self.is_compiled: bool = False
 
+        self.protein_sequence_encoder: SequenceEncoder = protein_sequence_encoder
+        self.rna_sequence_encoder: SequenceEncoder = rna_sequence_encoder
+        self.protein_structure_encoder: StructureEncoder = protein_structure_encoder
+
+        channel_prot_seq = protein_sequence_encoder.d_model
+        self.proj_prot_seq = torch.nn.Sequential(
+            LayerNorm(channel_prot_seq, create_offset=False),
+            LinearNoBias(channel_prot_seq, cfg.channel_plm),
+        )
+        channel_rna_seq = rna_sequence_encoder.d_model
+        self.proj_rna_seq = torch.nn.Sequential(
+            LayerNorm(channel_rna_seq, create_offset=False),
+            LinearNoBias(channel_rna_seq, cfg.channel_plm),
+        )
+        channel_prot_struct = protein_structure_encoder.d_model
+        self.proj_prot_struct = torch.nn.Sequential(
+            LayerNorm(channel_prot_struct, create_offset=False),
+            LinearNoBias(channel_prot_struct, cfg.channel_plm),
+        )
+
+        channel_prot_seq_attn = (
+            protein_sequence_encoder.n_layers * protein_sequence_encoder.n_heads
+        )
+        self.proj_prot_seq_attn = torch.nn.Sequential(
+            LayerNorm(channel_prot_seq_attn, create_offset=False),
+            LinearNoBias(channel_prot_seq_attn, cfg.channel_z, init="relu"),
+            torch.nn.ReLU(),
+            LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
+        )
+        channel_rna_seq_attn = (
+            rna_sequence_encoder.n_layers * rna_sequence_encoder.n_heads
+        )
+        self.proj_rna_seq_attn = torch.nn.Sequential(
+            LayerNorm(channel_rna_seq_attn, create_offset=False),
+            LinearNoBias(channel_rna_seq_attn, cfg.channel_z, init="relu"),
+            torch.nn.ReLU(),
+            LinearNoBias(cfg.channel_z, cfg.channel_z, init="final"),
+        )
+
+        # === Skip connection === #
+        self.skip_plm_to_s = torch.nn.Sequential(
+            LinearNoBias(cfg.channel_plm, cfg.channel_s, init="relu"),
+            torch.nn.ReLU(),
+            LinearNoBias(cfg.channel_s, cfg.channel_s, init="final"),
+        )
+
         # === PLM Module === #
         self.plm_module: PLMModule = PLMModule(
             channel_s_inputs=cfg.channel_s,
-            channel_plm_inputs=channel_plm_inputs,
-            channel_z=cfg.channel_z,
             channel_plm=cfg.channel_plm,
+            channel_z=cfg.channel_z,
             num_heads_attn=cfg.plm_module.num_heads_attn,
             num_heads_tri_attn=cfg.plm_module.num_heads_tri_attn,
             num_blocks=cfg.plm_module.num_blocks,
@@ -107,11 +158,6 @@ class Trunk(torch.nn.Module):
         self.layernorm_z = LayerNorm(cfg.channel_z)
         self.linear_s = LinearNoBias(cfg.channel_s, cfg.channel_s, init="final")
         self.linear_z = LinearNoBias(cfg.channel_z, cfg.channel_z, init="final")
-
-        # === Skip connection === #
-        self.proj_plm_to_s_trunk = LinearNoBias(
-            channel_plm_inputs, cfg.channel_s, init="final"
-        )
 
     def do_compile(self, **kwargs):
         """Compile the trunk module."""
@@ -142,7 +188,6 @@ class Trunk(torch.nn.Module):
         z_init: torch.Tensor,
         f_input: FoldingInput,
         num_recycles: int,
-        plm_inputs: torch.Tensor,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Perform the forward pass.
@@ -159,8 +204,6 @@ class Trunk(torch.nn.Module):
             The input features.
         num_recycles : int
             The number of recycling steps.
-        plm_inputs : torch.Tensor
-            Tensor of shape (B, L, C_plm) containing input single features for PLMs
 
         Returns
         -------
@@ -169,10 +212,22 @@ class Trunk(torch.nn.Module):
         z_trunk: torch.Tensor
             The updated tensor of shape (B, L, L, c_z).
         """
+        _add = partial(add, inplace=not self.training)
+
+        pairformer_stack = self.get_pairformer_stack()
+        plm_module = self.get_plm_module()
+        use_cuequiv_kernels = self.kernel_config.get("cuequivariance", False)
+
+        # Run the structure encoder once, without stochastic masking.
+        with torch.no_grad():
+            x_prot_struct = self.protein_structure_encoder(f_input)
+
+        # Initialize s_plm
+        s_plm_init = self.proj_prot_struct(x_prot_struct)
+
         # === Main trunk iteration with recycling === #
         s = torch.zeros_like(s_init)
         z = torch.zeros_like(z_init)
-
         for i in range(0, num_recycles + 1):
             enable_grad = self.training and i == num_recycles
             with torch.set_grad_enabled(enable_grad):
@@ -183,39 +238,38 @@ class Trunk(torch.nn.Module):
                 s = s_init + self.linear_s(self.layernorm_s(s))
                 z = z_init + self.linear_z(self.layernorm_z(z))
 
+                # Add sequence features
+                with torch.no_grad():
+                    x_prot, attn_prot = self.protein_sequence_encoder(
+                        f_input, mask_ratio=0.15
+                    )
+                s_plm = s_plm_init + self.proj_prot_seq(x_prot)
+                z = _add(z, self.proj_prot_seq_attn(attn_prot.flatten(-2)))
+                del x_prot, attn_prot
+
+                with torch.no_grad():
+                    x_rna, attn_rna = self.rna_sequence_encoder(f_input, mask_ratio=0.15)
+                s_plm = s_plm + self.proj_rna_seq(x_rna)
+                z = _add(z, self.proj_rna_seq_attn(attn_rna.flatten(-2)))
+                del x_rna, attn_rna
+
                 # Run trunk
-                s, z = self._run_trunk(s, z, s_inputs, plm_inputs, f_input)
+                z = plm_module(
+                    z,
+                    s_inputs,
+                    s_plm,
+                    f_input.token.asym_id,
+                    f_input.token.pad_mask,
+                    use_cuequiv_kernels=use_cuequiv_kernels,
+                )
+                s, z = pairformer_stack(
+                    s,
+                    z,
+                    f_input.token.pad_mask,
+                    use_cuequiv_kernels=use_cuequiv_kernels,
+                )
 
-        # Skip connection to s_trunk
-        s = s + self.proj_plm_to_s_trunk(plm_inputs)
+                # Skip connection to s_trunk
+                s = s + self.skip_plm_to_s(s_plm)
 
-        return s, z
-
-    def _run_trunk(
-        self,
-        s: torch.Tensor,
-        z: torch.Tensor,
-        s_inputs: torch.Tensor,
-        plm_inputs: torch.Tensor,
-        f_input: FoldingInput,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Run trunk body"""
-        # Revert to uncompiled version for validation
-        pairformer_stack = self.get_pairformer_stack()
-        plm_module = self.get_plm_module()
-        use_cuequiv_kernels = self.kernel_config.get("cuequivariance", False)
-        z = plm_module(
-            z,
-            s_inputs,
-            plm_inputs,
-            f_input.token.asym_id,
-            f_input.token.pad_mask,
-            use_cuequiv_kernels=use_cuequiv_kernels,
-        )
-        s, z = pairformer_stack(
-            s,
-            z,
-            f_input.token.pad_mask,
-            use_cuequiv_kernels=use_cuequiv_kernels,
-        )
         return s, z

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -184,7 +184,11 @@ class KFoldTrainingModule(pl.LightningModule):
         self.freeze_submodules()
 
         # Setup EMA
-        self.submodules_to_ignore_for_ema = ("sequence_encoder", "structure_encoder")
+        self.submodules_to_ignore_for_ema = (
+            "trunk.protein_sequence_encoder",
+            "trunk.rna_sequence_encoder",
+            "trunk.protein_structure_encoder",
+        )
         self.ema: ExponentialMovingAverage = ExponentialMovingAverage(
             model=self.model,
             decay=self.optimizer_config.ema_decay,
@@ -243,7 +247,7 @@ class KFoldTrainingModule(pl.LightningModule):
 
         self.frozen_modules = []
         if self.train_trunk is False:
-            self.frozen_modules += ["plm_input_embedder", "input_embedder", "trunk"]
+            self.frozen_modules += ["input_embedder", "trunk"]
 
         if self.train_distogram_head is False:
             self.frozen_modules += ["distogram_head"]
@@ -964,7 +968,9 @@ class KFoldTrainingModule(pl.LightningModule):
         checkpoint["state_dict"] = {
             k: v
             for k, v in checkpoint["state_dict"].items()
-            if "sequence_encoder" not in k and "structure_encoder" not in k
+            if "protein_sequence_encoder" not in k
+            and "rna_sequence_encoder" not in k
+            and "protein_structure_encoder" not in k
         }
 
         # Remove '._orig_mod.' from checkpoint keys


### PR DESCRIPTION
# Stochastic sequence masking per recycling & add rna seq encoder

## Summary
This Pull Request refactors the sequence and structure encoding architecture to support distinct encoders for proteins and RNA, implements **stochastic sequence masking per recycling step** in the main Trunk module, adds a new **RNA Sequence Encoder with Mixture of Experts (MoE)**, and updates the Exponential Moving Average (EMA) and checkpointing logics to be fully compatible with the new modular layout.

---

## Key Changes

### 1. Split & Renamed Encoders
* Replaced the unified `sequence_encoder` and `structure_encoder` with three distinct, dedicated modules:
  * `protein_sequence_encoder` (for protein sequences)
  * `rna_sequence_encoder` (for RNA sequences)
  * `protein_structure_encoder` (for protein structures)
* Added configuration YAML files mapping these new encoders to the model pipeline:
  * `configs/model/module/protein_sequence_encoder.yaml`
  * `configs/model/module/protein_structure_encoder.yaml`
  * `configs/model/module/rna_sequence_encoder.yaml`

### 2. Stochastic Sequence Masking per Recycling Step
* Reorganized the `Trunk` recycle loop (`src/kfold/model/modules/trunk.py`) to run sequence encoders with active gradient scaling only during the last recycling step, while stochastically masking sequence tokens inside the loop. (15%)
* The `protein_structure_encoder` is executed once *before* the recycle loop starts (without stochastic masking).

### 3. RNA Sequence Encoder & Mixture of Experts (MoE)
* Introduced a brand new `rna_sequence_encoder` targeting RNA token structures.
* Implemented a memory-efficient and vectorized **Mixture of Experts FFN** (`MoEFFN` in `src/kfold/model/layers/seq_enc/moe.py`) to scale the model capacity of the RNA sequence encoder.
* The routing uses top-k expert selection (default top-1) with soft dispatch and gather operations, leveraging bmm for high performance under compilation and mixed-precision training.

---

## File Diff Summary
* **Configs**: Updated model definitions and stage configurations (`configs/model/`, `configs/train-*.yaml`, `configs/train/stage_1.yaml`).
* **Layers**: Added `seq_enc/moe.py`, updated `seq_enc/blocks.py`, `seq_enc/transformer_stack.py`, and `folding/plm_module.py`.
* **Core Model & Training**: Refactored `src/kfold/model/model.py`, `src/kfold/model/modules/trunk.py`, `src/kfold/model/modules/sequence_encoder.py`, `src/kfold/model/modules/structure_encoder.py`, and `src/kfold/training/training_module.py`.
