### PR TITLE
Disable ligand Langevin during inference

### DIFF
--- a/src/kfold/data/pipelines/prior_sampling.py
+++ b/src/kfold/data/pipelines/prior_sampling.py
@@ -58,7 +58,7 @@ class PriorSamplerConfig:
             chain_translation_scale=24.0,
             ligand_augmentation_scale=0.3,
             bioprior=BioPriorConfig(max_steps=0),
-            ligand_langevin=LigandLangevinDynamicsConfig(enabled=True),
+            ligand_langevin=LigandLangevinDynamicsConfig(enabled=False),
             train=False,
         )
 


### PR DESCRIPTION
## What changed

- Disable `LigandLangevinDynamicsConfig` in
  `PriorSamplerConfig.inference_mode()`.
- Keep the training-only 25-step Numba Langevin configuration unchanged.

## Why

Inference mode explicitly enabled the ligand Langevin path and therefore used
the dataclass's previous 100+2 schedule. The intended inference behavior is the
existing IID ligand perturbation with `ligand_augmentation_scale: 0.3`, while
Langevin remains a training prior augmentation.

## Impact

- Inference ligands use Gaussian sigma 0.3 perturbation again.
- Training continues to use the configured 25-step, T=1, no-tail Numba sampler.
- P1 population-scope hardening and the zero-step initialization edge case are
  intentionally out of scope because neither is required for this inference
  fix.

## Checks

- Inspected the complete one-file staged diff.
- `git diff --check` passed.
- No tests were run for this one-line configuration change.
