### PR TITLE
hotfix: fix hard-coded number(5) of prior to number of diffusion samples

### DIFF
--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -147,7 +147,7 @@ def dry_run(args):
         return
 
     # Create data loader
-    dataset = InferenceDataset(input_queries, ccd, num_apo=args.num_apo)
+    dataset = InferenceDataset(input_queries, ccd, args.num_samples, args.num_apo)
     dataloader = torch.utils.data.DataLoader(
         dataset, batch_size=None, shuffle=False, num_workers=args.num_workers
     )

--- a/scripts/inference_multigpu.py
+++ b/scripts/inference_multigpu.py
@@ -160,7 +160,7 @@ def main():
     log_info(f"Predict total {nsample} samples: {nquery} inputs x {nseed} seeds.")
 
     # Create dataloader
-    dataset = InferenceDataset(input_queries, ccd, num_apo=args.num_apo)
+    dataset = InferenceDataset(input_queries, ccd, args.num_samples, args.num_apo)
     dataloader = torch.utils.data.DataLoader(
         dataset, batch_size=None, shuffle=False, num_workers=args.num_workers
     )

--- a/src/kfold/inference/dataset.py
+++ b/src/kfold/inference/dataset.py
@@ -33,6 +33,7 @@ class InferenceDataset(torch.utils.data.Dataset):
         self,
         queries: list[Query],
         ccd: CCD,
+        num_samples: int,
         num_apo: int | None = None,
     ) -> None:
         """
@@ -46,7 +47,7 @@ class InferenceDataset(torch.utils.data.Dataset):
             Maximum number of apo structures to use per query. By default, use all.
         """
         self.queries: list[Query] = queries
-        self.data_pipeline = InputDataPipeline(ccd, num_apo=num_apo)
+        self.data_pipeline = InputDataPipeline(ccd, num_samples, num_apo)
 
     def __len__(self) -> int:
         return len(self.queries)


### PR DESCRIPTION
Previously, we use the fixed number of prior (5) for diffusion sampling. Now we use different starting structure xT for each diffusion sample.