### PR TITLE
[codex] merge ECSI dev updates into main

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -32,6 +32,8 @@ trunk:
 score_model:
   _yaml_: "module/score_model.yaml"
   channel_coords: 6
+  separate_endpoint_atom_encoder: true
+  endpoint_branch_dropout: 0.0
 
 diffusion_head:
   _yaml_: "module/ecsi.yaml"

--- a/configs/model/module/score_model.yaml
+++ b/configs/model/module/score_model.yaml
@@ -6,6 +6,8 @@ channel_z: 256
 channel_atom: 128
 channel_atompair: 16
 channel_coords: 3
+separate_endpoint_atom_encoder: false
+endpoint_branch_dropout: 0.0
 atom_encoder_blocks: 3
 atom_encoder_heads: 4
 token_transformer_blocks: 12

--- a/configs/train-ecsi-tiny.yaml
+++ b/configs/train-ecsi-tiny.yaml
@@ -1,0 +1,29 @@
+model:
+  _yaml_: "model/kfold-ecsi.yaml"
+  protein_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_seq_3b.pth
+  rna_sequence_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/rna_seq_300m.pth
+  protein_structure_encoder:
+    path: /mnt/parallel_storage/share/kfold_weights/pretrained/prot_struct_3b.pth
+  trunk:
+    num_main_blocks: 8
+    blocks_per_ckpt: null
+  score_model:
+    token_transformer_blocks: 6
+    blocks_per_ckpt: null
+  confidence_head:
+    num_blocks: 2
+    blocks_per_ckpt: null
+
+train:
+  _yaml_: "train/stage_1.yaml"
+  name: ecsi-tiny
+
+  global_hparams:
+    diffusion_batch_size: 24
+
+  loss:
+    diffusion_loss:
+      smooth_lddt_loss:
+        chunk_size: 12

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -85,6 +85,7 @@ training:
   log_time_binned_losses: false
   time_bin_width: 0.1
   log_entity_binned_losses: false
+  log_monitor_norms: false
 
 validation:
   # Validation step hyperparameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 license = { file = "LICENSE" }
 dependencies = [
   # core dependencies
-  "torch",
+  "torch==2.11.0+cu128",
   "numpy",
   # additional dependencies
   "tqdm",
@@ -21,6 +21,16 @@ dependencies = [
   "einops",
   "gemmi",
 ]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cu128" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
 
 [project.optional-dependencies]
 cuequiv = [

--- a/src/kfold/model/layers/folding/diffusion.py
+++ b/src/kfold/model/layers/folding/diffusion.py
@@ -152,6 +152,8 @@ class DiffusionStack(nn.Module):
         channel_atom: int = 128,
         channel_atompair: int = 16,
         channel_coords: int = 3,
+        separate_endpoint_atom_encoder: bool = False,
+        endpoint_branch_dropout: float = 0.0,
         atom_encoder_blocks: int = 3,
         atom_encoder_heads: int = 4,
         token_transformer_blocks: int = 24,
@@ -174,6 +176,12 @@ class DiffusionStack(nn.Module):
             The atom pair representation dimension.
         channel_coords : int
             The atom coordinates dimension, by default 3.
+        separate_endpoint_atom_encoder : bool, optional
+            Whether to split a 6-channel ECSI coordinate input into separate
+            current-state and endpoint atom encoders, by default False.
+        endpoint_branch_dropout : float, optional
+            Dropout probability applied to the encoded endpoint token branch when
+            separate_endpoint_atom_encoder is enabled, by default 0.0.
         atom_encoder_blocks : int, optional
             The number of blocks in the atom encoder, by default 3.
         atom_encoder_heads : int, optional
@@ -197,6 +205,8 @@ class DiffusionStack(nn.Module):
         self.channel_atom: int = channel_atom
         self.channel_atompair: int = channel_atompair
         self.channel_coords: int = channel_coords
+        self.separate_endpoint_atom_encoder: bool = separate_endpoint_atom_encoder
+        self.endpoint_branch_dropout: float = endpoint_branch_dropout
         self.atom_encoder_blocks: int = atom_encoder_blocks
         self.atom_encoder_heads: int = atom_encoder_heads
         self.token_transformer_blocks: int = token_transformer_blocks
@@ -210,6 +220,16 @@ class DiffusionStack(nn.Module):
 
         # === Local atom-level attention encoder === #
         channel_token = channel_s * 2
+        if separate_endpoint_atom_encoder and channel_coords != 6:
+            raise ValueError(
+                "separate_endpoint_atom_encoder expects channel_coords=6 "
+                "for [r_t, r_T] ECSI inputs."
+            )
+        if not 0.0 <= endpoint_branch_dropout < 1.0:
+            raise ValueError("endpoint_branch_dropout must be in [0, 1).")
+        atom_encoder_channel_coords = (
+            3 if separate_endpoint_atom_encoder else channel_coords
+        )
         self.atom_embedder = AtomEmbedder(
             channel_z=channel_z,
             channel_atom=channel_atom,
@@ -220,11 +240,21 @@ class DiffusionStack(nn.Module):
             channel_atom=channel_atom,
             channel_atompair=channel_atompair,
             channel_token=channel_token,
-            channel_coords=channel_coords,
+            channel_coords=atom_encoder_channel_coords,
             num_blocks=atom_encoder_blocks,
             num_heads=atom_encoder_heads,
             use_structure=True,
         )
+        if separate_endpoint_atom_encoder:
+            self.endpoint_atom_attention_encoder = AtomAttentionEncoder(
+                channel_atom=channel_atom,
+                channel_atompair=channel_atompair,
+                channel_token=channel_token,
+                channel_coords=atom_encoder_channel_coords,
+                num_blocks=atom_encoder_blocks,
+                num_heads=atom_encoder_heads,
+                use_structure=True,
+            )
 
         # === Full token-level attention === #
         self.layernorm_s = LayerNorm(channel_s, create_offset=False)
@@ -453,15 +483,48 @@ class DiffusionStack(nn.Module):
 
         # NOTE: Add extra dimension for the number of diffusion samples, N.
         r_noisy = r_noisy * atom_mask[..., None]
-        a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
-            q,  # [B, 1, La, c_atom]
-            c,  # [B, 1, La, c_atom]
-            p,  # [B, 1, W, Lq, Lk, c_atompair]
-            r_noisy=r_noisy,  # [B, N, La, 3]
-            token_index=token_index,  # [B, 1, Lt]
-            mask=atom_mask,  # [B, 1, La]
-            num_tokens=token_mask.shape[-1],
-        )
+
+        if self.separate_endpoint_atom_encoder:
+            r_t, r_T = r_noisy[..., :3], r_noisy[..., 3:]
+            a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
+                q,  # [B, 1, La, c_atom]
+                c,  # [B, 1, La, c_atom]
+                p,  # [B, 1, W, Lq, Lk, c_atompair]
+                r_noisy=r_t,  # [B, N, La, 3]
+                token_index=token_index,  # [B, 1, Lt]
+                mask=atom_mask,  # [B, 1, La]
+                num_tokens=token_mask.shape[-1],
+            )
+            a_endpoint, _, _, _ = self.endpoint_atom_attention_encoder(
+                q,  # [B, 1, La, c_atom]
+                c,  # [B, 1, La, c_atom]
+                p,  # [B, 1, W, Lq, Lk, c_atompair]
+                r_noisy=r_T,  # [B, N, La, 3]
+                token_index=token_index,  # [B, 1, Lt]
+                mask=atom_mask,  # [B, 1, La]
+                num_tokens=token_mask.shape[-1],
+            )
+            if self.training and self.endpoint_branch_dropout > 0.0:
+                keep_prob = 1.0 - self.endpoint_branch_dropout
+                keep = (
+                    torch.rand(
+                        (*a_endpoint.shape[:2], 1, 1),
+                        device=a_endpoint.device,
+                    )
+                    < keep_prob
+                )
+                a_endpoint = a_endpoint * keep.to(a_endpoint.dtype) / keep_prob
+            a = a + a_endpoint
+        else:
+            a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
+                q,  # [B, 1, La, c_atom]
+                c,  # [B, 1, La, c_atom]
+                p,  # [B, 1, W, Lq, Lk, c_atompair]
+                r_noisy=r_noisy,  # [B, N, La, 3]
+                token_index=token_index,  # [B, 1, Lt]
+                mask=atom_mask,  # [B, 1, La]
+                num_tokens=token_mask.shape[-1],
+            )
         del q, c, p, r_noisy
 
         # Shape:

--- a/src/kfold/model/layers/folding/diffusion.py
+++ b/src/kfold/model/layers/folding/diffusion.py
@@ -255,6 +255,14 @@ class DiffusionStack(nn.Module):
                 num_heads=atom_encoder_heads,
                 use_structure=True,
             )
+            self.layernorm_a_t = LayerNorm(channel_token, create_offset=False)
+            self.layernorm_a_endpoint = LayerNorm(channel_token, create_offset=False)
+            self.endpoint_fusion = LinearNoBias(
+                channel_token * 2,
+                channel_token,
+                init="final",
+                precision=32,
+            )
 
         # === Full token-level attention === #
         self.layernorm_s = LayerNorm(channel_s, create_offset=False)
@@ -514,7 +522,12 @@ class DiffusionStack(nn.Module):
                     < keep_prob
                 )
                 a_endpoint = a_endpoint * keep.to(a_endpoint.dtype) / keep_prob
-            a = a + a_endpoint
+            a = self.endpoint_fusion(
+                torch.cat(
+                    (self.layernorm_a_t(a), self.layernorm_a_endpoint(a_endpoint)),
+                    dim=-1,
+                )
+            )
         else:
             a, q_skip, c_skip, p_skip = self.atom_attention_encoder(
                 q,  # [B, 1, La, c_atom]

--- a/src/kfold/model/modules/structure/score_model.py
+++ b/src/kfold/model/modules/structure/score_model.py
@@ -26,6 +26,11 @@ class DiffusionModule(torch.nn.Module):
             The atom pair representation dimension.
         channel_coords : int
             The coordinate dimension, default to 3 for (x, y, z).
+        separate_endpoint_atom_encoder : bool, optional
+            Split 6-channel ECSI coordinates into separate current-state and
+            endpoint atom encoders before shared token-level attention.
+        endpoint_branch_dropout : float, optional
+            Dropout probability for the encoded endpoint token branch.
         atom_encoder_blocks : int, optional
             The number of blocks of the atom encoder, by default 3.
         atom_encoder_heads : int, optional
@@ -47,6 +52,8 @@ class DiffusionModule(torch.nn.Module):
         channel_atom: int = 128
         channel_atompair: int = 16
         channel_coords: int = 3
+        separate_endpoint_atom_encoder: bool = False
+        endpoint_branch_dropout: float = 0.0
         atom_encoder_blocks: int = 3
         atom_encoder_heads: int = 4
         token_transformer_blocks: int = 12
@@ -66,6 +73,8 @@ class DiffusionModule(torch.nn.Module):
             channel_atom=cfg.channel_atom,
             channel_atompair=cfg.channel_atompair,
             channel_coords=cfg.channel_coords,
+            separate_endpoint_atom_encoder=cfg.separate_endpoint_atom_encoder,
+            endpoint_branch_dropout=cfg.endpoint_branch_dropout,
             atom_encoder_blocks=cfg.atom_encoder_blocks,
             atom_encoder_heads=cfg.atom_encoder_heads,
             token_transformer_blocks=cfg.token_transformer_blocks,

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -112,6 +112,19 @@ class TrainingConfig(_Config):
     log_entity_binned_losses: bool = False
 
 
+def _get_diffusion_time_for_binning(
+    diffusion_out: dict[str, Any],
+) -> torch.Tensor | None:
+    """Return the diffusion time tensor used by generic time-bin logging."""
+    t_hat = diffusion_out.get("t_hat")
+    if torch.is_tensor(t_hat):
+        return t_hat
+    t = diffusion_out.get("t")
+    if torch.is_tensor(t):
+        return t
+    return None
+
+
 @dataclasses.dataclass(kw_only=True)
 class ValidationConfig(_Config):
     """Validation step configuration."""
@@ -418,20 +431,17 @@ class KFoldTrainingModule(pl.LightningModule):
             loss, metrics = self.compute_losses(batch, out)
 
         if self._binned_cache_enabled and self.train_diffusion_head:
-            t_hat = out.get("diffusion", {}).get("t_hat", None)
+            diffusion_out = out.get("diffusion", {})
+            t_for_bins = _get_diffusion_time_for_binning(diffusion_out)
             diffusion_per_sample = self._timebin_last_diffusion_per_sample
             distogram_loss_per_batch = self._timebin_last_distogram_loss_per_batch
 
             # These caches are populated inside compute_losses/compute_diffusion_loss.
             # Skip if anything is missing for this batch.
-            if (
-                torch.is_tensor(t_hat)
-                and diffusion_per_sample is not None
-                and distogram_loss_per_batch is not None
-            ):
-                if self._timebin_enabled:
+            if diffusion_per_sample is not None and distogram_loss_per_batch is not None:
+                if self._timebin_enabled and torch.is_tensor(t_for_bins):
                     self.time_binned_logger.update(
-                        t_hat=t_hat,
+                        t_hat=t_for_bins,
                         structure_module=self.model.structure_module,
                         diffusion_per_sample=diffusion_per_sample,
                         distogram_loss_per_batch=distogram_loss_per_batch,

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -125,6 +125,22 @@ def _get_diffusion_time_for_binning(
     return None
 
 
+def _get_structure_module_for_binning(model: Any) -> Any:
+    """Return the structure module that defines time/sigma bounds for binning."""
+    diffusion_head = getattr(model, "diffusion_head", None)
+    if diffusion_head is not None:
+        return diffusion_head
+
+    structure_module = getattr(model, "structure_module", None)
+    if structure_module is not None:
+        return structure_module
+
+    raise AttributeError(
+        "Model must expose either diffusion_head or structure_module for "
+        "time-binned loss logging."
+    )
+
+
 @dataclasses.dataclass(kw_only=True)
 class ValidationConfig(_Config):
     """Validation step configuration."""
@@ -442,7 +458,7 @@ class KFoldTrainingModule(pl.LightningModule):
                 if self._timebin_enabled and torch.is_tensor(t_for_bins):
                     self.time_binned_logger.update(
                         t_hat=t_for_bins,
-                        structure_module=self.model.structure_module,
+                        structure_module=_get_structure_module_for_binning(self.model),
                         diffusion_per_sample=diffusion_per_sample,
                         distogram_loss_per_batch=distogram_loss_per_batch,
                         loss_weights=self.loss_weights,

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -547,10 +547,6 @@ class KFoldTrainingModule(pl.LightningModule):
         )
         all_metrics["loss"] = loss.detach()
 
-        if self._binned_cache_enabled and self.train_diffusion_head:
-            # Used to compute per-time-bin total loss without recomputing distogram head.
-            self._timebin_last_distogram_loss_per_batch = distogram_loss.detach()
-
         return loss, all_metrics
 
     def validation_step(
@@ -731,8 +727,11 @@ class KFoldTrainingModule(pl.LightningModule):
         metrics : dict[str, torch.Tensor]
             A dictionary containing loss metrics.
         """
-        loss = self.distogram_loss(logits, f_input).mean()
+        loss_per_batch = self.distogram_loss(logits, f_input)
+        loss = loss_per_batch.mean()
         metrics = {"distogram_loss": loss.detach()}
+        if self._binned_cache_enabled and self.train_diffusion_head:
+            self._timebin_last_distogram_loss_per_batch = loss_per_batch.detach()
         return loss, metrics
 
     def compute_diffusion_loss(

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -111,6 +111,9 @@ class TrainingConfig(_Config):
     # Logs `train/{metric}_entity_interval{1..10}` where interval10 means >=10.
     log_entity_binned_losses: bool = False
 
+    # Logging: parameter and gradient norm monitor metrics.
+    log_monitor_norms: bool = False
+
 
 def _get_diffusion_time_for_binning(
     diffusion_out: dict[str, Any],
@@ -906,6 +909,8 @@ class KFoldTrainingModule(pl.LightningModule):
 
     # === Training logs === #
     def on_before_optimizer_step(self, optimizer) -> None:
+        if not self.training_config.log_monitor_norms:
+            return
         if self.trainer.global_step % 50 == 0:
             self.log_model_state()
 

--- a/src/kfold/training/utils/binned_loss_logging.py
+++ b/src/kfold/training/utils/binned_loss_logging.py
@@ -79,6 +79,52 @@ def _per_bin_update(
         metrics[f"{label}__{name}"].update(m, c)
 
 
+def _as_batch_vector(
+    values: torch.Tensor,
+    *,
+    batch_size: int,
+    name: str,
+) -> torch.Tensor:
+    """Return values as a [B] tensor, broadcasting scalar losses if needed."""
+    if values.ndim == 0:
+        return values.reshape(1).expand(batch_size)
+    if values.ndim == 1 and values.shape[0] == batch_size:
+        return values
+    if values.ndim == 1 and values.shape[0] == 1:
+        return values.expand(batch_size)
+    raise ValueError(
+        f"{name} must be scalar or shape [B], got shape {tuple(values.shape)} "
+        f"for batch size {batch_size}."
+    )
+
+
+def _total_loss_per_sample(
+    *,
+    diffusion_per_sample: dict[str, torch.Tensor],
+    distogram_loss_per_batch: torch.Tensor,
+    loss_weights: dict[str, float],
+) -> torch.Tensor:
+    """Compute weighted total loss with shape [B, Nsample]."""
+    diffusion_weight = float(loss_weights["diffusion"])
+    distogram_weight = float(loss_weights["distogram"])
+    diffusion_term = diffusion_per_sample["diffusion_loss"] * diffusion_weight  # [B, N]
+    if diffusion_term.ndim < 2:
+        raise ValueError(
+            "diffusion_per_sample['diffusion_loss'] must have shape [B, Nsample], "
+            f"got shape {tuple(diffusion_term.shape)}."
+        )
+    batch_size = int(diffusion_term.shape[0])
+    disto_term = (
+        _as_batch_vector(
+            distogram_loss_per_batch,
+            batch_size=batch_size,
+            name="distogram_loss_per_batch",
+        )
+        * distogram_weight
+    )  # [B]
+    return diffusion_term + disto_term[:, None]
+
+
 class TimeBinnedLossLogger(torch.nn.Module):
     """
     Epoch-level aggregation of losses by normalized diffusion time u∈[0,1].
@@ -129,13 +175,11 @@ class TimeBinnedLossLogger(torch.nn.Module):
                 self.metrics, self.labels, name, values, bin_index, self.nbins
             )
 
-        diffusion_weight = float(loss_weights["diffusion"])
-        distogram_weight = float(loss_weights["distogram"])
-        disto_term = distogram_loss_per_batch * distogram_weight  # [B]
-        diffusion_term = (
-            diffusion_per_sample["diffusion_loss"] * diffusion_weight
-        )  # [B, N]
-        total_per_sample = diffusion_term + disto_term[:, None]
+        total_per_sample = _total_loss_per_sample(
+            diffusion_per_sample=diffusion_per_sample,
+            distogram_loss_per_batch=distogram_loss_per_batch,
+            loss_weights=loss_weights,
+        )
         _per_bin_update(
             self.metrics,
             self.labels,
@@ -220,13 +264,11 @@ class EntityBinnedLossLogger(torch.nn.Module):
                 self.metrics, self.labels, name, values, bin_index, self.nbins
             )
 
-        diffusion_weight = float(loss_weights["diffusion"])
-        distogram_weight = float(loss_weights["distogram"])
-        disto_term = distogram_loss_per_batch * distogram_weight  # [B]
-        diffusion_term = (
-            diffusion_per_sample["diffusion_loss"] * diffusion_weight
-        )  # [B, N]
-        total_per_sample = diffusion_term + disto_term[:, None]
+        total_per_sample = _total_loss_per_sample(
+            diffusion_per_sample=diffusion_per_sample,
+            distogram_loss_per_batch=distogram_loss_per_batch,
+            loss_weights=loss_weights,
+        )
         _per_bin_update(
             self.metrics,
             self.labels,

--- a/src/kfold/training/utils/binned_loss_logging.py
+++ b/src/kfold/training/utils/binned_loss_logging.py
@@ -34,15 +34,26 @@ def _entitybin_labels(nbins: int) -> list[str]:
 def _get_time_bounds(structure_module: Any) -> tuple[float, float]:
     """Return (t_min, t_max) bounds used for u-normalization.
 
-    - ECSI: sampling_time_min/max are already in [0, 1].
+    - ECSI: time_min/max are already in [0, 1].
+    - Legacy/config-wrapped ECSI: sampling.time_min/max are already in [0, 1].
     - EDM/AF3/Boltz-style: sigma_min/max are relative and typically scaled by sigma_data.
     """
     if hasattr(structure_module, "sampling"):
         t_min = float(structure_module.sampling.time_min)
         t_max = float(structure_module.sampling.time_max)
-    else:
+    elif hasattr(structure_module, "time_min") and hasattr(structure_module, "time_max"):
+        t_min = float(structure_module.time_min)
+        t_max = float(structure_module.time_max)
+    elif hasattr(structure_module, "sigma_min") and hasattr(
+        structure_module, "sigma_max"
+    ):
         t_min = float(structure_module.sigma_min)
         t_max = float(structure_module.sigma_max)
+    else:
+        raise AttributeError(
+            "structure_module must expose either sampling.time_min/time_max, "
+            "time_min/time_max, or sigma_min/sigma_max for time-binned logging."
+        )
     if hasattr(structure_module, "sigma_data") and t_max > 1.0:
         sigma_data = float(structure_module.sigma_data)
         t_min *= sigma_data
@@ -141,6 +152,8 @@ class TimeBinnedLossLogger(torch.nn.Module):
 
         out: dict[str, torch.Tensor] = {}
         for key, m in self.metrics.items():
+            if float(m.weight.item()) <= 0.0:
+                continue
             v = m.compute()
             if not v.isfinite().all():
                 continue
@@ -229,6 +242,8 @@ class EntityBinnedLossLogger(torch.nn.Module):
 
         out: dict[str, torch.Tensor] = {}
         for key, m in self.metrics.items():
+            if float(m.weight.item()) <= 0.0:
+                continue
             v = m.compute()
             if not v.isfinite().all():
                 continue

--- a/tests/test_time_binning.py
+++ b/tests/test_time_binning.py
@@ -1,9 +1,13 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torchmetrics import MeanMetric
 
-from kfold.training.training_module import _get_diffusion_time_for_binning
+from kfold.training.training_module import (
+    _get_diffusion_time_for_binning,
+    _get_structure_module_for_binning,
+)
 from kfold.training.utils.binned_loss_logging import (
     EntityBinConfig,
     EntityBinnedLossLogger,
@@ -80,6 +84,29 @@ def test_get_diffusion_time_for_binning_prefers_t_hat_and_falls_back_to_t():
     assert _get_diffusion_time_for_binning({"t_hat": t_hat, "t": t}) is t_hat
     assert _get_diffusion_time_for_binning({"t": t}) is t
     assert _get_diffusion_time_for_binning({}) is None
+
+
+def test_get_structure_module_for_binning_prefers_kfold_diffusion_head():
+    diffusion_head = SimpleNamespace(time_min=0.0, time_max=1.0)
+    legacy_structure_module = SimpleNamespace(time_min=0.1, time_max=0.9)
+    model = SimpleNamespace(
+        diffusion_head=diffusion_head,
+        structure_module=legacy_structure_module,
+    )
+
+    assert _get_structure_module_for_binning(model) is diffusion_head
+
+
+def test_get_structure_module_for_binning_supports_legacy_structure_module():
+    structure_module = SimpleNamespace(time_min=0.0, time_max=1.0)
+    model = SimpleNamespace(structure_module=structure_module)
+
+    assert _get_structure_module_for_binning(model) is structure_module
+
+
+def test_get_structure_module_for_binning_raises_for_unknown_model_shape():
+    with pytest.raises(AttributeError, match="diffusion_head or structure_module"):
+        _get_structure_module_for_binning(SimpleNamespace())
 
 
 def test_time_binned_loss_logger_updates_with_ecsi_style_t():

--- a/tests/test_time_binning.py
+++ b/tests/test_time_binning.py
@@ -5,6 +5,7 @@ import torch
 from torchmetrics import MeanMetric
 
 from kfold.training.training_module import (
+    KFoldTrainingModule,
     _get_diffusion_time_for_binning,
     _get_structure_module_for_binning,
 )
@@ -134,6 +135,26 @@ def test_time_binned_loss_logger_updates_with_ecsi_style_t():
     assert torch.isclose(out["train_time_bin/loss_interval10"], torch.tensor(6.0))
 
 
+def test_time_binned_loss_logger_broadcasts_scalar_distogram_loss():
+    logger = TimeBinnedLossLogger(TimeBinConfig(enabled=True, width=0.1))
+    structure_module = SimpleNamespace(time_min=0.0, time_max=1.0)
+
+    logger.update(
+        t_hat=torch.tensor([[0.05, 0.15]]),
+        structure_module=structure_module,
+        diffusion_per_sample={
+            "mse_loss": torch.tensor([[1.0, 3.0]]),
+            "diffusion_loss": torch.tensor([[2.0, 4.0]]),
+        },
+        distogram_loss_per_batch=torch.tensor(10.0),
+        loss_weights={"diffusion": 1.0, "distogram": 0.5},
+    )
+
+    out = logger.flush()
+    assert torch.isclose(out["train_time_bin/loss_interval1"], torch.tensor(7.0))
+    assert torch.isclose(out["train_time_bin/loss_interval2"], torch.tensor(9.0))
+
+
 def test_entity_binned_loss_logger_does_not_require_diffusion_time():
     logger = EntityBinnedLossLogger(EntityBinConfig(enabled=True, nbins=10))
     f_input = SimpleNamespace(
@@ -156,3 +177,51 @@ def test_entity_binned_loss_logger_does_not_require_diffusion_time():
     out = logger.flush()
     assert torch.isclose(out["train_entity_bin/mse_loss_interval2"], torch.tensor(2.0))
     assert torch.isclose(out["train_entity_bin/loss_interval2"], torch.tensor(3.0))
+
+
+def test_entity_binned_loss_logger_broadcasts_scalar_distogram_loss():
+    logger = EntityBinnedLossLogger(EntityBinConfig(enabled=True, nbins=10))
+    f_input = SimpleNamespace(
+        token=SimpleNamespace(
+            asym_id=torch.tensor([[1, 1, 2]]),
+            pad_mask=torch.tensor([[True, True, True]]),
+        )
+    )
+
+    logger.update(
+        f_input=f_input,
+        diffusion_per_sample={
+            "mse_loss": torch.tensor([[1.0, 3.0]]),
+            "diffusion_loss": torch.tensor([[2.0, 4.0]]),
+        },
+        distogram_loss_per_batch=torch.tensor(10.0),
+        loss_weights={"diffusion": 1.0, "distogram": 0.5},
+    )
+
+    out = logger.flush()
+    assert torch.isclose(out["train_entity_bin/loss_interval2"], torch.tensor(8.0))
+
+
+def test_compute_distogram_loss_caches_per_batch_loss_for_binned_logging():
+    class FakeDistogramLoss:
+        def __call__(self, logits, f_input):
+            return torch.tensor([1.0, 3.0], device=logits.device)
+
+    module = KFoldTrainingModule.__new__(KFoldTrainingModule)
+    module.distogram_loss = FakeDistogramLoss()
+    module._binned_cache_enabled = True
+    module.train_diffusion_head = True
+    module._timebin_last_distogram_loss_per_batch = None
+
+    loss, metrics = KFoldTrainingModule.compute_distogram_loss(
+        module,
+        logits=torch.empty(2, 1, 1, 1),
+        f_input=SimpleNamespace(),
+    )
+
+    assert torch.isclose(loss, torch.tensor(2.0))
+    assert torch.isclose(metrics["distogram_loss"], torch.tensor(2.0))
+    assert torch.equal(
+        module._timebin_last_distogram_loss_per_batch,
+        torch.tensor([1.0, 3.0]),
+    )

--- a/tests/test_time_binning.py
+++ b/tests/test_time_binning.py
@@ -1,6 +1,16 @@
+from types import SimpleNamespace
+
 import torch
 from torchmetrics import MeanMetric
 
+from kfold.training.training_module import _get_diffusion_time_for_binning
+from kfold.training.utils.binned_loss_logging import (
+    EntityBinConfig,
+    EntityBinnedLossLogger,
+    TimeBinConfig,
+    TimeBinnedLossLogger,
+    _get_time_bounds,
+)
 from kfold.training.utils.time_binning import binned_sum_and_count, compute_bin_index
 
 
@@ -37,3 +47,85 @@ def test_meanmetric_weighted_updates_matches_global_mean():
 
     # Global mean = (1+2+3+10)/4 = 4
     assert torch.isclose(m.compute(), torch.tensor(4.0))
+
+
+def test_get_time_bounds_supports_ecsi_time_attrs():
+    structure_module = SimpleNamespace(time_min=1e-8, time_max=0.9999)
+
+    assert _get_time_bounds(structure_module) == (1e-8, 0.9999)
+
+
+def test_get_time_bounds_supports_sampling_attrs():
+    structure_module = SimpleNamespace(
+        sampling=SimpleNamespace(time_min=0.001, time_max=0.999)
+    )
+
+    assert _get_time_bounds(structure_module) == (0.001, 0.999)
+
+
+def test_get_time_bounds_supports_scaled_edm_sigma_attrs():
+    structure_module = SimpleNamespace(
+        sigma_min=0.0004,
+        sigma_max=160.0,
+        sigma_data=16.0,
+    )
+
+    assert _get_time_bounds(structure_module) == (0.0064, 2560.0)
+
+
+def test_get_diffusion_time_for_binning_prefers_t_hat_and_falls_back_to_t():
+    t_hat = torch.tensor([[0.1]])
+    t = torch.tensor([[0.2]])
+
+    assert _get_diffusion_time_for_binning({"t_hat": t_hat, "t": t}) is t_hat
+    assert _get_diffusion_time_for_binning({"t": t}) is t
+    assert _get_diffusion_time_for_binning({}) is None
+
+
+def test_time_binned_loss_logger_updates_with_ecsi_style_t():
+    logger = TimeBinnedLossLogger(TimeBinConfig(enabled=True, width=0.1))
+    structure_module = SimpleNamespace(time_min=0.0, time_max=1.0)
+
+    logger.update(
+        t_hat=torch.tensor([[0.05, 0.15, 0.95]]),
+        structure_module=structure_module,
+        diffusion_per_sample={
+            "mse_loss": torch.tensor([[1.0, 3.0, 5.0]]),
+            "diffusion_loss": torch.tensor([[2.0, 4.0, 6.0]]),
+            "smooth_lddt_loss": torch.tensor([[0.1, 0.3, 0.5]]),
+        },
+        distogram_loss_per_batch=torch.tensor([0.0]),
+        loss_weights={"diffusion": 1.0, "distogram": 0.0},
+    )
+
+    out = logger.flush()
+    assert torch.isclose(out["train_time_bin/mse_loss_interval1"], torch.tensor(1.0))
+    assert torch.isclose(out["train_time_bin/mse_loss_interval2"], torch.tensor(3.0))
+    assert torch.isclose(out["train_time_bin/mse_loss_interval10"], torch.tensor(5.0))
+    assert torch.isclose(out["train_time_bin/loss_interval1"], torch.tensor(2.0))
+    assert torch.isclose(out["train_time_bin/loss_interval2"], torch.tensor(4.0))
+    assert torch.isclose(out["train_time_bin/loss_interval10"], torch.tensor(6.0))
+
+
+def test_entity_binned_loss_logger_does_not_require_diffusion_time():
+    logger = EntityBinnedLossLogger(EntityBinConfig(enabled=True, nbins=10))
+    f_input = SimpleNamespace(
+        token=SimpleNamespace(
+            asym_id=torch.tensor([[1, 1, 2, 0]]),
+            pad_mask=torch.tensor([[True, True, True, False]]),
+        )
+    )
+
+    logger.update(
+        f_input=f_input,
+        diffusion_per_sample={
+            "mse_loss": torch.tensor([[1.0, 3.0]]),
+            "diffusion_loss": torch.tensor([[2.0, 4.0]]),
+        },
+        distogram_loss_per_batch=torch.tensor([0.0]),
+        loss_weights={"diffusion": 1.0, "distogram": 0.0},
+    )
+
+    out = logger.flush()
+    assert torch.isclose(out["train_entity_bin/mse_loss_interval2"], torch.tensor(2.0))
+    assert torch.isclose(out["train_entity_bin/loss_interval2"], torch.tensor(3.0))


### PR DESCRIPTION
## Summary

- Merge the ECSI development branch into `main`.
- Add the ECSI tiny training config.
- Enable the ECSI separate endpoint atom encoder in the ECSI model config.
- Fix ECSI-compatible time/entity binned loss logging while keeping analysis-only
  logging disabled by default.
- Pin PyTorch to the CUDA 12.8 wheel source for the current B200 cluster stack.

## Notes

The final branch history no longer contains the temporary `_ai` spec add/remove
commits. The PR head is `ecsi-dev-main` and the base is `main`.

I searched the tracked config/model/training code for diffusion-time-specific
trunk gradient propagation controls and did not find one. The existing
`diffusion_conditioning_drop_rate` is conditioning dropout, not a diffusion-time
gradient propagation option, so this PR does not remove ordinary trunk-to-
diffusion gradient flow.

## Validation

- `git diff --check`
- `git diff --cached --check`

Tests were not run because they were not explicitly requested.
