### PR TITLE
[codex] default analysis logging off for ECSI

### DIFF
--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -85,6 +85,7 @@ training:
   log_time_binned_losses: false
   time_bin_width: 0.1
   log_entity_binned_losses: false
+  log_monitor_norms: false
 
 validation:
   # Validation step hyperparameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
   # core dependencies
-  "torch",
+  "torch==2.11.0+cu128",
   "numpy",
   # additional dependencies
   "tqdm",
@@ -21,6 +21,16 @@ dependencies = [
   "einops",
   "gemmi",
 ]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cu128" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
 
 [project.optional-dependencies]
 cuequiv = [

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -111,6 +111,9 @@ class TrainingConfig(_Config):
     # Logs `train/{metric}_entity_interval{1..10}` where interval10 means >=10.
     log_entity_binned_losses: bool = False
 
+    # Logging: parameter and gradient norm monitor metrics.
+    log_monitor_norms: bool = False
+
 
 def _get_diffusion_time_for_binning(
     diffusion_out: dict[str, Any],
@@ -906,6 +909,8 @@ class KFoldTrainingModule(pl.LightningModule):
 
     # === Training logs === #
     def on_before_optimizer_step(self, optimizer) -> None:
+        if not self.training_config.log_monitor_norms:
+            return
         if self.trainer.global_step % 50 == 0:
             self.log_model_state()
 


### PR DESCRIPTION
## Summary

- Keep ECSI separate endpoint atom encoding active via `configs/model/kfold-ecsi.yaml`.
- Keep time-binned and entity-binned train loss logging default-off.
- Add a default-off `log_monitor_norms` switch so parameter/gradient norm monitor logging is opt-in.
- Add a small `_ai` spec documenting the scoped behavior and validation plan.

## Notes

I searched the tracked config/model/training code for diffusion-time-specific
trunk gradient propagation controls and did not find one. The existing
`diffusion_conditioning_drop_rate` is conditioning dropout, not a diffusion-time
gradient propagation option, so this PR does not remove ordinary trunk-to-
diffusion gradient flow.

This branch is based on `ecsi-dev-main`; relative to `origin/ecsi-dev-main` it
also includes the existing `deps: pin torch cu128 for ecsi dev` commit.

## Validation

- `git diff --check`
- `git diff --cached --check`

Tests were not run because this change only gates default logging behavior and
the project instruction says not to run tests unless explicitly requested.
