### PR TITLE
Fast initialization

### DIFF
--- a/configs/model/module/protein_structure_encoder.yaml
+++ b/configs/model/module/protein_structure_encoder.yaml
@@ -1,9 +1,6 @@
 _registry_: "structure_encoder"
 _class_: "StructureEncoder"
 path: ???
-fa_tok_path: ???
-bb_tok_path: ???
-encoder_path: ???
 chain_type: 'protein'
 d_model: 2560
 n_heads: 33

--- a/src/kfold/model/layers/seq_enc/attention.py
+++ b/src/kfold/model/layers/seq_enc/attention.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from .nn import LayerNorm, Linear
 from .rotary import RotaryEmbedding
 
 
@@ -15,12 +16,12 @@ class MultiHeadAttention(nn.Module):
         self.d_head: int = self.d_model // self.n_heads
 
         self.layernorm_qkv = nn.Sequential(
-            nn.LayerNorm(d_model),
-            nn.Linear(d_model, d_model * 3, bias=False),
+            LayerNorm(d_model),
+            Linear(d_model, d_model * 3, bias=False),
         )
-        self.q_ln = nn.LayerNorm(d_model, bias=False)
-        self.k_ln = nn.LayerNorm(d_model, bias=False)
-        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        self.q_ln = LayerNorm(d_model, bias=False)
+        self.k_ln = LayerNorm(d_model, bias=False)
+        self.out_proj = Linear(d_model, d_model, bias=False)
 
         # Assume max sequence length of 20k, which is sufficient for most sequences.
         self.rotary = RotaryEmbedding(self.d_head, max_seqlen=20000)

--- a/src/kfold/model/layers/seq_enc/blocks.py
+++ b/src/kfold/model/layers/seq_enc/blocks.py
@@ -4,6 +4,7 @@ import torch.nn.functional as F
 
 from .attention import MultiHeadAttention
 from .moe import MoEFFN
+from .nn import LayerNorm, Linear
 
 
 class SwiGLU(nn.Module):
@@ -47,10 +48,10 @@ class TransformerBlock(nn.Module):
         else:
             d_ffn = swiglu_correction_fn(expansion_ratio, d_model)
             self.ffn = nn.Sequential(
-                nn.LayerNorm(d_model),
-                nn.Linear(d_model, d_ffn * 2, bias=False),
+                LayerNorm(d_model),
+                Linear(d_model, d_ffn * 2, bias=False),
                 SwiGLU(),
-                nn.Linear(d_ffn, d_model, bias=False),
+                Linear(d_ffn, d_model, bias=False),
             )
         self.scaling_factor: float = residue_scaling_factor
 

--- a/src/kfold/model/layers/seq_enc/moe.py
+++ b/src/kfold/model/layers/seq_enc/moe.py
@@ -1,8 +1,9 @@
 import math
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
+
+from .nn import LayerNorm, Linear
 
 
 def swiglu_correction_fn(expansion_ratio: float, d_model: int) -> int:
@@ -10,7 +11,7 @@ def swiglu_correction_fn(expansion_ratio: float, d_model: int) -> int:
     return int(((expansion_ratio * d_model) + 255) // 256 * 256)
 
 
-class MoEFFN(nn.Module):
+class MoEFFN(torch.nn.Module):
     """
     Sparse MoE FFN with optional shared experts (DeepSeek-MoE / Qwen-MoE style).
 
@@ -51,12 +52,12 @@ class MoEFFN(nn.Module):
         self.capacity_factor: float = capacity_factor
 
         # Pre-FFN LayerNorm (matches dense ffn structure)
-        self.norm = nn.LayerNorm(d_model)
+        self.norm = LayerNorm(d_model)
 
         # Router (no bias, as in Switch Transformer / Mixtral)
         # routing='modality': router is unused but kept as a no-op nn.Linear
         # so the module's state_dict layout stays stable across routing modes.
-        self.router = nn.Linear(d_model, self.num_routed, bias=False)
+        self.router = Linear(d_model, self.num_routed, bias=False)
 
         # Stacked routed expert weights — single big parameters for batched
         # bmm in the vectorized forward path. ffn_type='swiglu', bias=False:
@@ -65,10 +66,12 @@ class MoEFFN(nn.Module):
         #   w13: (E, 2h, d)   [first Linear]
         #   w2:  (E, d, h)    [second Linear]
         self.h_dim: int = swiglu_correction_fn(expansion_ratio, d_model)
-        self.w13_stacked = nn.Parameter(
+        self.w13_stacked = torch.nn.Parameter(
             torch.empty(self.num_routed, 2 * self.h_dim, d_model)
         )
-        self.w2_stacked = nn.Parameter(torch.empty(self.num_routed, d_model, self.h_dim))
+        self.w2_stacked = torch.nn.Parameter(
+            torch.empty(self.num_routed, d_model, self.h_dim)
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         orig_shape = x.shape

--- a/src/kfold/model/layers/seq_enc/nn.py
+++ b/src/kfold/model/layers/seq_enc/nn.py
@@ -1,0 +1,23 @@
+"""Basic layers without initialization"""
+
+import torch.nn as nn
+
+enable_init: bool = False
+
+
+class Linear(nn.Linear):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()
+
+
+class LayerNorm(nn.LayerNorm):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()
+
+
+class Embedding(nn.Embedding):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()

--- a/src/kfold/model/layers/seq_enc/transformer_stack.py
+++ b/src/kfold/model/layers/seq_enc/transformer_stack.py
@@ -3,6 +3,7 @@ import math
 import torch
 
 from .blocks import TransformerBlock
+from .nn import LayerNorm
 
 
 class TransformerStack(torch.nn.Module):
@@ -34,7 +35,7 @@ class TransformerStack(torch.nn.Module):
                 for _ in range(n_layers)
             ]
         )
-        self.norm = torch.nn.LayerNorm(d_model, bias=False)
+        self.norm = LayerNorm(d_model, bias=False)
 
     def forward(
         self,

--- a/src/kfold/model/layers/struct_enc/backbone.py
+++ b/src/kfold/model/layers/struct_enc/backbone.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 
+from .nn import Embedding, Linear
 from .transformer_layers import ESM1LayerNorm, TransformerLayer
 
 # From main non-JEPA training path: non-foldseek uses 4 special tokens.
@@ -30,15 +31,15 @@ class ProteinNetEncoder(nn.Module):
         self.bb_vocab_size = bb_vocab_size
         self.fa_vocab_size = fa_vocab_size
 
-        self.seq_embedding = nn.Embedding(seq_vocab_size, embed_dim)
-        self.bb_embedding = nn.Embedding(bb_vocab_size, embed_dim)
-        self.fa_embedding = nn.Embedding(fa_vocab_size, embed_dim)
+        self.seq_embedding = Embedding(seq_vocab_size, embed_dim)
+        self.bb_embedding = Embedding(bb_vocab_size, embed_dim)
+        self.fa_embedding = Embedding(fa_vocab_size, embed_dim)
         self.fuse_layer = nn.Sequential(
-            nn.Linear(embed_dim * 3, embed_dim),
+            Linear(embed_dim * 3, embed_dim),
             ESM1LayerNorm(embed_dim),
         )
 
-        self.chain_embedding = nn.Embedding(100, embed_dim)
+        self.chain_embedding = Embedding(100, embed_dim)
 
         self.encoder = nn.ModuleList(
             [

--- a/src/kfold/model/layers/struct_enc/nn.py
+++ b/src/kfold/model/layers/struct_enc/nn.py
@@ -1,0 +1,23 @@
+"""Basic layers without initialization"""
+
+import torch.nn as nn
+
+enable_init: bool = False
+
+
+class Linear(nn.Linear):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()
+
+
+class LayerNorm(nn.LayerNorm):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()
+
+
+class Embedding(nn.Embedding):
+    def reset_parameters(self) -> None:
+        if enable_init:
+            super().reset_parameters()

--- a/src/kfold/model/layers/struct_enc/transformer_layers.py
+++ b/src/kfold/model/layers/struct_enc/transformer_layers.py
@@ -23,12 +23,12 @@ disabled, so this lean version is byte-compatible for weight loading.
 import math
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
-from torch import Tensor
+
+from .nn import Linear
 
 
-def gelu(x: Tensor) -> Tensor:
+def gelu(x: torch.Tensor) -> torch.Tensor:
     """ESM2-style GELU — the *manual* `x * 0.5 * (1 + erf(x / sqrt(2)))`
     formula, matching the upstream training-time `layers.gelu`.
 
@@ -42,12 +42,12 @@ def gelu(x: Tensor) -> Tensor:
     return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
 
 
-def _rotate_half(x: Tensor) -> Tensor:
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
     x1, x2 = x.chunk(2, dim=-1)
     return torch.cat((-x2, x1), dim=-1)
 
 
-class RotaryEmbedding(nn.Module):
+class RotaryEmbedding(torch.nn.Module):
     """Rotary position embeddings (RoFormer, Su et al. 2021).
 
     Two entry points:
@@ -63,21 +63,14 @@ class RotaryEmbedding(nn.Module):
     def __init__(self, dim: int = 64):
         super().__init__()
         inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2).float() / dim))
-        # `persistent=True` matches the upstream training-time module, so
-        # `rot_emb.inv_freq` keys present in K-Fold checkpoints load
-        # without `unexpected_keys` complaints.
         self.register_buffer("inv_freq", inv_freq, persistent=True)
-
-        self._seq_len_cached: int | None = None
-        self._cos_cached: Tensor | None = None
-        self._sin_cached: Tensor | None = None
 
     def forward(
         self,
-        q: Tensor,
-        k: Tensor,
-        pos_id: Tensor,
-    ) -> tuple[Tensor, Tensor]:
+        q: torch.Tensor,
+        k: torch.Tensor,
+        pos_id: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         """Apply RoPE using explicit `[B, L]` position IDs (per-chain reset).
 
         q, k: `[B*H, L, head_dim]`
@@ -97,7 +90,7 @@ class RotaryEmbedding(nn.Module):
         return q, k
 
 
-class MultiheadAttention(nn.Module):
+class MultiheadAttention(torch.nn.Module):
     """Self-attention with rotary embeddings (always on).
 
     Lean port of the training-time `layers.MultiheadAttention`, restricted
@@ -129,10 +122,10 @@ class MultiheadAttention(nn.Module):
             raise ValueError("embed_dim must be divisible by num_heads")
 
         # Linear projections (names match upstream so state_dict loads).
-        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.k_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.v_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.q_proj = Linear(embed_dim, embed_dim, bias=bias)
+        self.out_proj = Linear(embed_dim, embed_dim, bias=bias)
 
         # bias_k / bias_v: not used at inference (kept None so state_dict
         # loading doesn't complain about extra keys — the training code
@@ -145,10 +138,10 @@ class MultiheadAttention(nn.Module):
 
     def forward(
         self,
-        x: Tensor,
-        seq_id: Tensor,
-        pos_id: Tensor,
-    ) -> Tensor:
+        x: torch.Tensor,
+        seq_id: torch.Tensor,
+        pos_id: torch.Tensor,
+    ) -> torch.Tensor:
         """
         x: [B, L, D]
         seq_id: [B, L] (bool or int)
@@ -184,7 +177,7 @@ class MultiheadAttention(nn.Module):
         return out
 
 
-class ESM1LayerNorm(nn.Module):
+class ESM1LayerNorm(torch.nn.Module):
     """Layer norm with ESM1 initialization (affine=True by default).
 
     Default `hidden_size=2560` matches the 3B encoder's `embed_dim` /
@@ -199,13 +192,13 @@ class ESM1LayerNorm(nn.Module):
         self.eps = eps
         self.affine = bool(affine)
         if self.affine:
-            self.weight = nn.Parameter(torch.ones(hidden_size))
-            self.bias = nn.Parameter(torch.zeros(hidden_size))
+            self.weight = torch.nn.Parameter(torch.ones(hidden_size))
+            self.bias = torch.nn.Parameter(torch.zeros(hidden_size))
         else:
             self.weight = None
             self.bias = None
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         dims = tuple(-(i + 1) for i in range(len(self.hidden_size)))
         means = x.mean(dims, keepdim=True)
         x_zeromean = x - means
@@ -216,7 +209,7 @@ class ESM1LayerNorm(nn.Module):
         return x
 
 
-class TransformerLayer(nn.Module):
+class TransformerLayer(torch.nn.Module):
     """ESM2-style pre-LN transformer block with rotary attention.
 
     Defaults match the 3B encoder block (`embed_dim=2560`,
@@ -237,8 +230,8 @@ class TransformerLayer(nn.Module):
 
         self.self_attn = MultiheadAttention(embed_dim, attention_heads)
         self.self_attn_layer_norm = ESM1LayerNorm(embed_dim)
-        self.fc1 = nn.Linear(embed_dim, ffn_embed_dim)
-        self.fc2 = nn.Linear(ffn_embed_dim, embed_dim)
+        self.fc1 = Linear(embed_dim, ffn_embed_dim)
+        self.fc2 = Linear(ffn_embed_dim, embed_dim)
         self.final_layer_norm = ESM1LayerNorm(embed_dim)
 
     def forward(

--- a/src/kfold/model/modules/structure_encoder.py
+++ b/src/kfold/model/modules/structure_encoder.py
@@ -43,10 +43,7 @@ class StructureEncoder(torch.nn.Module):
             Number of transformer layers.
         """
 
-        path: str | None = None
-        fa_tok_path: str | None = None
-        bb_tok_path: str | None = None
-        encoder_path: str | None = None
+        path: str
         chain_type: str = "protein"
         d_model: int = 2560
         n_layers: int = 33
@@ -59,26 +56,11 @@ class StructureEncoder(torch.nn.Module):
 
         # Create model components
         # TODO: replace to hf hub link.
-        if cfg.path is not None:
-            self.bb_tok = BackboneTokenizer().to(torch.bfloat16)
-            self.fa_tok = FullAtomTokenizer().to(torch.bfloat16)
-            self.encoder = ProteinNetEncoder().to(torch.bfloat16)
-            state_dict = torch.load(cfg.path, map_location="cpu")
-            self.load_state_dict(state_dict, strict=True)
-        else:
-            if cfg.fa_tok_path is None:
-                raise ValueError("fa_tok_path must be provided if path is not provided.")
-            if cfg.bb_tok_path is None:
-                raise ValueError("bb_tok_path must be provided if path is not provided.")
-            if cfg.encoder_path is None:
-                raise ValueError("encoder_path must be provided if path is not provided.")
-            self.bb_tok = BackboneTokenizer.from_pretrained(cfg.bb_tok_path)
-            self.fa_tok = FullAtomTokenizer.from_pretrained(cfg.fa_tok_path)
-            self.encoder = ProteinNetEncoder.from_pretrained(cfg.encoder_path)
-            # Set to bfloat16
-            self.bb_tok = self.bb_tok.to(torch.bfloat16)
-            self.fa_tok = self.fa_tok.to(torch.bfloat16)
-            self.encoder = self.encoder.to(torch.bfloat16)
+        self.bb_tok = BackboneTokenizer().to(torch.bfloat16)
+        self.fa_tok = FullAtomTokenizer().to(torch.bfloat16)
+        self.encoder = ProteinNetEncoder().to(torch.bfloat16)
+        state_dict = torch.load(cfg.path, map_location="cpu")
+        self.load_state_dict(state_dict, strict=True)
 
         # Set to eval mode
         self.eval()

--- a/src/kfold/utils/confidence_metrics.py
+++ b/src/kfold/utils/confidence_metrics.py
@@ -316,7 +316,7 @@ def compute_has_clash(
             ni, nj = chain_i.shape[0], chain_j.shape[0]
             if ni == 0 or nj == 0:
                 continue
-            d = (chain_i[:, None, :] - chain_j[None, :, :]).norm(-1)
+            d = (chain_i[:, None, :] - chain_j[None, :, :]).norm(dim=-1)
             n_clash = (d < threshold).sum().item()
             if n_clash > max_clash_num:
                 return True


### PR DESCRIPTION
This pull request refactors the model codebase to centralize basic layer definitions and standardize their usage across sequence and structure encoder modules. It introduces custom `Linear`, `LayerNorm`, and `Embedding` classes without initialization, and replaces direct calls to PyTorch's layers with these custom classes. Additionally, configuration and loading logic for the `structure_encoder` module is simplified to require only a single checkpoint path.

### Layer abstraction and usage (most important)

* Introduced custom `Linear`, `LayerNorm`, and `Embedding` classes in `src/kfold/model/layers/seq_enc/nn.py` and `src/kfold/model/layers/struct_enc/nn.py`, which override parameter initialization to allow toggling via the `enable_init` flag.
* Replaced all direct usages of `nn.Linear`, `nn.LayerNorm`, and `nn.Embedding` with the new custom classes throughout sequence encoder and structure encoder modules to skip weight initialization of billion scale models.

### Configuration and loading simplification

* Simplified the `structure_encoder` configuration to require only a single `path` for loading all components, removing the need for separate tokenizer and encoder paths. Corresponding logic for conditional loading based on multiple paths has been removed.

### Minor improvements and fixes

* Fixed a minor bug in `detect_clash` by explicitly specifying the `dim` argument in the `.norm()` call for clarity and correctness.
* Updated type annotations and class inheritance in structure encoder modules for consistency and improved clarity.

These changes improve maintainability, consistency, and clarity of the model codebase.