### PR TITLE
Add exact-bin interface contact hard-pair loss

### DIFF
--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -168,14 +168,13 @@ loss:
     near_cutoff: 12.0
     hard_negative_weight: 3.0
 
-  # FN-priority contact supervision on active inter-chain interfaces.
+  # Hard-pair exact-bin CE on active inter-chain interfaces.
   # This is inactive unless loss.weights.interface_contact is positive.
   interface_contact_loss:
     num_bins: 64
     min_dist: 2.0
     max_dist: 22.0
     contact_cutoff: 8.0
-    far_cutoff: 20.0
     positive_weight: 0.75
     negative_weight: 0.25
     focal_gamma: 2.0

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -151,6 +151,7 @@ loss:
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     smooth_lddt: 1.0
     patch_geometry: 5e-2
+    interface_contact: 0.0
 
   # Distogram loss
   distogram_loss:
@@ -166,6 +167,20 @@ loss:
     max_dist: 22.0
     near_cutoff: 12.0
     hard_negative_weight: 3.0
+
+  # FN-priority contact supervision on active inter-chain interfaces.
+  # This is inactive unless loss.weights.interface_contact is positive.
+  interface_contact_loss:
+    num_bins: 64
+    min_dist: 2.0
+    max_dist: 22.0
+    contact_cutoff: 8.0
+    far_cutoff: 20.0
+    positive_weight: 0.75
+    negative_weight: 0.25
+    focal_gamma: 2.0
+    fp_budget_ratio: 4.0
+    eps: 1e-6
 
   # Diffusion loss
   diffusion_loss:

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -151,7 +151,7 @@ loss:
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     smooth_lddt: 1.0
     patch_geometry: 5e-2
-    interface_contact: 0.0
+    interface_contact: 5e-2
 
   # Distogram loss
   distogram_loss:

--- a/src/kfold/training/loss/__init__.py
+++ b/src/kfold/training/loss/__init__.py
@@ -1,1 +1,1 @@
-from . import confidence, diffusion, distogram, patch_geometry
+from . import confidence, diffusion, distogram, interface_contact, patch_geometry

--- a/src/kfold/training/loss/interface_contact.py
+++ b/src/kfold/training/loss/interface_contact.py
@@ -5,23 +5,9 @@ import torch.nn.functional as F
 
 from kfold.data.types.model_input import FoldingInput
 
-_CHAIN_TYPE_COUNT = 4
-_MODALITIES: tuple[tuple[int, int, str], ...] = (
-    (0, 0, "protein_protein"),
-    (0, 1, "protein_dna"),
-    (0, 2, "protein_rna"),
-    (0, 3, "protein_ligand"),
-    (1, 1, "dna_dna"),
-    (1, 2, "dna_rna"),
-    (1, 3, "dna_ligand"),
-    (2, 2, "rna_rna"),
-    (2, 3, "rna_ligand"),
-    (3, 3, "ligand_ligand"),
-)
-
 
 class InterfaceContactBalancedLoss(torch.nn.Module):
-    """FN-priority contact loss with count-sensitive far-pair supervision."""
+    """Reweight exact-bin distogram CE on hard inter-chain pairs."""
 
     def __init__(
         self,
@@ -29,7 +15,6 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
         max_dist: float = 22.0,
         num_bins: int = 64,
         contact_cutoff: float = 8.0,
-        far_cutoff: float = 20.0,
         positive_weight: float = 0.75,
         negative_weight: float = 0.25,
         focal_gamma: float = 2.0,
@@ -37,25 +22,21 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
         eps: float = 1e-6,
     ) -> None:
         super().__init__()
-        if not min_dist < contact_cutoff < far_cutoff <= max_dist:
-            raise ValueError(
-                "Expected min_dist < contact_cutoff < far_cutoff <= max_dist."
-            )
+        if not min_dist < contact_cutoff < max_dist:
+            raise ValueError("Expected min_dist < contact_cutoff < max_dist.")
         if num_bins <= 1:
             raise ValueError("num_bins must be greater than one.")
         if positive_weight <= 0 or negative_weight < 0:
             raise ValueError("Loss weights must be non-negative with positive FN weight.")
         if not math.isclose(positive_weight + negative_weight, 1.0):
             raise ValueError("positive_weight and negative_weight must sum to one.")
-        if focal_gamma < 0:
-            raise ValueError("focal_gamma must be non-negative.")
-        if fp_budget_ratio <= 0:
-            raise ValueError("fp_budget_ratio must be positive.")
-        if eps <= 0:
-            raise ValueError("eps must be positive.")
+        if focal_gamma < 0 or fp_budget_ratio <= 0 or eps <= 0:
+            raise ValueError(
+                "Gamma must be non-negative; budget and eps must be positive."
+            )
 
+        self.num_bins = num_bins
         self.contact_cutoff = contact_cutoff
-        self.far_cutoff = far_cutoff
         self.positive_weight = positive_weight
         self.negative_weight = negative_weight
         self.focal_gamma = focal_gamma
@@ -64,6 +45,10 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
 
         bin_size = (max_dist - min_dist) / num_bins
         first_bin = min_dist + bin_size
+        last_bin = max_dist - bin_size
+        boundaries = torch.linspace(first_bin, last_bin, num_bins - 1)
+        self.register_buffer("boundaries", boundaries, persistent=False)
+
         contact_bin = int((contact_cutoff - first_bin) / bin_size)
         self.contact_bin = max(0, min(contact_bin, num_bins - 1))
 
@@ -112,35 +97,30 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
             include_self=True,
         )
         rank_within_group = sorted_position - first_position[sorted_group]
-        selected = rank_within_group < group_budget[sorted_group]
-        return sorted_pair_index[selected]
+        return sorted_pair_index[rank_within_group < group_budget[sorted_group]]
 
     def forward(
         self,
         logits: torch.Tensor,
         f_input: FoldingInput,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
-        """Compute an example-macro, interface-balanced contact loss."""
+        """Compute example-macro hard-pair distogram supervision."""
+        if logits.shape[-1] != self.num_bins:
+            raise ValueError(
+                f"Expected {self.num_bins} distogram bins, got {logits.shape[-1]}."
+            )
+
         logits_float = logits.float()
         batch_size, num_tokens, _, _ = logits_float.shape
         device = logits.device
-
-        log_normalizer = torch.logsumexp(logits_float, dim=-1)
-        log_contact = torch.logsumexp(
-            logits_float[..., : self.contact_bin + 1],
-            dim=-1,
-        )
-        log_noncontact = torch.logsumexp(
-            logits_float[..., self.contact_bin + 1 :],
-            dim=-1,
-        )
-        log_p_contact = log_contact - log_normalizer
-        p_contact = log_p_contact.exp()
+        log_prob = F.log_softmax(logits_float, dim=-1)
+        p_contact = log_prob[..., : self.contact_bin + 1].logsumexp(dim=-1).exp()
 
         with torch.no_grad():
             coords = f_input.token.repr_coords.float()
             displacement = coords[..., None, :, :] - coords[..., :, None, :]
             distance = displacement.norm(dim=-1)
+            target = (distance.unsqueeze(-1) > self.boundaries).sum(dim=-1).long()
 
             repr_mask = f_input.token.repr_mask
             pair_mask = repr_mask[..., None, :] & repr_mask[..., :, None]
@@ -156,7 +136,7 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
             ).triu(diagonal=1)
             valid = pair_mask & inter_chain & upper_triangle
             positive = valid & (distance < self.contact_cutoff)
-            far = valid & (distance >= self.far_cutoff)
+            negative = valid & ~positive
 
             dense_asym_id = torch.stack(
                 [
@@ -181,34 +161,30 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
             group_id = batch_offset + asym_low * chain_stride + asym_high
             num_groups = batch_size * group_stride
 
+        exact_bin_ce = -log_prob.gather(-1, target.unsqueeze(-1)).squeeze(-1)
         positive_group = group_id[positive]
-        far_group = group_id[far]
+        negative_group = group_id[negative]
         positive_probability = p_contact[positive]
-        positive_bce = -log_p_contact[positive]
+        negative_probability = p_contact[negative]
+        positive_ce = exact_bin_ce[positive]
+        negative_ce = exact_bin_ce[negative]
         positive_focal_weight = (
             (1.0 - positive_probability).pow(self.focal_gamma).detach()
         )
-        far_probability = p_contact[far]
-        far_log_odds = (log_contact - log_noncontact)[far]
-        far_bce = F.softplus(far_log_odds)
-        far_focal_weight = far_probability.pow(self.focal_gamma).detach()
+        negative_focal_weight = negative_probability.pow(self.focal_gamma).detach()
 
-        positive_numerator = self._scatter_sum(
-            positive_focal_weight * positive_bce,
-            positive_group,
-            num_groups,
-        )
-        positive_denominator = self._scatter_sum(
-            positive_focal_weight,
-            positive_group,
-            num_groups,
-        )
         positive_count = self._scatter_sum(
-            torch.ones_like(positive_bce),
+            torch.ones_like(positive_ce),
+            positive_group,
+            num_groups,
+        )
+        positive_numerator = self._scatter_sum(
+            positive_focal_weight * positive_ce,
             positive_group,
             num_groups,
         )
         active_interface = positive_count > 0
+        positive_loss = positive_numerator / (positive_count + self.eps)
 
         with torch.no_grad():
             fp_budget = torch.ceil(positive_count * self.fp_budget_ratio).long()
@@ -217,150 +193,105 @@ class InterfaceContactBalancedLoss(torch.nn.Module):
                 fp_budget,
                 torch.zeros_like(fp_budget),
             )
+            selected_negative_index = self._segmented_tail_indices(
+                negative_probability,
+                negative_group,
+                fp_budget,
+                num_groups,
+            )
 
-        selected_far_index = self._segmented_tail_indices(
-            far_probability.detach(),
-            far_group,
-            fp_budget,
+        selected_negative_group = negative_group[selected_negative_index]
+        selected_negative_numerator = self._scatter_sum(
+            (negative_focal_weight * negative_ce)[selected_negative_index],
+            selected_negative_group,
             num_groups,
         )
-        selected_far_group = far_group[selected_far_index]
-        selected_far_numerator = self._scatter_sum(
-            (far_focal_weight * far_bce)[selected_far_index],
-            selected_far_group,
+        selected_negative_count = self._scatter_sum(
+            torch.ones_like(negative_ce)[selected_negative_index],
+            selected_negative_group,
             num_groups,
         )
-        selected_far_count = self._scatter_sum(
-            torch.ones_like(far_bce)[selected_far_index],
-            selected_far_group,
-            num_groups,
-        )
+        negative_loss = selected_negative_numerator / (selected_negative_count + self.eps)
 
-        positive_loss = positive_numerator / (positive_denominator + self.eps)
-        far_loss = selected_far_numerator / (positive_count + self.eps)
-
-        active_group_index = torch.nonzero(active_interface, as_tuple=False).flatten()
+        active_group_index = torch.nonzero(
+            active_interface,
+            as_tuple=False,
+        ).flatten()
         active_batch = torch.div(
             active_group_index,
             group_stride,
             rounding_mode="floor",
-        )
-        example_positive_loss_sum = self._scatter_sum(
-            positive_loss[active_group_index],
-            active_batch,
-            batch_size,
         )
         example_interface_count = self._scatter_sum(
             torch.ones_like(positive_loss[active_group_index]),
             active_batch,
             batch_size,
         )
-        example_positive_loss = example_positive_loss_sum / example_interface_count.clamp(
-            min=1.0
-        )
-
-        example_far_loss_sum = self._scatter_sum(
-            far_loss[active_group_index],
+        example_positive_loss = self._scatter_sum(
+            positive_loss[active_group_index],
             active_batch,
             batch_size,
-        )
-        example_far_loss = example_far_loss_sum / example_interface_count.clamp(min=1.0)
+        ) / example_interface_count.clamp(min=1.0)
+        example_negative_loss = self._scatter_sum(
+            negative_loss[active_group_index],
+            active_batch,
+            batch_size,
+        ) / example_interface_count.clamp(min=1.0)
         example_loss = (
             self.positive_weight * example_positive_loss
-            + self.negative_weight * example_far_loss
+            + self.negative_weight * example_negative_loss
         )
-        loss = example_loss.mean() + log_p_contact.sum() * 0.0
+        loss = example_loss.mean() + logits_float.sum() * 0.0
 
-        active_example = example_interface_count > 0
         active_interface_float = active_interface.to(logits_float.dtype)
+        active_interface_count = active_interface_float.sum().clamp(min=1.0)
         positive_float = positive.to(logits_float.dtype)
-        far_float = far.to(logits_float.dtype)
-        selected_far_probability = far_probability[selected_far_index]
-        selected_far_focal_weight = far_focal_weight[selected_far_index]
+        negative_float = negative.to(logits_float.dtype)
+        selected_negative_probability = negative_probability[selected_negative_index]
+        selected_negative_focal_weight = negative_focal_weight[selected_negative_index]
         metrics = {
             "interface_contact_loss": loss.detach(),
             "interface_contact_fn_loss": (
-                (positive_loss * active_interface_float).sum()
-                / active_interface_float.sum().clamp(min=1.0)
+                (positive_loss * active_interface_float).sum() / active_interface_count
             ).detach(),
             "interface_contact_fp_loss": (
-                (far_loss * active_interface_float).sum()
-                / active_interface_float.sum().clamp(min=1.0)
+                (negative_loss * active_interface_float).sum() / active_interface_count
             ).detach(),
             "interface_contact_active_interfaces": (
                 active_interface_float.sum().detach()
             ),
-            "interface_contact_active_examples": active_example.float().sum().detach(),
+            "interface_contact_active_examples": (
+                (example_interface_count > 0).float().sum().detach()
+            ),
             "interface_contact_positive_pairs": positive_float.sum().detach(),
-            "interface_contact_far_pairs": far_float.sum().detach(),
-            "interface_contact_selected_far_pairs": (selected_far_count.sum().detach()),
+            "interface_contact_negative_pairs": negative_float.sum().detach(),
+            "interface_contact_selected_negative_pairs": (
+                selected_negative_count.sum().detach()
+            ),
             "interface_contact_fp_tail_budget": (
                 (fp_budget * active_interface).sum().detach()
             ),
             "interface_contact_p_true_contact": (
-                (p_contact * positive_float).sum() / positive_float.sum().clamp(min=1.0)
+                positive_probability.sum() / positive_float.sum().clamp(min=1.0)
             ).detach(),
-            "interface_contact_p_true_far": (
-                far_probability.sum() / far_float.sum().clamp(min=1.0)
+            "interface_contact_p_true_negative": (
+                negative_probability.sum() / negative_float.sum().clamp(min=1.0)
             ).detach(),
-            "interface_contact_p_selected_far": (
-                selected_far_probability.sum() / selected_far_probability.numel()
-                if selected_far_probability.numel() > 0
-                else far_probability.sum() * 0.0
+            "interface_contact_p_selected_negative": (
+                selected_negative_probability.mean()
+                if selected_negative_probability.numel() > 0
+                else negative_probability.sum() * 0.0
             ).detach(),
             "interface_contact_fn_focal_weight": (
                 positive_focal_weight.sum() / positive_float.sum().clamp(min=1.0)
             ).detach(),
             "interface_contact_fp_focal_weight": (
-                far_focal_weight.sum() / far_float.sum().clamp(min=1.0)
+                negative_focal_weight.sum() / negative_float.sum().clamp(min=1.0)
             ).detach(),
             "interface_contact_selected_fp_focal_weight": (
-                selected_far_focal_weight.sum() / selected_far_focal_weight.numel()
-                if selected_far_focal_weight.numel() > 0
-                else far_focal_weight.sum() * 0.0
+                selected_negative_focal_weight.mean()
+                if selected_negative_focal_weight.numel() > 0
+                else negative_focal_weight.sum() * 0.0
             ).detach(),
         }
-
-        with torch.no_grad():
-            chain_type = f_input.token.chain_type
-            type_i = chain_type[..., :, None]
-            type_j = chain_type[..., None, :]
-            type_low = torch.minimum(type_i, type_j)
-            type_high = torch.maximum(type_i, type_j)
-            modality = type_low * _CHAIN_TYPE_COUNT + type_high
-            group_modality = torch.full(
-                (num_groups,),
-                -1,
-                dtype=torch.long,
-                device=device,
-            )
-            group_modality.scatter_reduce_(
-                0,
-                group_id[valid],
-                modality[valid],
-                reduce="amax",
-                include_self=True,
-            )
-            for low, high, name in _MODALITIES:
-                modality_id = low * _CHAIN_TYPE_COUNT + high
-                in_modality = valid & (modality == modality_id)
-                metrics[f"interface_contact_active_interfaces_{name}"] = (
-                    (active_interface & (group_modality == modality_id))
-                    .float()
-                    .sum()
-                    .detach()
-                )
-                metrics[f"interface_contact_positive_pairs_{name}"] = (
-                    (positive & in_modality).float().sum().detach()
-                )
-                metrics[f"interface_contact_far_pairs_{name}"] = (
-                    (far & in_modality).float().sum().detach()
-                )
-                metrics[f"interface_contact_selected_far_pairs_{name}"] = (
-                    (group_modality[selected_far_group] == modality_id)
-                    .float()
-                    .sum()
-                    .detach()
-                )
-
         return loss, metrics

--- a/src/kfold/training/loss/interface_contact.py
+++ b/src/kfold/training/loss/interface_contact.py
@@ -1,0 +1,366 @@
+import math
+
+import torch
+import torch.nn.functional as F
+
+from kfold.data.types.model_input import FoldingInput
+
+_CHAIN_TYPE_COUNT = 4
+_MODALITIES: tuple[tuple[int, int, str], ...] = (
+    (0, 0, "protein_protein"),
+    (0, 1, "protein_dna"),
+    (0, 2, "protein_rna"),
+    (0, 3, "protein_ligand"),
+    (1, 1, "dna_dna"),
+    (1, 2, "dna_rna"),
+    (1, 3, "dna_ligand"),
+    (2, 2, "rna_rna"),
+    (2, 3, "rna_ligand"),
+    (3, 3, "ligand_ligand"),
+)
+
+
+class InterfaceContactBalancedLoss(torch.nn.Module):
+    """FN-priority contact loss with count-sensitive far-pair supervision."""
+
+    def __init__(
+        self,
+        min_dist: float = 2.0,
+        max_dist: float = 22.0,
+        num_bins: int = 64,
+        contact_cutoff: float = 8.0,
+        far_cutoff: float = 20.0,
+        positive_weight: float = 0.75,
+        negative_weight: float = 0.25,
+        focal_gamma: float = 2.0,
+        fp_budget_ratio: float = 4.0,
+        eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        if not min_dist < contact_cutoff < far_cutoff <= max_dist:
+            raise ValueError(
+                "Expected min_dist < contact_cutoff < far_cutoff <= max_dist."
+            )
+        if num_bins <= 1:
+            raise ValueError("num_bins must be greater than one.")
+        if positive_weight <= 0 or negative_weight < 0:
+            raise ValueError("Loss weights must be non-negative with positive FN weight.")
+        if not math.isclose(positive_weight + negative_weight, 1.0):
+            raise ValueError("positive_weight and negative_weight must sum to one.")
+        if focal_gamma < 0:
+            raise ValueError("focal_gamma must be non-negative.")
+        if fp_budget_ratio <= 0:
+            raise ValueError("fp_budget_ratio must be positive.")
+        if eps <= 0:
+            raise ValueError("eps must be positive.")
+
+        self.contact_cutoff = contact_cutoff
+        self.far_cutoff = far_cutoff
+        self.positive_weight = positive_weight
+        self.negative_weight = negative_weight
+        self.focal_gamma = focal_gamma
+        self.fp_budget_ratio = fp_budget_ratio
+        self.eps = eps
+
+        bin_size = (max_dist - min_dist) / num_bins
+        first_bin = min_dist + bin_size
+        contact_bin = int((contact_cutoff - first_bin) / bin_size)
+        self.contact_bin = max(0, min(contact_bin, num_bins - 1))
+
+    @staticmethod
+    def _scatter_sum(
+        values: torch.Tensor,
+        group_index: torch.Tensor,
+        num_groups: int,
+    ) -> torch.Tensor:
+        return values.new_zeros(num_groups).scatter_add(0, group_index, values)
+
+    @staticmethod
+    def _segmented_tail_indices(
+        probabilities: torch.Tensor,
+        group_index: torch.Tensor,
+        group_budget: torch.Tensor,
+        num_groups: int,
+    ) -> torch.Tensor:
+        """Select the highest-probability entries within each group."""
+        if probabilities.numel() == 0:
+            return group_index.new_empty(0)
+
+        probability_order = torch.argsort(
+            probabilities,
+            descending=True,
+            stable=True,
+        )
+        probability_sorted_group = group_index[probability_order]
+        group_order = torch.argsort(probability_sorted_group, stable=True)
+        sorted_pair_index = probability_order[group_order]
+        sorted_group = group_index[sorted_pair_index]
+        sorted_position = torch.arange(
+            probabilities.numel(),
+            device=probabilities.device,
+            dtype=torch.long,
+        )
+        first_position = group_index.new_full(
+            (num_groups,),
+            probabilities.numel(),
+        )
+        first_position.scatter_reduce_(
+            0,
+            sorted_group,
+            sorted_position,
+            reduce="amin",
+            include_self=True,
+        )
+        rank_within_group = sorted_position - first_position[sorted_group]
+        selected = rank_within_group < group_budget[sorted_group]
+        return sorted_pair_index[selected]
+
+    def forward(
+        self,
+        logits: torch.Tensor,
+        f_input: FoldingInput,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Compute an example-macro, interface-balanced contact loss."""
+        logits_float = logits.float()
+        batch_size, num_tokens, _, _ = logits_float.shape
+        device = logits.device
+
+        log_normalizer = torch.logsumexp(logits_float, dim=-1)
+        log_contact = torch.logsumexp(
+            logits_float[..., : self.contact_bin + 1],
+            dim=-1,
+        )
+        log_noncontact = torch.logsumexp(
+            logits_float[..., self.contact_bin + 1 :],
+            dim=-1,
+        )
+        log_p_contact = log_contact - log_normalizer
+        p_contact = log_p_contact.exp()
+
+        with torch.no_grad():
+            coords = f_input.token.repr_coords.float()
+            displacement = coords[..., None, :, :] - coords[..., :, None, :]
+            distance = displacement.norm(dim=-1)
+
+            repr_mask = f_input.token.repr_mask
+            pair_mask = repr_mask[..., None, :] & repr_mask[..., :, None]
+            asym_id = f_input.token.asym_id
+            asym_i = asym_id[..., :, None]
+            asym_j = asym_id[..., None, :]
+            inter_chain = asym_i != asym_j
+            upper_triangle = torch.ones(
+                num_tokens,
+                num_tokens,
+                dtype=torch.bool,
+                device=device,
+            ).triu(diagonal=1)
+            valid = pair_mask & inter_chain & upper_triangle
+            positive = valid & (distance < self.contact_cutoff)
+            far = valid & (distance >= self.far_cutoff)
+
+            dense_asym_id = torch.stack(
+                [
+                    torch.unique(
+                        example_asym_id,
+                        sorted=True,
+                        return_inverse=True,
+                    )[1]
+                    for example_asym_id in asym_id
+                ],
+                dim=0,
+            )
+            dense_asym_i = dense_asym_id[..., :, None]
+            dense_asym_j = dense_asym_id[..., None, :]
+            chain_stride = num_tokens
+            group_stride = chain_stride * chain_stride
+            batch_offset = (
+                torch.arange(batch_size, device=device, dtype=torch.long) * group_stride
+            )[:, None, None]
+            asym_low = torch.minimum(dense_asym_i, dense_asym_j)
+            asym_high = torch.maximum(dense_asym_i, dense_asym_j)
+            group_id = batch_offset + asym_low * chain_stride + asym_high
+            num_groups = batch_size * group_stride
+
+        positive_group = group_id[positive]
+        far_group = group_id[far]
+        positive_probability = p_contact[positive]
+        positive_bce = -log_p_contact[positive]
+        positive_focal_weight = (
+            (1.0 - positive_probability).pow(self.focal_gamma).detach()
+        )
+        far_probability = p_contact[far]
+        far_log_odds = (log_contact - log_noncontact)[far]
+        far_bce = F.softplus(far_log_odds)
+        far_focal_weight = far_probability.pow(self.focal_gamma).detach()
+
+        positive_numerator = self._scatter_sum(
+            positive_focal_weight * positive_bce,
+            positive_group,
+            num_groups,
+        )
+        positive_denominator = self._scatter_sum(
+            positive_focal_weight,
+            positive_group,
+            num_groups,
+        )
+        positive_count = self._scatter_sum(
+            torch.ones_like(positive_bce),
+            positive_group,
+            num_groups,
+        )
+        active_interface = positive_count > 0
+
+        with torch.no_grad():
+            fp_budget = torch.ceil(positive_count * self.fp_budget_ratio).long()
+            fp_budget = torch.where(
+                active_interface,
+                fp_budget,
+                torch.zeros_like(fp_budget),
+            )
+
+        selected_far_index = self._segmented_tail_indices(
+            far_probability.detach(),
+            far_group,
+            fp_budget,
+            num_groups,
+        )
+        selected_far_group = far_group[selected_far_index]
+        selected_far_numerator = self._scatter_sum(
+            (far_focal_weight * far_bce)[selected_far_index],
+            selected_far_group,
+            num_groups,
+        )
+        selected_far_count = self._scatter_sum(
+            torch.ones_like(far_bce)[selected_far_index],
+            selected_far_group,
+            num_groups,
+        )
+
+        positive_loss = positive_numerator / (positive_denominator + self.eps)
+        far_loss = selected_far_numerator / (positive_count + self.eps)
+
+        active_group_index = torch.nonzero(active_interface, as_tuple=False).flatten()
+        active_batch = torch.div(
+            active_group_index,
+            group_stride,
+            rounding_mode="floor",
+        )
+        example_positive_loss_sum = self._scatter_sum(
+            positive_loss[active_group_index],
+            active_batch,
+            batch_size,
+        )
+        example_interface_count = self._scatter_sum(
+            torch.ones_like(positive_loss[active_group_index]),
+            active_batch,
+            batch_size,
+        )
+        example_positive_loss = example_positive_loss_sum / example_interface_count.clamp(
+            min=1.0
+        )
+
+        example_far_loss_sum = self._scatter_sum(
+            far_loss[active_group_index],
+            active_batch,
+            batch_size,
+        )
+        example_far_loss = example_far_loss_sum / example_interface_count.clamp(min=1.0)
+        example_loss = (
+            self.positive_weight * example_positive_loss
+            + self.negative_weight * example_far_loss
+        )
+        loss = example_loss.mean() + log_p_contact.sum() * 0.0
+
+        active_example = example_interface_count > 0
+        active_interface_float = active_interface.to(logits_float.dtype)
+        positive_float = positive.to(logits_float.dtype)
+        far_float = far.to(logits_float.dtype)
+        selected_far_probability = far_probability[selected_far_index]
+        selected_far_focal_weight = far_focal_weight[selected_far_index]
+        metrics = {
+            "interface_contact_loss": loss.detach(),
+            "interface_contact_fn_loss": (
+                (positive_loss * active_interface_float).sum()
+                / active_interface_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_fp_loss": (
+                (far_loss * active_interface_float).sum()
+                / active_interface_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_active_interfaces": (
+                active_interface_float.sum().detach()
+            ),
+            "interface_contact_active_examples": active_example.float().sum().detach(),
+            "interface_contact_positive_pairs": positive_float.sum().detach(),
+            "interface_contact_far_pairs": far_float.sum().detach(),
+            "interface_contact_selected_far_pairs": (selected_far_count.sum().detach()),
+            "interface_contact_fp_tail_budget": (
+                (fp_budget * active_interface).sum().detach()
+            ),
+            "interface_contact_p_true_contact": (
+                (p_contact * positive_float).sum() / positive_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_p_true_far": (
+                far_probability.sum() / far_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_p_selected_far": (
+                selected_far_probability.sum() / selected_far_probability.numel()
+                if selected_far_probability.numel() > 0
+                else far_probability.sum() * 0.0
+            ).detach(),
+            "interface_contact_fn_focal_weight": (
+                positive_focal_weight.sum() / positive_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_fp_focal_weight": (
+                far_focal_weight.sum() / far_float.sum().clamp(min=1.0)
+            ).detach(),
+            "interface_contact_selected_fp_focal_weight": (
+                selected_far_focal_weight.sum() / selected_far_focal_weight.numel()
+                if selected_far_focal_weight.numel() > 0
+                else far_focal_weight.sum() * 0.0
+            ).detach(),
+        }
+
+        with torch.no_grad():
+            chain_type = f_input.token.chain_type
+            type_i = chain_type[..., :, None]
+            type_j = chain_type[..., None, :]
+            type_low = torch.minimum(type_i, type_j)
+            type_high = torch.maximum(type_i, type_j)
+            modality = type_low * _CHAIN_TYPE_COUNT + type_high
+            group_modality = torch.full(
+                (num_groups,),
+                -1,
+                dtype=torch.long,
+                device=device,
+            )
+            group_modality.scatter_reduce_(
+                0,
+                group_id[valid],
+                modality[valid],
+                reduce="amax",
+                include_self=True,
+            )
+            for low, high, name in _MODALITIES:
+                modality_id = low * _CHAIN_TYPE_COUNT + high
+                in_modality = valid & (modality == modality_id)
+                metrics[f"interface_contact_active_interfaces_{name}"] = (
+                    (active_interface & (group_modality == modality_id))
+                    .float()
+                    .sum()
+                    .detach()
+                )
+                metrics[f"interface_contact_positive_pairs_{name}"] = (
+                    (positive & in_modality).float().sum().detach()
+                )
+                metrics[f"interface_contact_far_pairs_{name}"] = (
+                    (far & in_modality).float().sum().detach()
+                )
+                metrics[f"interface_contact_selected_far_pairs_{name}"] = (
+                    (group_modality[selected_far_group] == modality_id)
+                    .float()
+                    .sum()
+                    .detach()
+                )
+
+        return loss, metrics

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -220,6 +220,7 @@ class LossConfig(_Config):
     diffusion_loss: Any
     confidence_loss: Any
     patch_geometry_loss: Any = dataclasses.field(default_factory=dict)
+    interface_contact_loss: Any = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -417,6 +418,11 @@ class KFoldTrainingModule(pl.LightningModule):
         self.patch_geometry_loss = loss_fn.patch_geometry.PatchPairGeometryLoss(
             **loss_config.patch_geometry_loss
         )
+        self.interface_contact_loss = (
+            loss_fn.interface_contact.InterfaceContactBalancedLoss(
+                **loss_config.interface_contact_loss
+            )
+        )
 
         # Diffusion loss
         diffusion_loss_config = loss_config.diffusion_loss
@@ -587,6 +593,19 @@ class KFoldTrainingModule(pl.LightningModule):
                 logits=model_output["distogram"]["logits"],
                 f_input=f_input,
             )
+            interface_contact_weight = self.loss_weights.get(
+                "interface_contact",
+                0.0,
+            )
+            if interface_contact_weight > 0:
+                interface_contact_loss, interface_contact_metrics = (
+                    self.interface_contact_loss(
+                        logits=model_output["distogram"]["logits"],
+                        f_input=f_input,
+                    )
+                )
+            else:
+                interface_contact_loss, interface_contact_metrics = 0.0, {}
             patch_weight = self.loss_weights.get("patch_geometry", 0.0)
             if patch_weight > 0 and "patch_geometry" in model_output:
                 patch_geometry_loss, patch_geometry_metrics = self.patch_geometry_loss(
@@ -596,6 +615,7 @@ class KFoldTrainingModule(pl.LightningModule):
                 patch_geometry_loss, patch_geometry_metrics = 0.0, {}
         else:
             distogram_loss, distogram_metrics = 0.0, {}
+            interface_contact_loss, interface_contact_metrics = 0.0, {}
             patch_geometry_loss, patch_geometry_metrics = 0.0, {}
 
         if self.train_diffusion_head:
@@ -646,12 +666,14 @@ class KFoldTrainingModule(pl.LightningModule):
             + loss_weights["distogram"] * distogram_loss
             + loss_weights["confidence"] * confidence_loss
             + loss_weights.get("patch_geometry", 0.0) * patch_geometry_loss
+            + loss_weights.get("interface_contact", 0.0) * interface_contact_loss
         )  # [B,]
         assert torch.is_tensor(loss), "Loss must be a torch.Tensor."
 
         # Log loss and metrics
         all_metrics = (
             distogram_metrics
+            | interface_contact_metrics
             | patch_geometry_metrics
             | diffusion_metrics
             | confidence_metrics

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -593,10 +593,7 @@ class KFoldTrainingModule(pl.LightningModule):
                 logits=model_output["distogram"]["logits"],
                 f_input=f_input,
             )
-            interface_contact_weight = self.loss_weights.get(
-                "interface_contact",
-                0.0,
-            )
+            interface_contact_weight = self.loss_weights["interface_contact"]
             if interface_contact_weight > 0:
                 interface_contact_loss, interface_contact_metrics = (
                     self.interface_contact_loss(
@@ -606,7 +603,7 @@ class KFoldTrainingModule(pl.LightningModule):
                 )
             else:
                 interface_contact_loss, interface_contact_metrics = 0.0, {}
-            patch_weight = self.loss_weights.get("patch_geometry", 0.0)
+            patch_weight = self.loss_weights["patch_geometry"]
             if patch_weight > 0 and "patch_geometry" in model_output:
                 patch_geometry_loss, patch_geometry_metrics = self.patch_geometry_loss(
                     model_output["patch_geometry"]
@@ -665,8 +662,8 @@ class KFoldTrainingModule(pl.LightningModule):
             loss_weights["diffusion"] * diffusion_loss
             + loss_weights["distogram"] * distogram_loss
             + loss_weights["confidence"] * confidence_loss
-            + loss_weights.get("patch_geometry", 0.0) * patch_geometry_loss
-            + loss_weights.get("interface_contact", 0.0) * interface_contact_loss
+            + loss_weights["patch_geometry"] * patch_geometry_loss
+            + loss_weights["interface_contact"] * interface_contact_loss
         )  # [B,]
         assert torch.is_tensor(loss), "Loss must be a torch.Tensor."
 

--- a/tests/unit_tests/test_interface_contact_loss.py
+++ b/tests/unit_tests/test_interface_contact_loss.py
@@ -1,9 +1,11 @@
 import math
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn.functional as F
 
+from kfold.training.loss.distogram import DistogramLoss
 from kfold.training.loss.interface_contact import InterfaceContactBalancedLoss
 
 _NUM_BINS = 64
@@ -19,7 +21,6 @@ def _folding_input(
         repr_coords=torch.tensor([coordinates], dtype=torch.float32),
         repr_mask=torch.ones((1, num_tokens), dtype=torch.bool),
         asym_id=torch.tensor([asym_id], dtype=torch.long),
-        chain_type=torch.zeros((1, num_tokens), dtype=torch.long),
     )
     return SimpleNamespace(token=token)
 
@@ -39,193 +40,219 @@ def _logits_with_contact_probabilities(
     return logits.requires_grad_()
 
 
-def test_interface_contact_loss_matches_detached_normalized_formula_and_gradient() -> (
-    None
-):
+def _target_bin(
+    loss_fn: InterfaceContactBalancedLoss,
+    f_input: SimpleNamespace,
+    pair: tuple[int, int],
+) -> torch.Tensor:
+    token_i, token_j = pair
+    distance = (
+        f_input.token.repr_coords[0, token_i] - f_input.token.repr_coords[0, token_j]
+    ).norm()
+    return (distance > loss_fn.boundaries).sum().long()
+
+
+def test_exact_bin_formula_and_detached_gradient() -> None:
     loss_fn = InterfaceContactBalancedLoss()
     f_input = _folding_input(
         coordinates=[
             [0.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
             [7.0, 0.0, 0.0],
-            [30.0, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
         ],
         asym_id=[1, 1, 2, 2],
     )
-    pair_probability = {
+    probabilities = {
         (0, 2): 0.20,
         (1, 2): 0.65,
         (0, 3): 0.10,
         (1, 3): 0.55,
     }
-    logits = _logits_with_contact_probabilities(
-        num_tokens=4,
-        probabilities=pair_probability,
-    )
+    logits = _logits_with_contact_probabilities(4, probabilities)
 
     loss, metrics = loss_fn(logits, f_input)
 
-    positive_probability = torch.tensor([0.20, 0.65])
-    far_probability = torch.tensor([0.10, 0.55])
-    positive_weight = (1.0 - positive_probability).pow(2)
-    far_weight = far_probability.pow(2)
-    positive_denominator = positive_weight.sum() + loss_fn.eps
-    far_denominator = torch.tensor(2.0 + loss_fn.eps)
-    expected_fn = (
-        positive_weight * -torch.log(positive_probability)
-    ).sum() / positive_denominator
-    expected_fp = (far_weight * -torch.log1p(-far_probability)).sum() / far_denominator
+    reference_logits = logits.detach().clone().requires_grad_()
+    log_prob = F.log_softmax(reference_logits, dim=-1)
+    positive_pairs = ((0, 2), (1, 2))
+    negative_pairs = ((0, 3), (1, 3))
+    positive_probability = torch.stack(
+        [
+            log_prob[0, *pair, :_NUM_CONTACT_BINS].logsumexp(dim=-1).exp()
+            for pair in positive_pairs
+        ]
+    )
+    negative_probability = torch.stack(
+        [
+            log_prob[0, *pair, :_NUM_CONTACT_BINS].logsumexp(dim=-1).exp()
+            for pair in negative_pairs
+        ]
+    )
+    positive_ce = torch.stack(
+        [
+            -log_prob[0, *pair, _target_bin(loss_fn, f_input, pair)]
+            for pair in positive_pairs
+        ]
+    )
+    negative_ce = torch.stack(
+        [
+            -log_prob[0, *pair, _target_bin(loss_fn, f_input, pair)]
+            for pair in negative_pairs
+        ]
+    )
+    positive_focal = (1.0 - positive_probability).pow(2).detach()
+    negative_focal = negative_probability.pow(2).detach()
+    expected_fn = (positive_focal * positive_ce).sum() / (2.0 + loss_fn.eps)
+    expected_fp = (negative_focal * negative_ce).sum() / (2.0 + loss_fn.eps)
     expected_loss = 0.75 * expected_fn + 0.25 * expected_fp
+    expected_gradient = torch.autograd.grad(expected_loss, reference_logits)[0]
 
-    assert torch.isclose(loss, expected_loss, atol=2e-6)
-    assert torch.isclose(
+    torch.testing.assert_close(loss, expected_loss, atol=2e-6, rtol=0.0)
+    torch.testing.assert_close(
         metrics["interface_contact_fn_loss"],
         expected_fn,
         atol=2e-6,
+        rtol=0.0,
     )
-    assert torch.isclose(
+    torch.testing.assert_close(
         metrics["interface_contact_fp_loss"],
         expected_fp,
         atol=2e-6,
+        rtol=0.0,
     )
     assert metrics["interface_contact_positive_pairs"].item() == 2
-    assert metrics["interface_contact_far_pairs"].item() == 2
-    assert metrics["interface_contact_selected_far_pairs"].item() == 2
-    assert metrics["interface_contact_active_interfaces"].item() == 1
+    assert metrics["interface_contact_negative_pairs"].item() == 2
+    assert metrics["interface_contact_selected_negative_pairs"].item() == 2
 
     loss.backward()
     assert logits.grad is not None
-    for pair_index, probability, weight in zip(
-        ((0, 2), (1, 2)),
-        positive_probability,
-        positive_weight,
-        strict=True,
-    ):
-        expected_gradient = 0.75 * weight / positive_denominator * (probability - 1.0)
-        actual_gradient = logits.grad[0, *pair_index, :_NUM_CONTACT_BINS].sum()
-        assert torch.isclose(actual_gradient, expected_gradient, atol=2e-6)
-    for pair_index, probability, weight in zip(
-        ((0, 3), (1, 3)),
-        far_probability,
-        far_weight,
-        strict=True,
-    ):
-        expected_gradient = 0.25 * weight / far_denominator * probability
-        actual_gradient = logits.grad[0, *pair_index, :_NUM_CONTACT_BINS].sum()
-        assert torch.isclose(actual_gradient, expected_gradient, atol=2e-6)
-
-    standard_positive_probability = positive_probability.clone().requires_grad_()
-    standard_far_probability = far_probability.clone().requires_grad_()
-    standard_positive_weight = (1.0 - standard_positive_probability).pow(2)
-    standard_far_weight = standard_far_probability.pow(2)
-    standard_loss = 0.75 * (
-        (standard_positive_weight * -torch.log(standard_positive_probability)).sum()
-        / (standard_positive_weight.sum() + loss_fn.eps)
-    ) + 0.25 * (
-        (standard_far_weight * -torch.log1p(-standard_far_probability)).sum()
-        / (2.0 + loss_fn.eps)
-    )
-    standard_loss.backward()
-    standard_logit_gradient = (
-        standard_positive_probability.grad
-        * positive_probability
-        * (1.0 - positive_probability)
-    )
-    actual_positive_gradient = torch.stack(
-        [
-            logits.grad[0, token_i, token_j, :_NUM_CONTACT_BINS].sum()
-            for token_i, token_j in ((0, 2), (1, 2))
-        ]
-    )
-    assert not torch.allclose(
-        actual_positive_gradient,
-        standard_logit_gradient,
+    torch.testing.assert_close(
+        logits.grad,
+        expected_gradient,
         atol=2e-6,
+        rtol=0.0,
     )
-    plain_fn = -torch.log(positive_probability).mean()
-    assert not torch.isclose(expected_fn, plain_fn, atol=1e-3)
+
+    normalized_fn = (positive_focal * positive_ce.detach()).sum() / (
+        positive_focal.sum() + loss_fn.eps
+    )
+    binary_fn = (positive_focal * -positive_probability.detach().log()).sum() / (
+        2.0 + loss_fn.eps
+    )
+    plain_fn = positive_ce.detach().mean()
+    assert not torch.isclose(expected_fn.detach(), normalized_fn, atol=1e-3)
+    assert not torch.isclose(expected_fn.detach(), binary_fn, atol=1e-3)
+    assert not torch.isclose(expected_fn.detach(), plain_fn, atol=1e-3)
 
 
-def test_interface_contact_fp_tail_counts_pairs_until_budget_then_caps() -> None:
+def test_positive_count_denominator_reduces_pressure_when_easy_pair_is_added() -> None:
+    loss_fn = InterfaceContactBalancedLoss(
+        positive_weight=1.0,
+        negative_weight=0.0,
+    )
+    one_pair_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
+        asym_id=[1, 2],
+    )
+    two_pair_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 1, 2],
+    )
+    one_pair_logits = _logits_with_contact_probabilities(
+        2,
+        {(0, 1): 0.20},
+    )
+    two_pair_logits = _logits_with_contact_probabilities(
+        3,
+        {(0, 2): 0.20, (1, 2): 0.999},
+    )
+
+    one_pair_loss, _ = loss_fn(one_pair_logits, one_pair_input)
+    two_pair_loss, _ = loss_fn(two_pair_logits, two_pair_input)
+    one_pair_loss.backward()
+    two_pair_loss.backward()
+
+    assert one_pair_logits.grad is not None
+    assert two_pair_logits.grad is not None
+    one_pair_gradient = one_pair_logits.grad[
+        0,
+        0,
+        1,
+        :_NUM_CONTACT_BINS,
+    ].sum()
+    two_pair_gradient = two_pair_logits.grad[
+        0,
+        0,
+        2,
+        :_NUM_CONTACT_BINS,
+    ].sum()
+    torch.testing.assert_close(
+        two_pair_gradient,
+        one_pair_gradient / 2.0,
+        atol=2e-6,
+        rtol=0.0,
+    )
+
+
+def test_selected_pair_gradients_are_collinear_with_distogram_ce() -> None:
     loss_fn = InterfaceContactBalancedLoss()
-    base_input = _folding_input(
-        coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+    distogram_loss_fn = DistogramLoss()
+    f_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [9.0, 0.0, 0.0],
+        ],
         asym_id=[1, 2, 2],
     )
-    budget_input = _folding_input(
-        coordinates=[
-            [0.0, 0.0, 0.0],
-            [7.0, 0.0, 0.0],
-            [30.0, 0.0, 0.0],
-            [40.0, 0.0, 0.0],
-            [50.0, 0.0, 0.0],
-            [60.0, 0.0, 0.0],
-        ],
-        asym_id=[1, 2, 2, 2, 2, 2],
+    auxiliary_logits = _logits_with_contact_probabilities(
+        3,
+        {(0, 1): 0.20, (0, 2): 0.80},
     )
-    overflow_input = _folding_input(
-        coordinates=[
-            [0.0, 0.0, 0.0],
-            [7.0, 0.0, 0.0],
-            [30.0, 0.0, 0.0],
-            [40.0, 0.0, 0.0],
-            [50.0, 0.0, 0.0],
-            [60.0, 0.0, 0.0],
-            [70.0, 0.0, 0.0],
-        ],
-        asym_id=[1, 2, 2, 2, 2, 2, 2],
-    )
-    base_logits = _logits_with_contact_probabilities(
-        num_tokens=3,
-        probabilities={(0, 1): 0.4, (0, 2): 0.05},
-    )
-    budget_logits = _logits_with_contact_probabilities(
-        num_tokens=6,
-        probabilities={
-            (0, 1): 0.4,
-            (0, 2): 0.05,
-            (0, 3): 0.05,
-            (0, 4): 0.05,
-            (0, 5): 0.05,
-        },
-    )
-    overflow_logits = _logits_with_contact_probabilities(
-        num_tokens=7,
-        probabilities={
-            (0, 1): 0.4,
-            (0, 2): 0.05,
-            (0, 3): 0.05,
-            (0, 4): 0.05,
-            (0, 5): 0.05,
-            (0, 6): 0.01,
-        },
-    )
+    distogram_logits = auxiliary_logits.detach().clone().requires_grad_()
 
-    base_loss, base_metrics = loss_fn(base_logits, base_input)
-    budget_loss, budget_metrics = loss_fn(budget_logits, budget_input)
-    overflow_loss, overflow_metrics = loss_fn(overflow_logits, overflow_input)
+    auxiliary_loss, _ = loss_fn(auxiliary_logits, f_input)
+    distogram_loss = distogram_loss_fn(distogram_logits, f_input).mean()
+    auxiliary_loss.backward()
+    distogram_loss.backward()
 
-    assert budget_loss > base_loss
-    assert torch.isclose(budget_loss, overflow_loss, atol=2e-6)
-    assert base_metrics["interface_contact_selected_far_pairs"].item() == 1
-    assert budget_metrics["interface_contact_selected_far_pairs"].item() == 4
-    assert overflow_metrics["interface_contact_selected_far_pairs"].item() == 4
+    assert auxiliary_logits.grad is not None
+    assert distogram_logits.grad is not None
+    for pair in ((0, 1), (0, 2)):
+        auxiliary_gradient = auxiliary_logits.grad[0, *pair]
+        distogram_gradient = distogram_logits.grad[0, *pair]
+        cosine = F.cosine_similarity(
+            auxiliary_gradient,
+            distogram_gradient,
+            dim=0,
+        )
+        torch.testing.assert_close(
+            cosine,
+            torch.tensor(1.0),
+            atol=2e-6,
+            rtol=0.0,
+        )
 
 
-def test_interface_contact_gamma_zero_reduces_to_separate_bce_means() -> None:
+def test_gamma_zero_is_selected_exact_bin_ce_mean() -> None:
     loss_fn = InterfaceContactBalancedLoss(focal_gamma=0.0)
     f_input = _folding_input(
         coordinates=[
             [0.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
             [7.0, 0.0, 0.0],
-            [30.0, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
         ],
         asym_id=[1, 1, 2, 2],
     )
     logits = _logits_with_contact_probabilities(
-        num_tokens=4,
-        probabilities={
+        4,
+        {
             (0, 2): 0.20,
             (1, 2): 0.65,
             (0, 3): 0.10,
@@ -235,28 +262,39 @@ def test_interface_contact_gamma_zero_reduces_to_separate_bce_means() -> None:
 
     loss, _ = loss_fn(logits, f_input)
 
-    positive_bce = -torch.log(torch.tensor([0.20, 0.65]))
-    far_bce = -torch.log1p(-torch.tensor([0.10, 0.55]))
-    expected = 0.75 * positive_bce.sum() / (2.0 + loss_fn.eps) + (
-        0.25 * far_bce.sum() / (2.0 + loss_fn.eps)
+    log_prob = F.log_softmax(logits, dim=-1)
+    positive_ce = torch.stack(
+        [
+            -log_prob[0, *pair, _target_bin(loss_fn, f_input, pair)]
+            for pair in ((0, 2), (1, 2))
+        ]
     )
-    assert torch.isclose(loss, expected, atol=2e-6)
+    negative_ce = torch.stack(
+        [
+            -log_prob[0, *pair, _target_bin(loss_fn, f_input, pair)]
+            for pair in ((0, 3), (1, 3))
+        ]
+    )
+    expected = 0.75 * positive_ce.sum() / (
+        2.0 + loss_fn.eps
+    ) + 0.25 * negative_ce.sum() / (2.0 + loss_fn.eps)
+    torch.testing.assert_close(loss, expected, atol=2e-6, rtol=0.0)
 
 
-def test_interface_contact_fp_gradient_only_uses_selected_tail() -> None:
+def test_top_negative_selects_high_probability_midrange_pair() -> None:
     loss_fn = InterfaceContactBalancedLoss(fp_budget_ratio=1.0)
     f_input = _folding_input(
         coordinates=[
             [0.0, 0.0, 0.0],
             [7.0, 0.0, 0.0],
+            [9.0, 0.0, 0.0],
             [30.0, 0.0, 0.0],
-            [40.0, 0.0, 0.0],
         ],
         asym_id=[1, 2, 2, 2],
     )
     logits = _logits_with_contact_probabilities(
-        num_tokens=4,
-        probabilities={
+        4,
+        {
             (0, 1): 0.60,
             (0, 2): 0.80,
             (0, 3): 0.40,
@@ -266,18 +304,93 @@ def test_interface_contact_fp_gradient_only_uses_selected_tail() -> None:
     loss, metrics = loss_fn(logits, f_input)
     loss.backward()
 
-    assert metrics["interface_contact_selected_far_pairs"].item() == 1
+    assert metrics["interface_contact_negative_pairs"].item() == 2
+    assert metrics["interface_contact_selected_negative_pairs"].item() == 1
     assert logits.grad is not None
     selected_gradient = logits.grad[0, 0, 2, :_NUM_CONTACT_BINS].sum()
     expected_gradient = (
-        0.25 * torch.tensor(0.80).pow(2) / (1.0 + loss_fn.eps) * torch.tensor(0.80)
+        0.25 * torch.tensor(0.80).pow(2) * torch.tensor(0.80) / (1.0 + loss_fn.eps)
     )
-    assert torch.isclose(selected_gradient, expected_gradient, atol=2e-6)
-    unselected_gradient = logits.grad[0, 0, 3, :_NUM_CONTACT_BINS].sum()
-    assert unselected_gradient.item() == 0.0
+    torch.testing.assert_close(
+        selected_gradient,
+        expected_gradient,
+        atol=2e-6,
+        rtol=0.0,
+    )
+    assert logits.grad[0, 0, 3].count_nonzero().item() == 0
 
 
-def test_interface_contact_fp_gradient_survives_probability_saturation() -> None:
+def test_missing_negative_keeps_fixed_mixture_weight() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
+        asym_id=[1, 2],
+    )
+    logits = _logits_with_contact_probabilities(2, {(0, 1): 0.35})
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    log_prob = F.log_softmax(logits, dim=-1)
+    target = _target_bin(loss_fn, f_input, (0, 1))
+    ce = -log_prob[0, 0, 1, target]
+    expected_fn = (1.0 - torch.tensor(0.35)).pow(2) * ce / (1.0 + loss_fn.eps)
+    torch.testing.assert_close(
+        loss,
+        0.75 * expected_fn,
+        atol=2e-6,
+        rtol=0.0,
+    )
+    assert metrics["interface_contact_fp_loss"].item() == 0.0
+
+
+def test_zero_positive_interface_is_ignored_but_graph_connected() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+        asym_id=[1, 2],
+    )
+    logits = _logits_with_contact_probabilities(2, {(0, 1): 0.60})
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    assert loss.item() == 0.0
+    assert metrics["interface_contact_active_interfaces"].item() == 0
+    assert metrics["interface_contact_selected_negative_pairs"].item() == 0
+    loss.backward()
+    assert logits.grad is not None
+    assert logits.grad.count_nonzero().item() == 0
+
+
+def test_sparse_asym_ids_are_equivalent() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    coordinates = [
+        [0.0, 0.0, 0.0],
+        [7.0, 0.0, 0.0],
+        [9.0, 0.0, 0.0],
+    ]
+    dense_input = _folding_input(coordinates, asym_id=[1, 2, 2])
+    sparse_input = _folding_input(coordinates, asym_id=[10_001, 80_002, 80_002])
+    dense_logits = _logits_with_contact_probabilities(
+        3,
+        {(0, 1): 0.40, (0, 2): 0.70},
+    )
+    sparse_logits = dense_logits.detach().clone().requires_grad_()
+
+    dense_loss, dense_metrics = loss_fn(dense_logits, dense_input)
+    sparse_loss, sparse_metrics = loss_fn(sparse_logits, sparse_input)
+
+    torch.testing.assert_close(dense_loss, sparse_loss)
+    assert (
+        dense_metrics["interface_contact_active_interfaces"]
+        == sparse_metrics["interface_contact_active_interfaces"]
+    )
+    assert (
+        dense_metrics["interface_contact_selected_negative_pairs"]
+        == sparse_metrics["interface_contact_selected_negative_pairs"]
+    )
+
+
+def test_saturated_false_positive_is_finite() -> None:
     loss_fn = InterfaceContactBalancedLoss()
     f_input = _folding_input(
         coordinates=[
@@ -293,118 +406,21 @@ def test_interface_contact_fp_gradient_survives_probability_saturation() -> None
 
     loss, metrics = loss_fn(logits, f_input)
 
-    far_logits = logits[0, 0, 2]
-    contact_logit = torch.logsumexp(far_logits[:_NUM_CONTACT_BINS], dim=-1)
-    noncontact_logit = torch.logsumexp(far_logits[_NUM_CONTACT_BINS:], dim=-1)
-    log_odds = contact_logit - noncontact_logit
-    probability = torch.sigmoid(log_odds)
-    expected_fp = (
-        probability.pow(2) * F.softplus(log_odds) / (torch.tensor(1.0) + loss_fn.eps)
-    )
-
     assert torch.isfinite(loss)
-    assert torch.isclose(
-        metrics["interface_contact_fp_loss"],
-        expected_fp,
-        atol=2e-6,
-    )
+    assert torch.isfinite(metrics["interface_contact_fp_loss"])
     assert metrics["interface_contact_fp_loss"] > 40.0
-
     loss.backward()
     assert logits.grad is not None
-    expected_gradient = (
-        0.25 * probability.pow(2) * probability / (torch.tensor(1.0) + loss_fn.eps)
-    )
-    contact_gradient = logits.grad[0, 0, 2, :_NUM_CONTACT_BINS].sum()
-    assert torch.isclose(contact_gradient, expected_gradient, atol=2e-6)
+    assert torch.isfinite(logits.grad).all()
 
 
-def test_interface_contact_zero_positive_interface_is_ignored() -> None:
-    loss_fn = InterfaceContactBalancedLoss()
-    f_input = _folding_input(
-        coordinates=[[0.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
-        asym_id=[1, 2],
-    )
-    logits = _logits_with_contact_probabilities(
-        num_tokens=2,
-        probabilities={(0, 1): 0.60},
-    )
-
-    loss, metrics = loss_fn(logits, f_input)
-
-    assert loss.item() == 0.0
-    assert metrics["interface_contact_fn_loss"].item() == 0.0
-    assert metrics["interface_contact_fp_loss"].item() == 0.0
-    assert metrics["interface_contact_selected_far_pairs"].item() == 0
-
-
-def test_interface_contact_far_absent_keeps_fixed_mixture_weight() -> None:
+def test_distogram_bin_mismatch_is_rejected() -> None:
     loss_fn = InterfaceContactBalancedLoss()
     f_input = _folding_input(
         coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
         asym_id=[1, 2],
     )
-    logits = _logits_with_contact_probabilities(
-        num_tokens=2,
-        probabilities={(0, 1): 0.35},
-    )
 
-    loss, metrics = loss_fn(logits, f_input)
-
-    probability = torch.tensor(0.35)
-    focal_weight = (1.0 - probability).pow(2)
-    expected_fn = focal_weight * -torch.log(probability) / (focal_weight + loss_fn.eps)
-    assert torch.isclose(loss, 0.75 * expected_fn, atol=2e-6)
-    assert metrics["interface_contact_fp_loss"].item() == 0.0
-
-
-def test_interface_contact_loss_keeps_zero_batch_connected_to_logits() -> None:
-    loss_fn = InterfaceContactBalancedLoss()
-    f_input = _folding_input(
-        coordinates=[[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]],
-        asym_id=[1, 1],
-    )
-    logits = torch.zeros((1, 2, 2, 64), requires_grad=True)
-
-    loss, metrics = loss_fn(logits, f_input)
-
-    assert loss.item() == 0.0
-    assert metrics["interface_contact_active_interfaces"].item() == 0
-    loss.backward()
-    assert logits.grad is not None
-    assert torch.count_nonzero(logits.grad).item() == 0
-
-
-def test_interface_contact_loss_accepts_sparse_asym_ids() -> None:
-    loss_fn = InterfaceContactBalancedLoss()
-    coordinates = [
-        [0.0, 0.0, 0.0],
-        [7.0, 0.0, 0.0],
-        [30.0, 0.0, 0.0],
-    ]
-    dense_input = _folding_input(
-        coordinates=coordinates,
-        asym_id=[1, 2, 2],
-    )
-    sparse_input = _folding_input(
-        coordinates=coordinates,
-        asym_id=[10_001, 80_002, 80_002],
-    )
-    logits = torch.zeros((1, 3, 3, 64))
-
-    dense_loss, dense_metrics = loss_fn(logits, dense_input)
-    sparse_loss, sparse_metrics = loss_fn(logits, sparse_input)
-
-    assert torch.isclose(dense_loss, sparse_loss, atol=1e-6)
-    assert (
-        dense_metrics["interface_contact_active_interfaces"]
-        == sparse_metrics["interface_contact_active_interfaces"]
-    )
-    assert (
-        dense_metrics["interface_contact_positive_pairs"]
-        == sparse_metrics["interface_contact_positive_pairs"]
-    )
-    assert (
-        dense_metrics["interface_contact_far_pairs"]
-        == sparse_metrics["interface_contact_far_pairs"]
-    )
+    logits = torch.zeros((1, 2, 2, 63))
+    with pytest.raises(ValueError, match="Expected 64 distogram bins"):
+        loss_fn(logits, f_input)

--- a/tests/unit_tests/test_interface_contact_loss.py
+++ b/tests/unit_tests/test_interface_contact_loss.py
@@ -1,0 +1,410 @@
+import math
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+from kfold.training.loss.interface_contact import InterfaceContactBalancedLoss
+
+_NUM_BINS = 64
+_NUM_CONTACT_BINS = 19
+
+
+def _folding_input(
+    coordinates: list[list[float]],
+    asym_id: list[int],
+) -> SimpleNamespace:
+    num_tokens = len(coordinates)
+    token = SimpleNamespace(
+        repr_coords=torch.tensor([coordinates], dtype=torch.float32),
+        repr_mask=torch.ones((1, num_tokens), dtype=torch.bool),
+        asym_id=torch.tensor([asym_id], dtype=torch.long),
+        chain_type=torch.zeros((1, num_tokens), dtype=torch.long),
+    )
+    return SimpleNamespace(token=token)
+
+
+def _logits_with_contact_probabilities(
+    num_tokens: int,
+    probabilities: dict[tuple[int, int], float],
+) -> torch.Tensor:
+    logits = torch.zeros((1, num_tokens, num_tokens, _NUM_BINS))
+    for (token_i, token_j), probability in probabilities.items():
+        logits[0, token_i, token_j, :_NUM_CONTACT_BINS] = math.log(
+            probability / _NUM_CONTACT_BINS
+        )
+        logits[0, token_i, token_j, _NUM_CONTACT_BINS:] = math.log(
+            (1.0 - probability) / (_NUM_BINS - _NUM_CONTACT_BINS)
+        )
+    return logits.requires_grad_()
+
+
+def test_interface_contact_loss_matches_detached_normalized_formula_and_gradient() -> (
+    None
+):
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 1, 2, 2],
+    )
+    pair_probability = {
+        (0, 2): 0.20,
+        (1, 2): 0.65,
+        (0, 3): 0.10,
+        (1, 3): 0.55,
+    }
+    logits = _logits_with_contact_probabilities(
+        num_tokens=4,
+        probabilities=pair_probability,
+    )
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    positive_probability = torch.tensor([0.20, 0.65])
+    far_probability = torch.tensor([0.10, 0.55])
+    positive_weight = (1.0 - positive_probability).pow(2)
+    far_weight = far_probability.pow(2)
+    positive_denominator = positive_weight.sum() + loss_fn.eps
+    far_denominator = torch.tensor(2.0 + loss_fn.eps)
+    expected_fn = (
+        positive_weight * -torch.log(positive_probability)
+    ).sum() / positive_denominator
+    expected_fp = (far_weight * -torch.log1p(-far_probability)).sum() / far_denominator
+    expected_loss = 0.75 * expected_fn + 0.25 * expected_fp
+
+    assert torch.isclose(loss, expected_loss, atol=2e-6)
+    assert torch.isclose(
+        metrics["interface_contact_fn_loss"],
+        expected_fn,
+        atol=2e-6,
+    )
+    assert torch.isclose(
+        metrics["interface_contact_fp_loss"],
+        expected_fp,
+        atol=2e-6,
+    )
+    assert metrics["interface_contact_positive_pairs"].item() == 2
+    assert metrics["interface_contact_far_pairs"].item() == 2
+    assert metrics["interface_contact_selected_far_pairs"].item() == 2
+    assert metrics["interface_contact_active_interfaces"].item() == 1
+
+    loss.backward()
+    assert logits.grad is not None
+    for pair_index, probability, weight in zip(
+        ((0, 2), (1, 2)),
+        positive_probability,
+        positive_weight,
+        strict=True,
+    ):
+        expected_gradient = 0.75 * weight / positive_denominator * (probability - 1.0)
+        actual_gradient = logits.grad[0, *pair_index, :_NUM_CONTACT_BINS].sum()
+        assert torch.isclose(actual_gradient, expected_gradient, atol=2e-6)
+    for pair_index, probability, weight in zip(
+        ((0, 3), (1, 3)),
+        far_probability,
+        far_weight,
+        strict=True,
+    ):
+        expected_gradient = 0.25 * weight / far_denominator * probability
+        actual_gradient = logits.grad[0, *pair_index, :_NUM_CONTACT_BINS].sum()
+        assert torch.isclose(actual_gradient, expected_gradient, atol=2e-6)
+
+    standard_positive_probability = positive_probability.clone().requires_grad_()
+    standard_far_probability = far_probability.clone().requires_grad_()
+    standard_positive_weight = (1.0 - standard_positive_probability).pow(2)
+    standard_far_weight = standard_far_probability.pow(2)
+    standard_loss = 0.75 * (
+        (standard_positive_weight * -torch.log(standard_positive_probability)).sum()
+        / (standard_positive_weight.sum() + loss_fn.eps)
+    ) + 0.25 * (
+        (standard_far_weight * -torch.log1p(-standard_far_probability)).sum()
+        / (2.0 + loss_fn.eps)
+    )
+    standard_loss.backward()
+    standard_logit_gradient = (
+        standard_positive_probability.grad
+        * positive_probability
+        * (1.0 - positive_probability)
+    )
+    actual_positive_gradient = torch.stack(
+        [
+            logits.grad[0, token_i, token_j, :_NUM_CONTACT_BINS].sum()
+            for token_i, token_j in ((0, 2), (1, 2))
+        ]
+    )
+    assert not torch.allclose(
+        actual_positive_gradient,
+        standard_logit_gradient,
+        atol=2e-6,
+    )
+    plain_fn = -torch.log(positive_probability).mean()
+    assert not torch.isclose(expected_fn, plain_fn, atol=1e-3)
+
+
+def test_interface_contact_fp_tail_counts_pairs_until_budget_then_caps() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    base_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+        asym_id=[1, 2, 2],
+    )
+    budget_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+            [40.0, 0.0, 0.0],
+            [50.0, 0.0, 0.0],
+            [60.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 2, 2, 2, 2, 2],
+    )
+    overflow_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+            [40.0, 0.0, 0.0],
+            [50.0, 0.0, 0.0],
+            [60.0, 0.0, 0.0],
+            [70.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 2, 2, 2, 2, 2, 2],
+    )
+    base_logits = _logits_with_contact_probabilities(
+        num_tokens=3,
+        probabilities={(0, 1): 0.4, (0, 2): 0.05},
+    )
+    budget_logits = _logits_with_contact_probabilities(
+        num_tokens=6,
+        probabilities={
+            (0, 1): 0.4,
+            (0, 2): 0.05,
+            (0, 3): 0.05,
+            (0, 4): 0.05,
+            (0, 5): 0.05,
+        },
+    )
+    overflow_logits = _logits_with_contact_probabilities(
+        num_tokens=7,
+        probabilities={
+            (0, 1): 0.4,
+            (0, 2): 0.05,
+            (0, 3): 0.05,
+            (0, 4): 0.05,
+            (0, 5): 0.05,
+            (0, 6): 0.01,
+        },
+    )
+
+    base_loss, base_metrics = loss_fn(base_logits, base_input)
+    budget_loss, budget_metrics = loss_fn(budget_logits, budget_input)
+    overflow_loss, overflow_metrics = loss_fn(overflow_logits, overflow_input)
+
+    assert budget_loss > base_loss
+    assert torch.isclose(budget_loss, overflow_loss, atol=2e-6)
+    assert base_metrics["interface_contact_selected_far_pairs"].item() == 1
+    assert budget_metrics["interface_contact_selected_far_pairs"].item() == 4
+    assert overflow_metrics["interface_contact_selected_far_pairs"].item() == 4
+
+
+def test_interface_contact_gamma_zero_reduces_to_separate_bce_means() -> None:
+    loss_fn = InterfaceContactBalancedLoss(focal_gamma=0.0)
+    f_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 1, 2, 2],
+    )
+    logits = _logits_with_contact_probabilities(
+        num_tokens=4,
+        probabilities={
+            (0, 2): 0.20,
+            (1, 2): 0.65,
+            (0, 3): 0.10,
+            (1, 3): 0.55,
+        },
+    )
+
+    loss, _ = loss_fn(logits, f_input)
+
+    positive_bce = -torch.log(torch.tensor([0.20, 0.65]))
+    far_bce = -torch.log1p(-torch.tensor([0.10, 0.55]))
+    expected = 0.75 * positive_bce.sum() / (2.0 + loss_fn.eps) + (
+        0.25 * far_bce.sum() / (2.0 + loss_fn.eps)
+    )
+    assert torch.isclose(loss, expected, atol=2e-6)
+
+
+def test_interface_contact_fp_gradient_only_uses_selected_tail() -> None:
+    loss_fn = InterfaceContactBalancedLoss(fp_budget_ratio=1.0)
+    f_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+            [40.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 2, 2, 2],
+    )
+    logits = _logits_with_contact_probabilities(
+        num_tokens=4,
+        probabilities={
+            (0, 1): 0.60,
+            (0, 2): 0.80,
+            (0, 3): 0.40,
+        },
+    )
+
+    loss, metrics = loss_fn(logits, f_input)
+    loss.backward()
+
+    assert metrics["interface_contact_selected_far_pairs"].item() == 1
+    assert logits.grad is not None
+    selected_gradient = logits.grad[0, 0, 2, :_NUM_CONTACT_BINS].sum()
+    expected_gradient = (
+        0.25 * torch.tensor(0.80).pow(2) / (1.0 + loss_fn.eps) * torch.tensor(0.80)
+    )
+    assert torch.isclose(selected_gradient, expected_gradient, atol=2e-6)
+    unselected_gradient = logits.grad[0, 0, 3, :_NUM_CONTACT_BINS].sum()
+    assert unselected_gradient.item() == 0.0
+
+
+def test_interface_contact_fp_gradient_survives_probability_saturation() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[
+            [0.0, 0.0, 0.0],
+            [7.0, 0.0, 0.0],
+            [30.0, 0.0, 0.0],
+        ],
+        asym_id=[1, 2, 2],
+    )
+    logits = torch.zeros((1, 3, 3, _NUM_BINS))
+    logits[0, 0, 2, :_NUM_CONTACT_BINS] = 50.0
+    logits.requires_grad_()
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    far_logits = logits[0, 0, 2]
+    contact_logit = torch.logsumexp(far_logits[:_NUM_CONTACT_BINS], dim=-1)
+    noncontact_logit = torch.logsumexp(far_logits[_NUM_CONTACT_BINS:], dim=-1)
+    log_odds = contact_logit - noncontact_logit
+    probability = torch.sigmoid(log_odds)
+    expected_fp = (
+        probability.pow(2) * F.softplus(log_odds) / (torch.tensor(1.0) + loss_fn.eps)
+    )
+
+    assert torch.isfinite(loss)
+    assert torch.isclose(
+        metrics["interface_contact_fp_loss"],
+        expected_fp,
+        atol=2e-6,
+    )
+    assert metrics["interface_contact_fp_loss"] > 40.0
+
+    loss.backward()
+    assert logits.grad is not None
+    expected_gradient = (
+        0.25 * probability.pow(2) * probability / (torch.tensor(1.0) + loss_fn.eps)
+    )
+    contact_gradient = logits.grad[0, 0, 2, :_NUM_CONTACT_BINS].sum()
+    assert torch.isclose(contact_gradient, expected_gradient, atol=2e-6)
+
+
+def test_interface_contact_zero_positive_interface_is_ignored() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+        asym_id=[1, 2],
+    )
+    logits = _logits_with_contact_probabilities(
+        num_tokens=2,
+        probabilities={(0, 1): 0.60},
+    )
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    assert loss.item() == 0.0
+    assert metrics["interface_contact_fn_loss"].item() == 0.0
+    assert metrics["interface_contact_fp_loss"].item() == 0.0
+    assert metrics["interface_contact_selected_far_pairs"].item() == 0
+
+
+def test_interface_contact_far_absent_keeps_fixed_mixture_weight() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [7.0, 0.0, 0.0]],
+        asym_id=[1, 2],
+    )
+    logits = _logits_with_contact_probabilities(
+        num_tokens=2,
+        probabilities={(0, 1): 0.35},
+    )
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    probability = torch.tensor(0.35)
+    focal_weight = (1.0 - probability).pow(2)
+    expected_fn = focal_weight * -torch.log(probability) / (focal_weight + loss_fn.eps)
+    assert torch.isclose(loss, 0.75 * expected_fn, atol=2e-6)
+    assert metrics["interface_contact_fp_loss"].item() == 0.0
+
+
+def test_interface_contact_loss_keeps_zero_batch_connected_to_logits() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    f_input = _folding_input(
+        coordinates=[[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]],
+        asym_id=[1, 1],
+    )
+    logits = torch.zeros((1, 2, 2, 64), requires_grad=True)
+
+    loss, metrics = loss_fn(logits, f_input)
+
+    assert loss.item() == 0.0
+    assert metrics["interface_contact_active_interfaces"].item() == 0
+    loss.backward()
+    assert logits.grad is not None
+    assert torch.count_nonzero(logits.grad).item() == 0
+
+
+def test_interface_contact_loss_accepts_sparse_asym_ids() -> None:
+    loss_fn = InterfaceContactBalancedLoss()
+    coordinates = [
+        [0.0, 0.0, 0.0],
+        [7.0, 0.0, 0.0],
+        [30.0, 0.0, 0.0],
+    ]
+    dense_input = _folding_input(
+        coordinates=coordinates,
+        asym_id=[1, 2, 2],
+    )
+    sparse_input = _folding_input(
+        coordinates=coordinates,
+        asym_id=[10_001, 80_002, 80_002],
+    )
+    logits = torch.zeros((1, 3, 3, 64))
+
+    dense_loss, dense_metrics = loss_fn(logits, dense_input)
+    sparse_loss, sparse_metrics = loss_fn(logits, sparse_input)
+
+    assert torch.isclose(dense_loss, sparse_loss, atol=1e-6)
+    assert (
+        dense_metrics["interface_contact_active_interfaces"]
+        == sparse_metrics["interface_contact_active_interfaces"]
+    )
+    assert (
+        dense_metrics["interface_contact_positive_pairs"]
+        == sparse_metrics["interface_contact_positive_pairs"]
+    )
+    assert (
+        dense_metrics["interface_contact_far_pairs"]
+        == sparse_metrics["interface_contact_far_pairs"]
+    )


### PR DESCRIPTION
## Summary

- add an interface-contact auxiliary that reweights the same 64-bin cross entropy used by the base distogram loss
- enable it in the full training config with outer weight 5e-2
- normalize hard native-contact supervision by positive-pair count, so its pressure falls as hard contacts are resolved
- select the highest-contact-probability d >= 8 A negatives within a 4x positive-count budget and apply detached focal weights
- keep zero-positive interfaces excluded
- remove experiment-only modality logging from the core implementation

## Motivation

The prior binary contact BCE could move probability mass across the 8 A boundary in a direction that disagreed with the exact distogram target, while focal-weight normalization kept FN pressure nearly invariant after hard pairs became rare. Reusing the exact-bin target makes every selected-pair auxiliary gradient a positive scalar multiple of the base distogram CE gradient.

## Verification

- 10 focused unit tests pass: exact values, detached full-logit gradients, gradient collinearity, count-denominator decay, 8-20 A negative selection, gamma-zero limit, fixed mixture, zero-active graph connection, sparse asym IDs, and saturated FP finiteness
- Ruff check passes on the changed Python files
- no _ai, analysis, launch, or resume artifacts are tracked

This PR establishes implementation correctness only; it does not claim held-out utility.