### PR TITLE
Add ECSI patch-distogram supervision

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -44,6 +44,19 @@ distogram_head:
 confidence_head:
   _yaml_: "module/confidence_head.yaml"
 
+patch_pair_geometry:
+  enabled: false
+  channel_z: 256
+  num_bins: 64
+  min_dist: 2.0
+  max_dist: 22.0
+  patch_size: 16
+  max_patches_per_chain: 8
+  max_patch_pairs: 256
+  interface_cutoff: 12.0
+  positive_cutoff: 12.0
+  hard_negative_cutoff: 22.0
+
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2
 confidence_conditioning_drop_rate: 0.2

--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -45,7 +45,7 @@ confidence_head:
   _yaml_: "module/confidence_head.yaml"
 
 patch_pair_geometry:
-  enabled: false
+  enabled: true
   channel_z: 256
   num_bins: 64
   min_dist: 2.0

--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -55,7 +55,7 @@ patch_pair_geometry:
   max_patch_pairs: 256
   interface_cutoff: 12.0
   positive_cutoff: 12.0
-  hard_negative_cutoff: 22.0
+  hard_negative_cutoff: 18.0
 
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -129,12 +129,22 @@ loss:
     chain_com: 0.0
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     smooth_lddt: 1.0
+    patch_geometry: 3e-2
 
   # Distogram loss
   distogram_loss:
     num_bins: 64
     min_dist: 2.0
     max_dist: 22.0
+
+  # Patch-pair COM geometry auxiliary loss.
+  # This is inert unless model.patch_pair_geometry.enabled=true.
+  patch_geometry_loss:
+    num_bins: 64
+    min_dist: 2.0
+    max_dist: 22.0
+    near_cutoff: 12.0
+    hard_negative_weight: 1.0
 
   # Diffusion loss
   diffusion_loss:

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -129,7 +129,7 @@ loss:
     chain_com: 0.0
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     smooth_lddt: 1.0
-    patch_geometry: 3e-2
+    patch_geometry: 5e-2
 
   # Distogram loss
   distogram_loss:
@@ -144,7 +144,7 @@ loss:
     min_dist: 2.0
     max_dist: 22.0
     near_cutoff: 12.0
-    hard_negative_weight: 1.0
+    hard_negative_weight: 3.0
 
   # Diffusion loss
   diffusion_loss:

--- a/src/kfold/data/types/model_input.py
+++ b/src/kfold/data/types/model_input.py
@@ -795,6 +795,7 @@ class FoldingInput:
     bond: BondTensor
     sequence: SequenceTensor
     constraint: ConstraintTensor
+    crop_mode: torch.Tensor | None = None
 
     def __post_init__(self):
         # check all layouts are on the same device and have same batch status
@@ -812,6 +813,20 @@ class FoldingInput:
                 assert layout.batch_size == batch_size, (
                     f"{name} layout must have the same batch size as chain layout."
                 )
+        if self.crop_mode is None:
+            shape = (batch_size,) if is_batched else ()
+            crop_mode = torch.zeros(shape, dtype=torch.long, device=device)
+            object.__setattr__(self, "crop_mode", crop_mode)
+        else:
+            assert self.crop_mode.device == device, (
+                "crop_mode must be on the same device as the layouts."
+            )
+            assert self.crop_mode.dtype == torch.long, "crop_mode must be long."
+            expected_shape = (batch_size,) if is_batched else ()
+            assert self.crop_mode.shape == expected_shape, (
+                f"crop_mode must have shape {expected_shape}, got "
+                f"{tuple(self.crop_mode.shape)}."
+            )
 
     def to(self, device: str | torch.device) -> Self:
         return self.__class__(
@@ -821,6 +836,7 @@ class FoldingInput:
             bond=self.bond.to(device),
             sequence=self.sequence.to(device),
             constraint=self.constraint.to(device),
+            crop_mode=self.crop_mode.to(device),
         )
 
     @property
@@ -871,6 +887,11 @@ class FoldingInput:
             bond=self.bond.add_batch_dim(deepcopy),
             sequence=self.sequence.add_batch_dim(deepcopy),
             constraint=self.constraint.add_batch_dim(deepcopy),
+            crop_mode=(
+                self.crop_mode.unsqueeze(0).clone()
+                if deepcopy
+                else self.crop_mode.unsqueeze(0)
+            ),
         )
 
     @classmethod
@@ -958,6 +979,7 @@ class FoldingInput:
         batched_constraint = ConstraintTensor.from_list(
             [data.constraint for data in data_list]
         )
+        batched_crop_mode = torch.stack([data.crop_mode for data in data_list], dim=0)
 
         return cls(
             chain=batched_chain,
@@ -966,6 +988,7 @@ class FoldingInput:
             bond=batched_bond,
             sequence=batched_sequence,
             constraint=batched_constraint,
+            crop_mode=batched_crop_mode,
         )
 
     def to_list(self, deepcopy: bool = False) -> list[Self]:
@@ -987,6 +1010,9 @@ class FoldingInput:
                     bond=bond_list[b],
                     sequence=sequence_list[b],
                     constraint=constraint_list[b],
+                    crop_mode=(
+                        self.crop_mode[b].clone() if deepcopy else self.crop_mode[b]
+                    ),
                 )
             )
         return data_list
@@ -1096,4 +1122,5 @@ class FoldingInput:
             bond=self.bond.pad(max_bonds),
             sequence=self.sequence.pad(max_sequence_tokens),
             constraint=self.constraint.pad(max_constraints),
+            crop_mode=self.crop_mode,
         )

--- a/src/kfold/model/model.py
+++ b/src/kfold/model/model.py
@@ -14,6 +14,7 @@ from kfold.model.modules import (
     confidence_head,
     distogram_head,
     input_embedder,
+    patch_geometry,
     sequence_encoder,
     structure_encoder,
     tri_stack,
@@ -104,6 +105,9 @@ class KFoldConfig:
     diffusion_head: sample_diffusion.BaseStructureModule.Config
     distogram_head: distogram_head.DistogramHead.Config
     confidence_head: confidence_head.ConfidenceHead.Config
+    patch_pair_geometry: patch_geometry.PatchPairGeometryHead.Config = dataclasses.field(
+        default_factory=patch_geometry.PatchPairGeometryHead.Config
+    )
 
     # Kernel configurations
     kernel_cuequivariance: bool = True
@@ -258,6 +262,15 @@ class KFold(torch.nn.Module):
             config.diffusion_head, score_model=self.score_model
         )
         self.distogram_head = distogram_head.DistogramHead(config.distogram_head)
+        patch_pair_geometry_cfg = getattr(
+            config,
+            "patch_pair_geometry",
+            patch_geometry.PatchPairGeometryHead.Config(),
+        )
+        self.patch_pair_geometry_head = patch_geometry.PatchPairGeometryHead(
+            patch_pair_geometry_cfg,
+            channel_z=self.channel_z,
+        )
         self.confidence_head = confidence_head.ConfidenceHead(
             config.confidence_head, kernel_config=kernel_config
         )
@@ -691,6 +704,9 @@ class KFold(torch.nn.Module):
         dict_out["distogram"] = {
             "logits": self.distogram_head(z),
         }
+        patch_geometry_out = self.patch_pair_geometry_head(f_input, z)
+        if patch_geometry_out:
+            dict_out["patch_geometry"] = patch_geometry_out
 
         if train_diffusion_head:
             # Diffusion head
@@ -765,6 +781,7 @@ class KFold(torch.nn.Module):
             "main_stack",
             "linear_refine",
             "refine_stack",
+            "patch_pair_geometry_head",
         ]
 
     def get_trunk_parameter_names(self) -> list[str]:

--- a/src/kfold/model/modules/__init__.py
+++ b/src/kfold/model/modules/__init__.py
@@ -2,6 +2,7 @@ from . import (
     confidence_head,
     distogram_head,
     input_embedder,
+    patch_geometry,
     sequence_encoder,
     structure,
     structure_encoder,

--- a/src/kfold/model/modules/patch_geometry.py
+++ b/src/kfold/model/modules/patch_geometry.py
@@ -1,0 +1,489 @@
+import math
+from typing import TypedDict
+
+import torch
+import torch.nn as nn
+
+from kfold.data.types.model_input import FoldingInput
+from kfold.model.primitives import LayerNorm, Linear
+from kfold.utils.registry import BaseConfig
+
+CROP_UNKNOWN = 0
+CROP_CONTIGUOUS = 1
+CROP_SPATIAL = 2
+CROP_SPATIAL_INTERFACE = 3
+
+
+class _Patch(TypedDict):
+    idx: torch.Tensor
+    chain_id: int
+    is_interface: bool
+    is_background: bool
+
+
+class _PatchPair(TypedDict):
+    patch_i: int
+    patch_j: int
+    target: torch.Tensor
+    weight: float
+    hard_negative: bool
+    priority: float
+
+
+class PatchPairGeometryHead(nn.Module):
+    class Config(BaseConfig):
+        enabled: bool = False
+        channel_z: int = 256
+        num_bins: int = 64
+        min_dist: float = 2.0
+        max_dist: float = 22.0
+        patch_size: int = 16
+        max_patches_per_chain: int = 8
+        max_patch_pairs: int = 256
+        interface_cutoff: float = 12.0
+        positive_cutoff: float = 12.0
+        hard_negative_cutoff: float = 22.0
+
+    def __init__(self, cfg: Config, channel_z: int | None = None):
+        super().__init__()
+        self.enabled: bool = bool(cfg.enabled)
+        self.channel_z: int = int(cfg.channel_z if channel_z is None else channel_z)
+        self.num_bins: int = int(cfg.num_bins)
+        self.min_dist: float = float(cfg.min_dist)
+        self.max_dist: float = float(cfg.max_dist)
+        self.patch_size: int = int(cfg.patch_size)
+        self.max_patches_per_chain: int = int(cfg.max_patches_per_chain)
+        self.max_patch_pairs: int = int(cfg.max_patch_pairs)
+        self.interface_cutoff: float = float(cfg.interface_cutoff)
+        self.positive_cutoff: float = float(cfg.positive_cutoff)
+        self.hard_negative_cutoff: float = float(cfg.hard_negative_cutoff)
+
+        bin_size = (self.max_dist - self.min_dist) / self.num_bins
+        first_bin = self.min_dist + bin_size
+        last_bin = self.max_dist - bin_size
+        boundaries = torch.linspace(first_bin, last_bin, self.num_bins - 1)
+        self.register_buffer("boundaries", boundaries, persistent=False)
+
+        self.norm_z = LayerNorm(self.channel_z)
+        self.pool_score = Linear(self.channel_z, 1)
+        self.pool_value = Linear(self.channel_z, self.channel_z)
+        self.transition = nn.Sequential(
+            LayerNorm(self.channel_z),
+            Linear(self.channel_z, 4 * self.channel_z),
+            nn.GELU(),
+            Linear(4 * self.channel_z, self.channel_z),
+        )
+        self.out = Linear(self.channel_z, self.num_bins, init="final")
+        if not self.enabled:
+            for param in self.parameters():
+                param.requires_grad_(False)
+
+    def _zero_active_param_sum(self, ref: torch.Tensor) -> torch.Tensor:
+        zero = ref.new_zeros(())
+        for param in self.parameters():
+            if param.requires_grad:
+                zero = zero + param.to(dtype=ref.dtype).sum() * 0.0
+        return zero
+
+    def forward(self, f_input: FoldingInput, z: torch.Tensor) -> dict[str, torch.Tensor]:
+        if not self.enabled:
+            return {}
+        if not f_input.is_batched:
+            raise ValueError("PatchPairGeometryHead expects batched FoldingInput.")
+
+        per_batch_logits: list[torch.Tensor] = []
+        per_batch_targets: list[torch.Tensor] = []
+        per_batch_weights: list[torch.Tensor] = []
+        per_batch_hard_negative: list[torch.Tensor] = []
+
+        for b in range(z.shape[0]):
+            patches, patch_pairs = self._build_patch_pairs(f_input, b)
+            logits = [
+                self._pool_patch_pair(z[b], patches[p["patch_i"]], patches[p["patch_j"]])
+                for p in patch_pairs
+            ]
+            if logits:
+                logits_b = torch.stack(logits, dim=0)
+                targets_b = torch.stack([p["target"] for p in patch_pairs], dim=0)
+                weights_b = z.new_tensor([p["weight"] for p in patch_pairs])
+                hard_b = torch.tensor(
+                    [p["hard_negative"] for p in patch_pairs],
+                    device=z.device,
+                    dtype=torch.bool,
+                )
+            else:
+                logits_b = z.new_zeros((0, self.num_bins))
+                targets_b = torch.zeros((0,), device=z.device, dtype=torch.long)
+                weights_b = z.new_zeros((0,))
+                hard_b = torch.zeros((0,), device=z.device, dtype=torch.bool)
+            per_batch_logits.append(logits_b)
+            per_batch_targets.append(targets_b)
+            per_batch_weights.append(weights_b)
+            per_batch_hard_negative.append(hard_b)
+
+        max_pairs = max((x.shape[0] for x in per_batch_logits), default=0)
+        if max_pairs == 0:
+            max_pairs = 1
+        logits_out = z.new_zeros((z.shape[0], max_pairs, self.num_bins))
+        targets_out = torch.zeros(
+            (z.shape[0], max_pairs),
+            device=z.device,
+            dtype=torch.long,
+        )
+        weights_out = z.new_zeros((z.shape[0], max_pairs))
+        hard_out = torch.zeros(
+            (z.shape[0], max_pairs),
+            device=z.device,
+            dtype=torch.bool,
+        )
+        valid_out = torch.zeros(
+            (z.shape[0], max_pairs),
+            device=z.device,
+            dtype=torch.bool,
+        )
+        logits_out = logits_out + self._zero_active_param_sum(z)
+
+        for b, logits_b in enumerate(per_batch_logits):
+            n = logits_b.shape[0]
+            if n == 0:
+                continue
+            logits_out[b, :n] = logits_b
+            targets_out[b, :n] = per_batch_targets[b]
+            weights_out[b, :n] = per_batch_weights[b]
+            hard_out[b, :n] = per_batch_hard_negative[b]
+            valid_out[b, :n] = True
+
+        return {
+            "logits": logits_out,
+            "target": targets_out,
+            "weight": weights_out,
+            "hard_negative": hard_out,
+            "valid_mask": valid_out,
+        }
+
+    def _build_patch_pairs(
+        self,
+        f_input: FoldingInput,
+        batch_idx: int,
+    ) -> tuple[list[_Patch], list[_PatchPair]]:
+        with torch.no_grad():
+            coords = f_input.token.repr_coords[batch_idx]
+            repr_mask = f_input.token.repr_mask[batch_idx]
+            token_mask = f_input.token.pad_mask[batch_idx]
+            finite_mask = torch.isfinite(coords).all(dim=-1)
+            valid = token_mask & repr_mask & finite_mask
+            asym_id = f_input.token.asym_id[batch_idx]
+            crop_mode = self._crop_mode(f_input, batch_idx)
+
+            chain_ids = sorted(int(x.item()) for x in asym_id[valid].unique())
+            if len(chain_ids) < 2:
+                return [], []
+
+            interface_mask = self._interface_token_mask(coords, asym_id, valid)
+            patches: list[_Patch] = []
+            for chain_id in chain_ids:
+                idx = torch.where(valid & (asym_id == chain_id))[0]
+                if idx.numel() == 0:
+                    continue
+                patches.extend(
+                    self._make_chain_patches(
+                        f_input=f_input,
+                        batch_idx=batch_idx,
+                        chain_id=chain_id,
+                        idx=idx,
+                        crop_mode=crop_mode,
+                        interface_mask=interface_mask,
+                    )
+                )
+
+            patch_pairs = self._select_patch_pairs(patches, coords, crop_mode)
+        return patches, patch_pairs
+
+    def _crop_mode(self, f_input: FoldingInput, batch_idx: int) -> int:
+        crop_mode = getattr(f_input, "crop_mode", None)
+        if crop_mode is None:
+            return CROP_UNKNOWN
+        if crop_mode.ndim == 0:
+            return int(crop_mode.item())
+        return int(crop_mode[batch_idx].item())
+
+    def _interface_token_mask(
+        self,
+        coords: torch.Tensor,
+        asym_id: torch.Tensor,
+        valid: torch.Tensor,
+    ) -> torch.Tensor:
+        interface = torch.zeros_like(valid)
+        idx = torch.where(valid)[0]
+        if idx.numel() < 2:
+            return interface
+        d = torch.cdist(coords[idx], coords[idx])
+        inter_chain = asym_id[idx, None] != asym_id[idx][None, :]
+        near = (d < self.interface_cutoff) & inter_chain
+        interface[idx] = near.any(dim=-1)
+        return interface
+
+    def _make_chain_patches(
+        self,
+        f_input: FoldingInput,
+        batch_idx: int,
+        chain_id: int,
+        idx: torch.Tensor,
+        crop_mode: int,
+        interface_mask: torch.Tensor,
+    ) -> list[_Patch]:
+        if crop_mode == CROP_CONTIGUOUS:
+            return self._contiguous_patches(f_input, batch_idx, chain_id, idx)
+        if crop_mode == CROP_SPATIAL_INTERFACE:
+            return self._interface_patches(
+                f_input,
+                batch_idx,
+                chain_id,
+                idx,
+                interface_mask,
+            )
+        return self._spatial_patches(
+            f_input.token.repr_coords[batch_idx],
+            chain_id,
+            idx,
+            is_interface=False,
+            is_background=False,
+        )
+
+    def _contiguous_patches(
+        self,
+        f_input: FoldingInput,
+        batch_idx: int,
+        chain_id: int,
+        idx: torch.Tensor,
+    ) -> list[_Patch]:
+        org_index = f_input.token.org_token_index[batch_idx, idx]
+        idx = idx[torch.argsort(org_index)]
+        n_patches = min(
+            self.max_patches_per_chain,
+            max(1, math.ceil(idx.numel() / self.patch_size)),
+        )
+        return [
+            {
+                "idx": chunk,
+                "chain_id": chain_id,
+                "is_interface": False,
+                "is_background": False,
+            }
+            for chunk in torch.tensor_split(idx, n_patches)
+            if chunk.numel() > 0
+        ]
+
+    def _spatial_patches(
+        self,
+        coords: torch.Tensor,
+        chain_id: int,
+        idx: torch.Tensor,
+        is_interface: bool,
+        is_background: bool,
+        max_patches: int | None = None,
+    ) -> list[_Patch]:
+        max_patches = self.max_patches_per_chain if max_patches is None else max_patches
+        n_patches = min(
+            max_patches,
+            max(1, math.ceil(idx.numel() / self.patch_size)),
+        )
+        clusters = self._fps_clusters(coords[idx], idx, n_patches)
+        return [
+            {
+                "idx": cluster,
+                "chain_id": chain_id,
+                "is_interface": is_interface,
+                "is_background": is_background,
+            }
+            for cluster in clusters
+            if cluster.numel() > 0
+        ]
+
+    def _interface_patches(
+        self,
+        f_input: FoldingInput,
+        batch_idx: int,
+        chain_id: int,
+        idx: torch.Tensor,
+        interface_mask: torch.Tensor,
+    ) -> list[_Patch]:
+        coords = f_input.token.repr_coords[batch_idx]
+        iface_idx = idx[interface_mask[idx]]
+        bg_idx = idx[~interface_mask[idx]]
+        if iface_idx.numel() == 0:
+            return self._spatial_patches(
+                coords,
+                chain_id,
+                idx,
+                is_interface=False,
+                is_background=False,
+            )
+
+        iface_budget = max(1, self.max_patches_per_chain - int(bg_idx.numel() > 0))
+        patches = self._spatial_patches(
+            coords,
+            chain_id,
+            iface_idx,
+            is_interface=True,
+            is_background=False,
+            max_patches=iface_budget,
+        )
+
+        if bg_idx.numel() > 0 and len(patches) < self.max_patches_per_chain:
+            patches.append(
+                {
+                    "idx": bg_idx,
+                    "chain_id": chain_id,
+                    "is_interface": False,
+                    "is_background": True,
+                }
+            )
+        return patches
+
+    def _fps_clusters(
+        self,
+        coords_local: torch.Tensor,
+        idx_global: torch.Tensor,
+        n_clusters: int,
+    ) -> list[torch.Tensor]:
+        if n_clusters <= 1 or idx_global.numel() <= 1:
+            return [idx_global]
+
+        n_clusters = min(n_clusters, idx_global.numel())
+        centers = [0]
+        min_dist = torch.full(
+            (idx_global.numel(),),
+            float("inf"),
+            device=coords_local.device,
+            dtype=coords_local.dtype,
+        )
+        for _ in range(1, n_clusters):
+            last = coords_local[centers[-1]].unsqueeze(0)
+            dist = torch.cdist(coords_local, last).squeeze(-1)
+            min_dist = torch.minimum(min_dist, dist)
+            centers.append(int(torch.argmax(min_dist).item()))
+
+        center_coords = coords_local[centers]
+        assign = torch.cdist(coords_local, center_coords).argmin(dim=-1)
+        clusters = []
+        for cluster_i in range(n_clusters):
+            cluster = idx_global[assign == cluster_i]
+            if cluster.numel() > 0:
+                clusters.append(cluster)
+        return clusters
+
+    def _select_patch_pairs(
+        self,
+        patches: list[_Patch],
+        coords: torch.Tensor,
+        crop_mode: int,
+    ) -> list[_PatchPair]:
+        pairs: list[_PatchPair] = []
+        for i, patch_i in enumerate(patches):
+            for j, patch_j in enumerate(patches[i + 1 :], start=i + 1):
+                if patch_i["chain_id"] == patch_j["chain_id"]:
+                    continue
+
+                coords_i = coords[patch_i["idx"]]
+                coords_j = coords[patch_j["idx"]]
+                com_i = coords_i.mean(dim=0)
+                com_j = coords_j.mean(dim=0)
+                com_dist = torch.linalg.norm(com_i - com_j)
+                token_min_dist = torch.cdist(coords_i, coords_j).min()
+                positive = bool((token_min_dist < self.positive_cutoff).item())
+                hard_negative = bool((token_min_dist > self.hard_negative_cutoff).item())
+                weight = self._patch_pair_weight(
+                    crop_mode,
+                    patch_i,
+                    patch_j,
+                    positive=positive,
+                    hard_negative=hard_negative,
+                )
+                if weight <= 0:
+                    continue
+                target = (com_dist.unsqueeze(-1) > self.boundaries).sum(dim=-1).long()
+                priority = self._patch_pair_priority(
+                    crop_mode,
+                    positive=positive,
+                    hard_negative=hard_negative,
+                    distance=float(com_dist.item()),
+                )
+                pairs.append(
+                    {
+                        "patch_i": i,
+                        "patch_j": j,
+                        "target": target,
+                        "weight": weight,
+                        "hard_negative": hard_negative,
+                        "priority": priority,
+                    }
+                )
+
+        pairs.sort(key=lambda x: x["priority"], reverse=True)
+        return pairs[: self.max_patch_pairs]
+
+    def _patch_pair_weight(
+        self,
+        crop_mode: int,
+        patch_i: _Patch,
+        patch_j: _Patch,
+        positive: bool,
+        hard_negative: bool,
+    ) -> float:
+        any_background = patch_i["is_background"] or patch_j["is_background"]
+        both_interface = patch_i["is_interface"] and patch_j["is_interface"]
+
+        if crop_mode == CROP_CONTIGUOUS:
+            if hard_negative:
+                return 2.0
+            return 1.0 if positive else 0.5
+
+        if crop_mode == CROP_SPATIAL_INTERFACE:
+            if any_background:
+                return 0.1
+            if positive and both_interface:
+                return 1.5
+            if hard_negative and both_interface:
+                return 1.0
+            return 1.0 if positive else 0.25
+
+        if any_background:
+            return 0.1
+        if hard_negative:
+            return 0.5
+        return 1.0 if positive else 0.25
+
+    def _patch_pair_priority(
+        self,
+        crop_mode: int,
+        positive: bool,
+        hard_negative: bool,
+        distance: float,
+    ) -> float:
+        if crop_mode == CROP_CONTIGUOUS and hard_negative:
+            return 4.0 + min(distance, 100.0) / 1000.0
+        if positive:
+            return 3.0 - min(distance, 100.0) / 1000.0
+        if hard_negative:
+            return 2.0 + min(distance, 100.0) / 1000.0
+        return 1.0
+
+    def _pool_patch_pair(
+        self,
+        z: torch.Tensor,
+        patch_i: _Patch,
+        patch_j: _Patch,
+    ) -> torch.Tensor:
+        idx_i = patch_i["idx"]
+        idx_j = patch_j["idx"]
+        z_ij = z[idx_i][:, idx_j]
+        z_ji = z[idx_j][:, idx_i].transpose(0, 1)
+        pair_z = 0.5 * (z_ij + z_ji)
+        flat_z = self.norm_z(pair_z.reshape(-1, self.channel_z))
+        score = self.pool_score(flat_z).squeeze(-1)
+        alpha = score.float().softmax(dim=-1).to(flat_z.dtype)
+        value = self.pool_value(flat_z)
+        pooled = torch.einsum("n,nc->c", alpha, value)
+        pooled = pooled + self.transition(pooled)
+        return self.out(pooled)

--- a/src/kfold/training/dataset/cropper/multi_anchor.py
+++ b/src/kfold/training/dataset/cropper/multi_anchor.py
@@ -90,6 +90,7 @@ class MultiAnchorCropper(BaseCropper):
 
     def __init__(self, config: Config):
         self.config = config
+        self.last_crop_mode: int = 0
 
         assert (
             self.config.w_contiguous
@@ -138,13 +139,16 @@ class MultiAnchorCropper(BaseCropper):
         v = rng.random()
         if v < self.w_contiguous:
             # Contiguous cropping
+            self.last_crop_mode = 1
             crop_indices = self.crop_contiguous(struct, metadata, max_tokens, rng=rng)
         elif v < self.w_contiguous + self.w_spatial:
             # Spatial cropping
+            self.last_crop_mode = 2
             crop_indices = self.crop_spatial(
                 struct, metadata, max_tokens, bias_asym_id, rng=rng
             )
         else:  # Spatial interface cropping
+            self.last_crop_mode = 3
             crop_indices = self.crop_spatial_interface(
                 struct, metadata, max_tokens, bias_asym_id, rng=rng
             )

--- a/src/kfold/training/dataset/datasets/train_dataset.py
+++ b/src/kfold/training/dataset/datasets/train_dataset.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import lmdb
 import numpy as np
+import torch
 
 from kfold.data.pipelines import featurization, prior_sampling, tokenization
 from kfold.data.types.ccd import CCD
@@ -237,10 +238,11 @@ class TrainingDataset(BaseLMDBDataset):
         self.drop_apo_structure(tokenized, rng)
 
         # Cropping
-        cropped = self.crop_structure(tokenized, metadata, rng=rng, **kwargs)
+        cropped, crop_mode = self.crop_structure(tokenized, metadata, rng=rng, **kwargs)
 
         # Featurization
         f_input = self.featurize(cropped)
+        f_input = f_input.copy_with(crop_mode=torch.tensor(crop_mode, dtype=torch.long))
 
         # Pad the features.
         f_input = self.pad_input(f_input)
@@ -318,9 +320,10 @@ class TrainingDataset(BaseLMDBDataset):
         metadata: Metadata,
         rng: np.random.Generator,
         **kwargs,
-    ) -> TokenizedStructure:
+    ) -> tuple[TokenizedStructure, int]:
         assert "asym_ids" in kwargs, "asym_ids must be provided for cropping."
         asym_ids: int | tuple[int, int] | None = kwargs["asym_ids"]
+        crop_mode = 0
         if self.max_tokens < tokenized.num_tokens:
             # Crop the tokenized structure
             tokenized = self.cropper.crop(
@@ -331,7 +334,8 @@ class TrainingDataset(BaseLMDBDataset):
                 bias_asym_id=asym_ids,
                 rng=rng,
             )
-        return tokenized
+            crop_mode = int(getattr(self.cropper, "last_crop_mode", 0))
+        return tokenized, crop_mode
 
     def drop_apo_structure(
         self, tokenized: TokenizedStructure, rng: np.random.Generator

--- a/src/kfold/training/loss/__init__.py
+++ b/src/kfold/training/loss/__init__.py
@@ -1,1 +1,1 @@
-from . import confidence, diffusion, distogram
+from . import confidence, diffusion, distogram, patch_geometry

--- a/src/kfold/training/loss/patch_geometry.py
+++ b/src/kfold/training/loss/patch_geometry.py
@@ -1,0 +1,117 @@
+import torch
+import torch.nn.functional as F
+
+
+def _binary_average_precision(
+    score: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor | None:
+    score = score[mask]
+    target = target[mask]
+    if score.numel() == 0 or not target.any() or target.all():
+        return None
+
+    order = torch.argsort(score, descending=True)
+    sorted_target = target[order].to(score.dtype)
+    rank = torch.arange(
+        1, sorted_target.numel() + 1, device=score.device, dtype=score.dtype
+    )
+    precision = sorted_target.cumsum(dim=0) / rank
+    return (precision * sorted_target).sum() / sorted_target.sum().clamp(min=1.0)
+
+
+class PatchPairGeometryLoss(torch.nn.Module):
+    def __init__(
+        self,
+        min_dist: float = 2.0,
+        max_dist: float = 22.0,
+        num_bins: int = 64,
+        near_cutoff: float = 12.0,
+        hard_negative_weight: float = 1.0,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.min_dist: float = min_dist
+        self.max_dist: float = max_dist
+        self.num_bins: int = num_bins
+        self.near_cutoff: float = near_cutoff
+        self.hard_negative_weight: float = hard_negative_weight
+        self.eps: float = eps
+
+        bin_size = (max_dist - min_dist) / num_bins
+        first_bin = min_dist + bin_size
+        self.near_bin = int((near_cutoff - first_bin) / bin_size)
+        self.near_bin = max(0, min(self.near_bin, num_bins - 1))
+
+    def forward(
+        self,
+        patch_output: dict[str, torch.Tensor],
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        logits = patch_output["logits"]
+        target = patch_output["target"]
+        weight = patch_output["weight"]
+        valid_mask = patch_output["valid_mask"]
+        hard_negative = patch_output["hard_negative"] & valid_mask
+
+        if logits.numel() == 0 or not valid_mask.any():
+            zero = logits.sum() * 0.0
+            return zero, {
+                "patch_geometry_loss": zero.detach(),
+                "patch_geometry_ce_loss": zero.detach(),
+                "patch_geometry_hard_negative_loss": zero.detach(),
+                "patch_geometry_valid_pairs": zero.detach(),
+            }
+
+        b, m, _ = logits.shape
+        ce = F.cross_entropy(
+            logits.reshape(b * m, self.num_bins),
+            target.reshape(b * m),
+            reduction="none",
+        ).view(b, m)
+
+        valid_weight = weight * valid_mask.to(weight.dtype)
+        denom = valid_weight.sum().clamp(min=1.0)
+        ce_loss = (ce * valid_weight).sum() / denom
+
+        prob = torch.softmax(logits, dim=-1)
+        p_near = prob[..., : self.near_bin + 1].sum(dim=-1)
+        hard_weight = valid_weight * hard_negative.to(valid_weight.dtype)
+        hard_denom = hard_weight.sum().clamp(min=1.0)
+        hard_loss = (
+            -torch.log1p(-p_near.clamp(max=1.0 - self.eps)) * hard_weight
+        ).sum() / hard_denom
+
+        loss = ce_loss + self.hard_negative_weight * hard_loss
+        with torch.no_grad():
+            near_target = (target <= self.near_bin) & valid_mask
+            far_target = (target > self.near_bin) & valid_mask
+            ap = _binary_average_precision(p_near.detach(), near_target, valid_mask)
+
+        metrics = {
+            "patch_geometry_loss": loss.detach(),
+            "patch_geometry_ce_loss": ce_loss.detach(),
+            "patch_geometry_hard_negative_loss": hard_loss.detach(),
+            "patch_geometry_valid_pairs": valid_mask.float().sum().detach(),
+            "patch_geometry_hard_negative_pairs": hard_negative.float().sum().detach(),
+            "patch_geometry_near_pairs": near_target.float().sum().detach(),
+            "patch_geometry_far_pairs": far_target.float().sum().detach(),
+            "patch_geometry_target_near_rate": near_target.float().sum().detach()
+            / valid_mask.float().sum().clamp(min=1.0).detach(),
+            "patch_geometry_pred_near_mass": p_near[valid_mask].mean().detach(),
+        }
+        if ap is not None:
+            metrics["patch_geometry_near_ap"] = ap.detach()
+        if near_target.any():
+            metrics["patch_geometry_p_near_true_near"] = (
+                p_near[near_target].mean().detach()
+            )
+        if far_target.any():
+            metrics["patch_geometry_false_positive_near_mass"] = (
+                p_near[far_target].mean().detach()
+            )
+        if hard_negative.any():
+            metrics["patch_geometry_hard_negative_p_near"] = (
+                p_near[hard_negative].mean().detach()
+            )
+        return loss, metrics

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -210,6 +210,25 @@ def _get_structure_module_for_binning(model: Any) -> Any:
     )
 
 
+def _binary_average_precision(
+    score: torch.Tensor,
+    target: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor | None:
+    score = score[mask]
+    target = target[mask]
+    if score.numel() == 0 or not target.any() or target.all():
+        return None
+
+    order = torch.argsort(score, descending=True)
+    sorted_target = target[order].to(score.dtype)
+    rank = torch.arange(
+        1, sorted_target.numel() + 1, device=score.device, dtype=score.dtype
+    )
+    precision = sorted_target.cumsum(dim=0) / rank
+    return (precision * sorted_target).sum() / sorted_target.sum().clamp(min=1.0)
+
+
 @dataclasses.dataclass(kw_only=True)
 class ValidationConfig(_Config):
     """Validation step configuration."""
@@ -231,6 +250,7 @@ class LossConfig(_Config):
     distogram_loss: Any
     diffusion_loss: Any
     confidence_loss: Any
+    patch_geometry_loss: Any = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -425,6 +445,9 @@ class KFoldTrainingModule(pl.LightningModule):
         self.distogram_loss = loss_fn.distogram.DistogramLoss(
             **loss_config.distogram_loss
         )
+        self.patch_geometry_loss = loss_fn.patch_geometry.PatchPairGeometryLoss(
+            **loss_config.patch_geometry_loss
+        )
 
         # Diffusion loss
         diffusion_loss_config = loss_config.diffusion_loss
@@ -605,6 +628,16 @@ class KFoldTrainingModule(pl.LightningModule):
                 logits=model_output["distogram"]["logits"],
                 f_input=f_input,
             )
+            patch_weight = self.loss_weights.get("patch_geometry", 0.0)
+            if patch_weight > 0 and "patch_geometry" in model_output:
+                patch_geometry_loss, patch_geometry_metrics = self.patch_geometry_loss(
+                    model_output["patch_geometry"]
+                )
+            else:
+                patch_geometry_loss, patch_geometry_metrics = 0.0, {}
+        else:
+            distogram_loss, distogram_metrics = 0.0, {}
+            patch_geometry_loss, patch_geometry_metrics = 0.0, {}
 
         if self.train_diffusion_head:
             diffusion_out = model_output["diffusion"]
@@ -616,7 +649,6 @@ class KFoldTrainingModule(pl.LightningModule):
             )
 
         else:
-            distogram_loss, distogram_metrics = 0.0, {}
             diffusion_loss, diffusion_metrics = 0.0, {}
 
         if self.train_confidence_head:
@@ -654,12 +686,17 @@ class KFoldTrainingModule(pl.LightningModule):
             loss_weights["diffusion"] * diffusion_loss
             + loss_weights["distogram"] * distogram_loss
             + loss_weights["confidence"] * confidence_loss
+            + loss_weights.get("patch_geometry", 0.0) * patch_geometry_loss
         )  # [B,]
         assert torch.is_tensor(loss), "Loss must be a torch.Tensor."
 
         # Log loss and metrics
         all_metrics = (
-            distogram_metrics | diffusion_metrics | confidence_metrics | sample_metrics
+            distogram_metrics
+            | patch_geometry_metrics
+            | diffusion_metrics
+            | confidence_metrics
+            | sample_metrics
         )
         all_metrics["loss"] = loss.detach()
 
@@ -846,9 +883,78 @@ class KFoldTrainingModule(pl.LightningModule):
         loss_per_batch = self.distogram_loss(logits, f_input)
         loss = loss_per_batch.mean()
         metrics = {"distogram_loss": loss.detach()}
+        if hasattr(self.distogram_loss, "boundaries") and hasattr(f_input, "token"):
+            metrics |= self.compute_distogram_diagnostic_metrics(logits, f_input)
         if self._binned_cache_enabled and self.train_diffusion_head:
             self._timebin_last_distogram_loss_per_batch = loss_per_batch.detach()
         return loss, metrics
+
+    def compute_distogram_diagnostic_metrics(
+        self,
+        logits: torch.Tensor,
+        f_input: FoldingInput,
+        near_cutoff: float = 12.0,
+        far_cutoff: float = 22.0,
+    ) -> dict[str, torch.Tensor]:
+        """Log inter-chain near-ranking and false-positive pressure diagnostics."""
+        with torch.no_grad():
+            boundaries = self.distogram_loss.boundaries.to(logits.device)
+            gt_coords = f_input.token.repr_coords
+            diff = gt_coords[..., None, :, :] - gt_coords[..., :, None, :]
+            d_repr = diff.norm(dim=-1)
+
+            repr_mask = f_input.token.repr_mask
+            pair_mask = repr_mask[..., None, :] & repr_mask[..., :, None]
+            asym_id = f_input.token.asym_id
+            inter_chain = asym_id[..., None, :] != asym_id[..., :, None]
+            upper_tri = torch.ones(
+                logits.shape[-3],
+                logits.shape[-2],
+                dtype=torch.bool,
+                device=logits.device,
+            ).triu(diagonal=1)
+            valid = pair_mask & inter_chain & upper_tri
+
+            if not valid.any():
+                zero = logits.sum().detach() * 0.0
+                return {
+                    "distogram_inter_chain_valid_pairs": zero,
+                    "distogram_inter_chain_near_pairs": zero,
+                    "distogram_inter_chain_far_pairs": zero,
+                }
+
+            bin_size = float(boundaries[1].item() - boundaries[0].item())
+            near_bin = int((near_cutoff - float(boundaries[0].item())) / bin_size)
+            near_bin = max(0, min(near_bin, logits.shape[-1] - 1))
+            p_near = torch.softmax(logits.float(), dim=-1)[..., : near_bin + 1].sum(
+                dim=-1
+            )
+
+            true_near = (d_repr < near_cutoff) & valid
+            true_far = (d_repr > far_cutoff) & valid
+            ap = _binary_average_precision(p_near, true_near, valid)
+
+            valid_count = valid.float().sum().clamp(min=1.0)
+            metrics = {
+                "distogram_inter_chain_valid_pairs": valid.float().sum().detach(),
+                "distogram_inter_chain_near_pairs": true_near.float().sum().detach(),
+                "distogram_inter_chain_far_pairs": true_far.float().sum().detach(),
+                "distogram_inter_chain_target_near_rate": (
+                    true_near.float().sum() / valid_count
+                ).detach(),
+                "distogram_inter_chain_pred_near_mass": p_near[valid].mean().detach(),
+            }
+            if ap is not None:
+                metrics["distogram_inter_chain_near_ap"] = ap.detach()
+            if true_near.any():
+                metrics["distogram_inter_chain_p_near_true_near"] = (
+                    p_near[true_near].mean().detach()
+                )
+            if true_far.any():
+                metrics["distogram_inter_chain_false_positive_near_mass"] = (
+                    p_near[true_far].mean().detach()
+                )
+            return metrics
 
     def compute_diffusion_loss(
         self,

--- a/tests/unit_tests/test_patch_geometry.py
+++ b/tests/unit_tests/test_patch_geometry.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+
+import torch
+
+from kfold.model.modules.patch_geometry import (
+    CROP_CONTIGUOUS,
+    PatchPairGeometryHead,
+)
+from kfold.training.loss.patch_geometry import PatchPairGeometryLoss
+
+
+def _fake_input(crop_mode: int = CROP_CONTIGUOUS):
+    asym_id = torch.tensor([[1] * 8 + [2] * 8], dtype=torch.long)
+    coords = torch.zeros(1, 16, 3)
+    coords[0, :8, 0] = torch.arange(8, dtype=torch.float32)
+    coords[0, 8:, 0] = 50.0 + torch.arange(8, dtype=torch.float32)
+    token = SimpleNamespace(
+        pad_mask=torch.ones(1, 16, dtype=torch.bool),
+        repr_mask=torch.ones(1, 16, dtype=torch.bool),
+        asym_id=asym_id,
+        repr_coords=coords,
+        org_token_index=torch.arange(16, dtype=torch.long).view(1, 16),
+    )
+    chain = SimpleNamespace(
+        pad_mask=torch.tensor([[True, True]], dtype=torch.bool),
+        asym_id=torch.tensor([[1, 2]], dtype=torch.long),
+    )
+    return SimpleNamespace(
+        token=token,
+        chain=chain,
+        crop_mode=torch.tensor([crop_mode], dtype=torch.long),
+        is_batched=True,
+    )
+
+
+def _fake_single_chain_input(crop_mode: int = CROP_CONTIGUOUS):
+    f_input = _fake_input(crop_mode)
+    f_input.token.asym_id = torch.ones(1, 16, dtype=torch.long)
+    f_input.chain.pad_mask = torch.tensor([[True, False]], dtype=torch.bool)
+    f_input.chain.asym_id = torch.tensor([[1, 0]], dtype=torch.long)
+    return f_input
+
+
+def _active_params(module):
+    return [p for p in module.parameters() if p.requires_grad]
+
+
+def test_patch_geometry_head_freezes_when_disabled():
+    head = PatchPairGeometryHead(
+        PatchPairGeometryHead.Config(enabled=False, channel_z=16),
+    )
+
+    assert not any(p.requires_grad for p in head.parameters())
+
+
+def test_patch_geometry_head_and_loss_on_contiguous_hard_negatives():
+    cfg = PatchPairGeometryHead.Config(
+        enabled=True,
+        channel_z=16,
+        patch_size=4,
+        max_patches_per_chain=2,
+        max_patch_pairs=8,
+    )
+    head = PatchPairGeometryHead(cfg)
+    f_input = _fake_input(crop_mode=CROP_CONTIGUOUS)
+    z = torch.randn(1, 16, 16, 16)
+
+    out = head(f_input, z)
+    loss, metrics = PatchPairGeometryLoss()(out)
+
+    assert out["valid_mask"].sum() > 0
+    assert out["hard_negative"].sum() > 0
+    assert torch.isfinite(loss)
+    assert metrics["patch_geometry_valid_pairs"] > 0
+
+
+def test_patch_geometry_head_touches_active_params_without_patch_pairs():
+    head = PatchPairGeometryHead(
+        PatchPairGeometryHead.Config(
+            enabled=True,
+            channel_z=16,
+            patch_size=4,
+            max_patches_per_chain=2,
+            max_patch_pairs=8,
+        ),
+    )
+    f_input = _fake_single_chain_input()
+    z = torch.randn(1, 16, 16, 16, requires_grad=True)
+
+    out = head(f_input, z)
+    loss, metrics = PatchPairGeometryLoss()(out)
+    loss.backward()
+
+    assert out["valid_mask"].sum() == 0
+    assert torch.isfinite(loss)
+    assert metrics["patch_geometry_valid_pairs"] == 0
+    assert all(p.grad is not None for p in _active_params(head))


### PR DESCRIPTION
## Summary

This PR adds patch-pair COM distogram auxiliary supervision for ECSI training.

The goal is to reduce false-positive inter-chain near/contact signals in trunk `z` by adding a patch-level geometry objective. The patch head samples inter-chain patch pairs, pools the corresponding trunk pair representation, predicts patch COM distance bins, and applies an auxiliary distogram loss with hard-negative pressure.

For ECSI configs, patch-distogram supervision is enabled by default.

## Motivation

Recent ECSI/EDM analysis suggested that trunk `z` can preserve reasonable pairwise near/contact ranking while still producing inter-chain distance fields that are not easily realizable as a consistent 3D geometry. In particular, the model appears to over-activate false-positive near signals for token or local patch pairs that should be far apart once molecule-level geometry is considered.

This patch-distogram objective is intended to provide higher-level geometric pressure, especially on far and hard-negative inter-chain patch pairs.

## Changes

- Add patch-pair geometry head for COM distogram prediction.
- Add patch sampling and patch-pair metadata construction.
- Add `PatchPairGeometryLoss`.
- Add patch geometry training metrics.
- Add no-grad inter-chain distogram diagnostic metrics from existing distogram logits.
- Add ECSI config defaults for patch-distogram supervision.
- Enable patch-distogram supervision by default for ECSI.
- Add unit tests for patch geometry behavior.

## Tests

- `pytest tests/unit_tests/test_patch_geometry.py -q`
- `pytest tests/test_time_binning.py -q`
- ECSI config smoke test