### PR TITLE
Accelerate ligand Langevin prior sampling

### DIFF
--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -47,10 +47,26 @@ data:
   prior_sampler:
     # If null, no prior sampling
     chain_translation_scale: 24.0 # Angstroms
+    # Legacy IID atom noise, used only when ligand_langevin.enabled is false.
     ligand_augmentation_scale: 0.3
     bioprior:
       noise_scale: 0.5
       max_steps: 10
+    # Generate independent internal ligand conformers around the ETKDG/CCD
+    # initial structure. A short noise-free harmonic correction removes the
+    # larger-step integration bias while preserving approximately 1 A coverage.
+    ligand_langevin:
+      enabled: true
+      num_steps: 100
+      dt: 0.01
+      temperature: 1.0
+      bond_strength: 50.0
+      angle_strength: 10.0
+      relaxation_steps: 2
+      relaxation_dt: 0.00125
+      # Optional safety filters. Null disables sample rejection.
+      max_bond_deviation: null
+      max_aligned_rmsd: null
     train: true # Only for train/val
 
 # Lightning Trainer Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ train = [
   'wandb', # for experiment tracking
   'lmdb', # for training dataset storage
   'msgpack', # for data serialization
+  "numba",
 ]
 preprocess = [
   'pdbeccdutils', # for ccd data handling

--- a/src/kfold/data/pipelines/prior_sampling.py
+++ b/src/kfold/data/pipelines/prior_sampling.py
@@ -9,7 +9,11 @@ import numpy as np
 import kfold.constants as C
 from kfold.data.types.structure import Chain, RefStructure
 from kfold.data.utils.simulation.bioprior import BioPriorConfig, BioPriorPerturbation
-from kfold.data.utils.simulation.langevin_dynamics import LangevinDynamicsSimulator
+from kfold.data.utils.simulation.langevin_dynamics import (
+    LangevinDynamicsSimulator,
+    LigandLangevinDynamicsConfig,
+    LigandLangevinDynamicsSimulator,
+)
 from kfold.utils.geometry.random_augment import center_random_augmentation
 from kfold.utils.geometry.rigid_align import compute_rmsd
 from kfold.utils.misc import spawn_rng
@@ -29,15 +33,21 @@ class PriorSamplerConfig:
     chain_translation_scale : float
         Scale of random translation augmentation for each chain (in Angstrom).
     ligand_augmentation_scale : float
-        Scale of random noise augmentation for ligand coordinates (in Angstrom).
+        Legacy scale of independent atom noise for ligand coordinates (in Angstrom).
+        Used only when ligand Langevin perturbation is disabled.
     bioprior : BioPriorConfig
         BioPrior perturbation configuration for protein prior sources.
+    ligand_langevin : LigandLangevinDynamicsConfig
+        Bond-angle harmonic Langevin perturbation around the initial conformer.
     """
 
     chain_translation_scale: float = 24.0  # Angstrom
     ligand_augmentation_scale: float = 0.3  # Angstrom
     bioprior: BioPriorConfig = dataclasses.field(
         default_factory=lambda: BioPriorConfig(noise_scale=0.3, max_steps=10)
+    )
+    ligand_langevin: LigandLangevinDynamicsConfig = dataclasses.field(
+        default_factory=LigandLangevinDynamicsConfig
     )
     train: bool = False
 
@@ -48,6 +58,7 @@ class PriorSamplerConfig:
             chain_translation_scale=24.0,
             ligand_augmentation_scale=0.3,
             bioprior=BioPriorConfig(max_steps=0),
+            ligand_langevin=LigandLangevinDynamicsConfig(enabled=True),
             train=False,
         )
 
@@ -64,6 +75,13 @@ class PriorSampler:
         # Ligand augmentation scale
         self.ligand_augmentation_scale: float = config.ligand_augmentation_scale
         self.bioprior: BioPriorPerturbation = BioPriorPerturbation(config.bioprior)
+
+        # Bond-angle harmonic ligand perturbation. This is distinct from the
+        # missing-atom relaxation performed by LangevinDynamicsSimulator.
+        self.ligand_langevin_simulator = LigandLangevinDynamicsSimulator(
+            config.ligand_langevin
+        )
+        self.ligand_langevin_config = self.ligand_langevin_simulator.config
 
         # Langevin dynamics simulator for relaxing missing atoms
         self.langevin_simulator = LangevinDynamicsSimulator.default()
@@ -185,11 +203,13 @@ class PriorSampler:
                 # No perturbation for nucleic acids yet
                 pass
             elif c.is_ligand:
-                # Apply random noise augmentation to ligand coordinates.
-                scale = self.ligand_augmentation_scale
-                if scale > 0.0:
-                    noise = rng.normal(scale=scale, size=coords.shape)
-                    coords = coords + noise
+                # Preserve the legacy IID atom perturbation when this chain is
+                # outside the bond-angle harmonic ligand path.
+                if not self._use_ligand_langevin(c):
+                    scale = self.ligand_augmentation_scale
+                    if scale > 0.0:
+                        noise = rng.normal(scale=scale, size=coords.shape)
+                        coords = coords + noise
 
             # Flatten coordinates: [L, A, 3] -> [Natom, 3]
             if c.is_polymer:
@@ -205,6 +225,10 @@ class PriorSampler:
 
             # Fill missing coordinates using Langevin dynamics relaxation
             coords = self.langevin_relaxation(coords, c, rng)
+            if self._use_ligand_langevin(c):
+                coords = self.sample_ligand_langevin_priors(
+                    coords, c, num_samples=1, rng=rng
+                )[0]
 
             chain_coords.append(coords)
 
@@ -272,6 +296,126 @@ class PriorSampler:
                 if np.isfinite(coord).all():
                     coords[atom_i] = coord
         return coords
+
+    def _use_ligand_langevin(self, chain: Chain) -> bool:
+        """Whether to perturb this chain from its initial ligand conformer."""
+        return (
+            self.ligand_langevin_config.enabled
+            and chain.is_small_molecule
+            and chain.num_atoms > 1
+        )
+
+    def sample_ligand_langevin_priors(
+        self,
+        coords: np.ndarray,
+        chain: Chain,
+        num_samples: int,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Sample and validate bond-angle harmonic priors for a ligand entity."""
+        if not np.isfinite(coords).all():
+            self.logger.warning(
+                "Skipping ligand Langevin perturbation for entity %s because its "
+                "initial conformer contains non-finite coordinates.",
+                chain.entity_id,
+            )
+            return np.repeat(coords[None, ...], num_samples, axis=0)
+
+        bond_indices = self.get_ligand_bond_indices(chain)
+        samples = self.ligand_langevin_simulator(
+            coords, bond_indices, num_samples, rng
+        )
+
+        is_valid = self.get_valid_ligand_prior_mask(coords, samples, bond_indices)
+        samples[~is_valid] = coords
+        rejected = int((~is_valid).sum())
+        if rejected > 0:
+            self.logger.warning(
+                "Rejected %d/%d ligand Langevin priors for entity %s; "
+                "falling back to the initial conformer.",
+                rejected,
+                num_samples,
+                chain.entity_id,
+            )
+        return samples
+
+    def get_ligand_bond_indices(self, chain: Chain) -> np.ndarray:
+        """Convert ligand bond records to chain-local atom index pairs."""
+        atom_pairs: list[tuple[int, int]] = []
+        for residue_indices, atom_names in zip(
+            chain.bond.residue_index,
+            chain.bond.atom_name,
+            strict=True,
+        ):
+            try:
+                atom_i = chain.find_atom_index(int(residue_indices[0]), atom_names[0])
+                atom_j = chain.find_atom_index(int(residue_indices[1]), atom_names[1])
+            except KeyError as exc:
+                self.logger.warning(
+                    "Skipping invalid ligand bond for entity %s: %s",
+                    chain.entity_id,
+                    exc,
+                )
+                continue
+            atom_pairs.append((atom_i, atom_j))
+        return np.asarray(atom_pairs, dtype=np.int64).reshape(-1, 2)
+
+    def is_valid_ligand_prior(
+        self,
+        initial_coords: np.ndarray,
+        sampled_coords: np.ndarray,
+        bond_indices: np.ndarray,
+    ) -> bool:
+        """Check finite coordinates, bond preservation, and local RMSD."""
+        if sampled_coords.shape != initial_coords.shape:
+            return False
+        return bool(
+            self.get_valid_ligand_prior_mask(
+                initial_coords,
+                sampled_coords[None, ...],
+                bond_indices,
+            )[0]
+        )
+
+    def get_valid_ligand_prior_mask(
+        self,
+        initial_coords: np.ndarray,
+        sampled_coords: np.ndarray,
+        bond_indices: np.ndarray,
+    ) -> np.ndarray:
+        """Validate a batch of ligand priors without a per-sample Python loop."""
+        if sampled_coords.ndim != 3 or sampled_coords.shape[1:] != initial_coords.shape:
+            raise ValueError(
+                "sampled_coords must have shape [Nsample, Natom, 3], got "
+                f"{sampled_coords.shape}."
+            )
+
+        is_valid = np.isfinite(sampled_coords).all(axis=(-2, -1))
+
+        cfg = self.ligand_langevin_config
+        if cfg.max_bond_deviation is not None and len(bond_indices) > 0:
+            atom_i, atom_j = bond_indices.T
+            initial_lengths = np.linalg.norm(
+                initial_coords[atom_i] - initial_coords[atom_j], axis=-1
+            )
+            sampled_lengths = np.linalg.norm(
+                sampled_coords[:, atom_i] - sampled_coords[:, atom_j], axis=-1
+            )
+            max_bond_deviation = np.max(
+                np.abs(sampled_lengths - initial_lengths[None, :]), axis=-1
+            )
+            is_valid &= max_bond_deviation <= cfg.max_bond_deviation
+
+        # Avoid passing non-finite or already rejected samples to the SVD.
+        valid_indices = np.flatnonzero(is_valid)
+        if cfg.max_aligned_rmsd is not None and len(valid_indices) > 0:
+            valid_samples = sampled_coords[valid_indices]
+            initial_batch = np.broadcast_to(initial_coords, valid_samples.shape)
+            aligned_rmsd = compute_rmsd(
+                initial_batch, valid_samples, mask=None, align=True
+            )
+            is_valid[valid_indices] &= aligned_rmsd <= cfg.max_aligned_rmsd
+        return is_valid
 
     # === Helper methods for augmentation and optimal transport permutation === #
     def apply_random_augmentation(

--- a/src/kfold/data/utils/simulation/langevin_dynamics.py
+++ b/src/kfold/data/utils/simulation/langevin_dynamics.py
@@ -4,7 +4,11 @@ Algorithm S3 "Sampling from the Globular Polymer Prior via Short Langevin Dynami
 
 NOTE (SeonghwanSeo): Since bond information is not constructed in current data pipeline,
 I modified the original algorithm to approximate bond forces using residue centers.
-."""
+
+The ligand simulator below is a separate K-Fold prior perturbation path. It
+restores the historical bond-length and bond-angle harmonic potential around a
+supplied CCD/ETKDG conformer; it is not NeuralPLexer3 Algorithm S3.
+"""
 
 import dataclasses
 from typing import Self
@@ -100,6 +104,273 @@ class LangevinDynamicsSimulator:
             is_constraint=is_constraint,
             rng=rng,
         )
+
+
+@dataclasses.dataclass(kw_only=True)
+class LigandLangevinDynamicsConfig:
+    """Configuration for bond-angle harmonic ligand prior perturbation."""
+
+    enabled: bool = False
+    num_steps: int = 100
+    dt: float = 0.01
+    temperature: float = 1.0
+    bond_strength: float = 50.0
+    angle_strength: float = 10.0
+    relaxation_steps: int = 2
+    relaxation_dt: float = 0.00125
+    max_bond_deviation: float | None = None
+    max_aligned_rmsd: float | None = None
+
+    @classmethod
+    def from_config(cls, config: DictConfig | Self) -> Self:
+        """Create a validated config from a structured or OmegaConf config."""
+        base_cfg = OmegaConf.structured(cls)
+        merged_cfg = OmegaConf.merge(base_cfg, config)
+        return OmegaConf.to_object(merged_cfg)
+
+
+class LigandLangevinDynamicsSimulator:
+    """Sample local ligand conformers around a supplied initial structure."""
+
+    def __init__(self, config: LigandLangevinDynamicsConfig) -> None:
+        config = LigandLangevinDynamicsConfig.from_config(config)
+        self._validate_config(config)
+        self.config = config
+
+    @staticmethod
+    def _validate_config(config: LigandLangevinDynamicsConfig) -> None:
+        if config.num_steps < 0:
+            raise ValueError("num_steps must be non-negative.")
+        if config.dt <= 0.0:
+            raise ValueError("dt must be positive.")
+        if config.temperature < 0.0:
+            raise ValueError("temperature must be non-negative.")
+        if config.bond_strength < 0.0 or config.angle_strength < 0.0:
+            raise ValueError("Harmonic restraint strengths must be non-negative.")
+        if config.relaxation_steps < 0:
+            raise ValueError("relaxation_steps must be non-negative.")
+        if config.relaxation_dt <= 0.0:
+            raise ValueError("relaxation_dt must be positive.")
+        if (
+            config.max_bond_deviation is not None
+            and config.max_bond_deviation <= 0.0
+        ):
+            raise ValueError("max_bond_deviation must be positive.")
+        if config.max_aligned_rmsd is not None and config.max_aligned_rmsd <= 0.0:
+            raise ValueError("max_aligned_rmsd must be positive.")
+
+    def __call__(
+        self,
+        x_init: np.ndarray,
+        bond_indices: np.ndarray,
+        num_samples: int,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        return self.simulate(x_init, bond_indices, num_samples, rng)
+
+    def simulate(
+        self,
+        x_init: np.ndarray,
+        bond_indices: np.ndarray,
+        num_samples: int,
+        rng: np.random.Generator | None = None,
+    ) -> np.ndarray:
+        """Run vectorized restrained Langevin dynamics.
+
+        Parameters
+        ----------
+        x_init : np.ndarray
+            Complete initial ligand coordinates, shape ``[Natom, 3]``.
+        bond_indices : np.ndarray
+            Chain-local bonded atom pairs, shape ``[Nbond, 2]``.
+        num_samples : int
+            Number of independent internal conformers to sample.
+        rng : np.random.Generator, optional
+            Random number generator.
+
+        Returns
+        -------
+        np.ndarray
+            Perturbed coordinates with shape ``[Nsample, Natom, 3]``.
+        """
+        if x_init.ndim != 2 or x_init.shape[-1] != 3:
+            raise ValueError(f"x_init must have shape [Natom, 3], got {x_init.shape}.")
+        if not np.isfinite(x_init).all():
+            raise ValueError("x_init must contain only finite coordinates.")
+        if num_samples < 0:
+            raise ValueError("num_samples must be non-negative.")
+        if num_samples == 0:
+            return np.empty((0, *x_init.shape), dtype=x_init.dtype)
+
+        num_atoms = len(x_init)
+        bond_indices = _normalize_pair_indices(bond_indices, num_atoms)
+        angle_indices = _build_angle_indices(bond_indices, num_atoms)
+        rest_bond_lengths = _compute_bond_lengths(x_init, bond_indices)
+        rest_angles = _compute_angles(x_init, angle_indices)
+        x = np.repeat(x_init[None, ...], num_samples, axis=0)
+        if self.config.num_steps == 0 and self.config.relaxation_steps == 0:
+            return x
+
+        rng = rng or np.random.default_rng()
+        dtype = x_init.dtype
+        initial_center = x_init.mean(axis=0, keepdims=True)
+        bond_incidence = _make_incidence_matrix(bond_indices, num_atoms, dtype)
+        rest_bond_lengths = rest_bond_lengths.astype(dtype, copy=False)
+        rest_angles = rest_angles.astype(dtype, copy=False)
+        noise_scale = np.asarray(
+            np.sqrt(2.0 * self.config.temperature * self.config.dt), dtype=dtype
+        )
+
+        bond_i = bond_indices[:, 0]
+        bond_j = bond_indices[:, 1]
+        if len(angle_indices) > 0:
+            angle_i, angle_j, angle_k = angle_indices.T
+            angle_i_incidence = _make_incidence_matrix(
+                np.stack([angle_i, angle_j], axis=-1), num_atoms, dtype
+            )
+            angle_k_incidence = _make_incidence_matrix(
+                np.stack([angle_k, angle_j], axis=-1), num_atoms, dtype
+            )
+        eps = np.asarray(1e-8, dtype=dtype)
+        cos_limit = np.asarray(1.0 - 1e-7, dtype=dtype)
+        total_steps = self.config.num_steps + self.config.relaxation_steps
+        for step_index in range(total_steps):
+            is_stochastic_step = step_index < self.config.num_steps
+            drift = np.zeros_like(x)
+            if len(bond_indices) > 0:
+                displacement = x[:, bond_i] - x[:, bond_j]
+                distance = np.sqrt(
+                    np.einsum("...d,...d->...", displacement, displacement)
+                )
+                is_valid_bond = distance >= eps
+                extension = distance - rest_bond_lengths[None, :]
+                safe_distance = np.maximum(distance, eps)
+                coefficient = -self.config.bond_strength * extension / safe_distance
+                coefficient *= is_valid_bond
+                bond_drift = displacement * coefficient[..., None]
+                drift += np.matmul(bond_incidence, bond_drift)
+
+            if len(angle_indices) > 0:
+                vector_i = x[:, angle_i] - x[:, angle_j]
+                vector_k = x[:, angle_k] - x[:, angle_j]
+                norm_i = np.sqrt(
+                    np.einsum("...d,...d->...", vector_i, vector_i)
+                )
+                norm_k = np.sqrt(
+                    np.einsum("...d,...d->...", vector_k, vector_k)
+                )
+                is_valid_angle = (norm_i >= eps) & (norm_k >= eps)
+                safe_norm_i = np.maximum(norm_i, eps)
+                safe_norm_k = np.maximum(norm_k, eps)
+                unit_i = vector_i / safe_norm_i[..., None]
+                unit_k = vector_k / safe_norm_k[..., None]
+                cos_angle = np.einsum("...d,...d->...", unit_i, unit_k)
+                np.clip(cos_angle, -cos_limit, cos_limit, out=cos_angle)
+                angle = np.arccos(cos_angle)
+                sin_angle = np.sqrt(np.maximum(1.0 - cos_angle**2, eps))
+                angle_extension = angle - rest_angles[None, :]
+                scale = self.config.angle_strength * angle_extension / sin_angle
+                scale *= is_valid_angle
+                angle_gradient_i = (
+                    cos_angle[..., None] * unit_i - unit_k
+                ) * (scale / safe_norm_i)[..., None]
+                angle_gradient_k = (
+                    cos_angle[..., None] * unit_k - unit_i
+                ) * (scale / safe_norm_k)[..., None]
+                drift -= np.matmul(angle_i_incidence, angle_gradient_i)
+                drift -= np.matmul(angle_k_incidence, angle_gradient_k)
+
+            step_dt = (
+                self.config.dt
+                if is_stochastic_step
+                else self.config.relaxation_dt
+            )
+            drift *= step_dt
+            if is_stochastic_step:
+                noise = rng.standard_normal(size=x.shape, dtype=dtype)
+                noise *= noise_scale
+                drift += noise
+            x += drift
+
+        # Remove the translational zero mode without constraining rotation.
+        x -= x.mean(axis=1, keepdims=True) - initial_center[None, ...]
+
+        return x
+
+
+def _build_angle_indices(bond_indices: np.ndarray, num_atoms: int) -> np.ndarray:
+    """Return all unique graph angles ``i-j-k`` induced by ligand bonds."""
+    neighbors: list[list[int]] = [[] for _ in range(num_atoms)]
+    for atom_i, atom_j in bond_indices:
+        neighbors[int(atom_i)].append(int(atom_j))
+        neighbors[int(atom_j)].append(int(atom_i))
+
+    angle_indices: list[tuple[int, int, int]] = []
+    for center, center_neighbors in enumerate(neighbors):
+        for first_index in range(len(center_neighbors) - 1):
+            for second_index in range(first_index + 1, len(center_neighbors)):
+                angle_indices.append(
+                    (
+                        center_neighbors[first_index],
+                        center,
+                        center_neighbors[second_index],
+                    )
+                )
+    return np.asarray(angle_indices, dtype=np.int64).reshape(-1, 3)
+
+
+def _compute_bond_lengths(
+    coords: np.ndarray, bond_indices: np.ndarray
+) -> np.ndarray:
+    """Compute bond lengths for a fixed ligand topology."""
+    if len(bond_indices) == 0:
+        return np.empty((0,), dtype=coords.dtype)
+    displacement = coords[bond_indices[:, 0]] - coords[bond_indices[:, 1]]
+    return np.linalg.norm(displacement, axis=-1)
+
+
+def _compute_angles(coords: np.ndarray, angle_indices: np.ndarray) -> np.ndarray:
+    """Compute bond angles in radians for a fixed ligand topology."""
+    if len(angle_indices) == 0:
+        return np.empty((0,), dtype=coords.dtype)
+    atom_i, atom_j, atom_k = angle_indices.T
+    vector_i = coords[atom_i] - coords[atom_j]
+    vector_k = coords[atom_k] - coords[atom_j]
+    norm_i = np.linalg.norm(vector_i, axis=-1)
+    norm_k = np.linalg.norm(vector_k, axis=-1)
+    denominator = np.maximum(norm_i * norm_k, 1e-8)
+    cos_angle = np.einsum("...d,...d->...", vector_i, vector_k) / denominator
+    return np.arccos(np.clip(cos_angle, -1.0 + 1e-7, 1.0 - 1e-7))
+
+
+def _normalize_pair_indices(pair_indices: np.ndarray, num_atoms: int) -> np.ndarray:
+    """Validate, canonicalize, and deduplicate undirected atom pairs."""
+    pair_indices = np.asarray(pair_indices, dtype=np.int64)
+    if pair_indices.size == 0:
+        return np.empty((0, 2), dtype=np.int64)
+    if pair_indices.ndim != 2 or pair_indices.shape[1] != 2:
+        raise ValueError(
+            f"pair_indices must have shape [Npair, 2], got {pair_indices.shape}."
+        )
+    if pair_indices.min() < 0 or pair_indices.max() >= num_atoms:
+        raise ValueError("pair_indices contains an out-of-range atom index.")
+    if np.any(pair_indices[:, 0] == pair_indices[:, 1]):
+        raise ValueError("pair_indices cannot contain self edges.")
+    pair_indices = np.sort(pair_indices, axis=1)
+    return np.unique(pair_indices, axis=0)
+
+
+def _make_incidence_matrix(
+    pair_indices: np.ndarray,
+    num_atoms: int,
+    dtype: np.dtype,
+) -> np.ndarray:
+    """Return an atom-by-edge incidence matrix for vectorized force scatter."""
+    incidence = np.zeros((num_atoms, len(pair_indices)), dtype=dtype)
+    edge_index = np.arange(len(pair_indices))
+    incidence[pair_indices[:, 0], edge_index] = 1.0
+    incidence[pair_indices[:, 1], edge_index] = -1.0
+    return incidence
 
 
 def run_langevin_dynamics(


### PR DESCRIPTION
## What changed

- Add a vectorized bond-length and bond-angle harmonic Langevin sampler for multi-atom small-molecule priors.
- Wire it into the current `PriorSampler` flow after the ETKDG/apo source is flattened and missing atoms are relaxed.
- Keep the existing IID Gaussian perturbation as the fallback when ligand Langevin is disabled.
- Set the training schedule to 100 stochastic steps at `dt=0.01`, followed by 2 noise-free harmonic correction steps at `dt=0.00125`.
- Declare `numba` in the `train` optional dependencies.

## Why

The Gaussian ligand prior was under-dispersed relative to the historical approximately 1 Å coverage target and produced substantially larger bond/angle distortion. Simply reducing the Langevin step count while increasing `dt` recovered coverage but introduced integration bias. Two short deterministic correction steps recover the target bond/angle geometry while retaining the runtime gain.

## Impact

Small-molecule ligand priors now use the harmonic Langevin path by default in `configs/train/full.yaml`. Protein BioPrior, nucleic-acid handling, `prior_uid` rigid-group augmentation, and OT behavior from `train/0723` are preserved.

## Validation

- Rebased onto `origin/train/0723` at `bb5a6cbf8c0e1c3e8f8c32091d17f1167cb2b4ff`.
- `git diff --check origin/train/0723...HEAD` passed.
- CPU benchmark on 100 unique real training CCD ligands, 4 priors per ligand, selection digest `537e9f02552591a096a4e4dc0ba3928e2e43535d66e31a0920341fd48dc33d25`:
  - 200-step vectorized: 16.46 ms/ligand
  - accelerated 100+2: 8.55 ms/ligand (1.92x faster)
  - accelerated coverage: 0.980 Å RMSD to initial
  - bond deviation: 0.1332 Å; angle deviation: 13.31 degrees
- The benchmark exercised the unchanged ligand simulator core before the final rebase adaptation to the `train/0723` `PriorSampler` call path.
- Unit test suite was not run for this publish step.
