### PR TITLE
fix(ecsi): hide holo-unresolved atoms from the training coordinate stack

### DIFF
--- a/src/kfold/model/layers/folding/diffusion.py
+++ b/src/kfold/model/layers/folding/diffusion.py
@@ -309,6 +309,7 @@ class DiffusionStack(nn.Module):
         c_noise: torch.Tensor,
         s_inputs: torch.Tensor,
         z: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Training forward pass of the AF3 diffusion module
         See Section 3.7 Algorithm 20: Diffusion Module in the AF3 paper.
@@ -326,6 +327,11 @@ class DiffusionStack(nn.Module):
             The input single representation, shape [B, Lt, c_s].
         z: torch.Tensor
             The trunk pair representation, shape [B, Lt, Lt, c_z].
+        atom_mask: torch.Tensor | None
+            Atoms the coordinate stack may attend to and pool from, shape [B, La].
+            Defaults to `f_input.atom.pad_mask`. A caller may narrow it to hide
+            atoms whose coordinates are undefined; the reference-conformer features
+            built by `get_atom_embeddings` still cover the full `pad_mask`.
 
         Returns
         -------
@@ -333,7 +339,8 @@ class DiffusionStack(nn.Module):
             The scaled updated atom positions, shape [B, N, La, 3].
         """
         token_index = f_input.atom.token_index  # [B, Lt]
-        atom_mask = f_input.atom.pad_mask  # [B, La]
+        if atom_mask is None:
+            atom_mask = f_input.atom.pad_mask  # [B, La]
         token_mask = f_input.token.pad_mask  # [B, Lt]
 
         s = self.get_single_conditioning(s_inputs, c_noise)  # [B, N, Lt, c_s]

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -52,27 +52,44 @@ def custom_rigid_align(
     target: torch.Tensor,
     mask: torch.Tensor | None,
     rotation_only: bool = False,
+    output_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Torch implementation of weighted rigid alignment.
+
+    `mask` selects the atoms that drive the fit; `output_mask` selects the atoms
+    that survive in the result, and defaults to `mask`.
     """
+    output_mask_was_none = output_mask is None
     if mask is None:
         mask = torch.ones(coords.shape[:-1], dtype=torch.bool, device=coords.device)
     if not mask.any():
-        return coords
+        if output_mask_was_none:
+            return coords
+        keep_mask = output_mask.bool().unsqueeze(-1)
+        return coords.masked_fill(~keep_mask, 0.0)
+    if output_mask is None:
+        output_mask = mask
 
     original_dtype = coords.dtype
-    mask_bool = mask.bool().unsqueeze(-1)
-    coords = coords.masked_fill(~mask_bool, 0.0)
-    target = target.masked_fill(~mask_bool, 0.0)
+    fit_mask = mask.bool().unsqueeze(-1)
+    keep_mask = output_mask.bool().unsqueeze(-1)
 
     with torch.autocast(device_type=coords.device.type, enabled=False):
         coords, target = coords.float(), target.float()
-        weights = mask.to(dtype=coords.dtype)
-        RT, T = get_rigid_transform_torch(coords, target, weights)
-        aligned_coords = coords @ RT
+
+        # Fit on the alignment overlap only.
+        fit_coords = coords.masked_fill(~fit_mask, 0.0)
+        fit_target = target.masked_fill(~fit_mask, 0.0)
+        weights = mask.to(dtype=fit_coords.dtype)
+        RT, T = get_rigid_transform_torch(fit_coords, fit_target, weights)
+
+        # Apply it to every atom the caller considers valid.
+        aligned_coords = coords.masked_fill(~keep_mask, 0.0) @ RT
         if not rotation_only:
-            aligned_coords += T.unsqueeze(-2)
+            aligned_coords = (aligned_coords + T.unsqueeze(-2)).masked_fill(
+                ~keep_mask, 0.0
+            )
 
     return aligned_coords.to(original_dtype)
 
@@ -425,6 +442,7 @@ class KFoldECSI(BaseStructureModule):
             s_inputs=s_inputs,  # [B, Lt, c_s]
             z=z,  # [B, Lt, Lt, c_z]
             x_T=x_T,  # [B, N, Natom, 3]
+            atom_mask=train_input["atom_mask"],  # [B, Natom]
         )  # [B, N, Natom, 3]
 
         loss_weights = self.loss_weights(t)  # [B, N]
@@ -446,6 +464,7 @@ class KFoldECSI(BaseStructureModule):
         s_inputs: torch.Tensor,
         z: torch.Tensor,
         x_T: torch.Tensor | None = None,
+        atom_mask: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
         """Forward pass through the score model with ECSI preconditioning.
@@ -464,6 +483,8 @@ class KFoldECSI(BaseStructureModule):
             Trunk pairwise embeddings. Shape (B, L, L, c_z).
         x_T : torch.Tensor | None
             Source (apo) coordinates x_T. Shape (B, N, L, 3).
+        atom_mask : torch.Tensor | None
+            Atoms the coordinate stack may attend to. Shape (B, L).
 
         Returns
         -------
@@ -488,6 +509,7 @@ class KFoldECSI(BaseStructureModule):
             c_noise=c_noise,  # [B, N]
             s_inputs=s_inputs,  # [B, Lt, c_s]
             z=z,  # [B, Lt, Lt, c_z]
+            atom_mask=atom_mask,  # [B, Natom]
         )
 
         # Output preconditioning: \hat{x}_0 = c_{skip} * x_t + c_{out} * F_\theta
@@ -558,13 +580,22 @@ class KFoldECSI(BaseStructureModule):
         num_prior = x_apo.shape[-3]
         idx = [i % num_prior for i in range(num_samples)]
         x_T = x_apo[:, idx, :, :]  # [B, N, Natom, 3]
-        x_T_mask = apo_mask.unsqueeze(-2)  # [B, 1, Natom]
+
+        # Atoms the coordinate stack may see. Unresolved atoms have no holo target,
+        # so x_0 is 0 there and any interpolant through it is meaningless. Hiding
+        # them keeps that meaningless coordinate out of every geometric operation
+        # below and out of the score model's attention. Inference has no
+        # `resolved_mask`, so it keeps using the full `pad_mask`.
+        train_mask = apo_mask & holo_mask  # [B, Natom]
+        x_T_mask = train_mask.unsqueeze(-2)  # [B, 1, Natom]
 
         # Apply centering/coordinate augmentation
         x_0 = self.random_augmentation(x_0, mask=x_0_mask)
 
         # Rotate x_T toward x_0 while preserving the prior translation distribution.
-        x_T = custom_rigid_align(x_T, x_0, x_0_mask, rotation_only=True)
+        x_T = custom_rigid_align(
+            x_T, x_0, x_0_mask, rotation_only=True, output_mask=x_T_mask
+        )
 
         # === Interpolate to get x_t === #
         C = self.coeff
@@ -577,7 +608,8 @@ class KFoldECSI(BaseStructureModule):
         # ECSI interpolation with atom-wise noise.
         x_t = alpha_t * x_0 + beta_t * x_T + gamma_t * noise
 
-        # Mask out unresolved/pad atoms.
+        # Zero the hidden atoms as well as the padding, so that a code path which
+        # forgets `train_mask` sees the origin rather than a prior-scale offset.
         x_0.masked_fill_(~x_0_mask[..., None], 0.0)
         x_T.masked_fill_(~x_T_mask[..., None], 0.0)
         x_t.masked_fill_(~x_T_mask[..., None], 0.0)
@@ -587,6 +619,7 @@ class KFoldECSI(BaseStructureModule):
             "x_0": x_0,
             "x_t": x_t,
             "x_T": x_T,
+            "atom_mask": train_mask,
         }
 
     # ============================================================

--- a/src/kfold/model/modules/structure/score_model.py
+++ b/src/kfold/model/modules/structure/score_model.py
@@ -118,6 +118,7 @@ class DiffusionModule(torch.nn.Module):
         c_noise: torch.Tensor,
         s_inputs: torch.Tensor,
         z: torch.Tensor,
+        atom_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Training forward pass of the AF3 diffusion module.
         See Section 3.7 Algorithm 20: Diffusion Module in the AF3 paper.
@@ -137,6 +138,9 @@ class DiffusionModule(torch.nn.Module):
             The input single representation, shape [B, Lt, c_s].
         z : torch.Tensor
             The trunk pair representation, shape [B, Lt, c_z].
+        atom_mask : torch.Tensor | None
+            Atoms the coordinate stack may attend to, shape [B, La].
+            Defaults to `f_input.atom.pad_mask`.
 
         Returns
         -------
@@ -150,6 +154,7 @@ class DiffusionModule(torch.nn.Module):
             c_noise,
             s_inputs,
             z,
+            atom_mask=atom_mask,
         )
 
     # === Inference step ===

--- a/tests/unit_tests/test_ecsi_align_masks.py
+++ b/tests/unit_tests/test_ecsi_align_masks.py
@@ -1,0 +1,235 @@
+"""Mask semantics around holo-unresolved atoms.
+
+Two masks disagree on those atoms: `pad_mask` covers them, `resolved_mask` does
+not. Training hides them from the coordinate stack; inference, which has no
+`resolved_mask`, keeps using `pad_mask`.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from kfold.model.modules.structure.ecsi import KFoldECSI, custom_rigid_align
+
+torch.set_float32_matmul_precision("highest")
+
+# Atom layout shared by the `sample_train_input` tests below.
+NUM_RESOLVED = 8  # resolved in the holo label and present in the prior
+NUM_UNRESOLVED = 2  # present in the prior, unresolved in the holo label
+NUM_PAD = 2  # padding
+NUM_ATOMS = NUM_RESOLVED + NUM_UNRESOLVED + NUM_PAD
+UNRESOLVED = slice(NUM_RESOLVED, NUM_RESOLVED + NUM_UNRESOLVED)
+PADDING = slice(NUM_RESOLVED + NUM_UNRESOLVED, NUM_ATOMS)
+
+
+@pytest.fixture
+def coords() -> torch.Tensor:
+    """A non-degenerate point cloud, shape [1, 8, 3]."""
+    generator = torch.Generator().manual_seed(0)
+    return torch.randn((1, 8, 3), generator=generator) * 10.0
+
+
+@pytest.fixture
+def rot_matrix() -> torch.Tensor:
+    """45 degree rotation matrix around the Z axis."""
+    cos_a, sin_a = math.cos(math.pi / 4), math.sin(math.pi / 4)
+    return torch.tensor(
+        [[cos_a, -sin_a, 0.0], [sin_a, cos_a, 0.0], [0.0, 0.0, 1.0]],
+        dtype=torch.float32,
+    )
+
+
+def test_output_mask_defaults_to_fit_mask(coords: torch.Tensor):
+    """Without `output_mask` the fit mask still governs the output."""
+    mask = torch.ones((1, 8), dtype=torch.bool)
+    mask[0, -2:] = False
+
+    aligned = custom_rigid_align(coords, coords, mask, rotation_only=True)
+
+    assert torch.allclose(aligned[0, -2:], torch.zeros(2, 3), atol=1e-6)
+
+
+def test_output_mask_preserves_atoms_outside_the_fit(
+    coords: torch.Tensor, rot_matrix: torch.Tensor
+):
+    """Atoms outside the fit mask are rotated, not zeroed."""
+    # x_0 is only defined on the first six atoms; x_T is defined on all eight.
+    fit_mask = torch.ones((1, 8), dtype=torch.bool)
+    fit_mask[0, -2:] = False
+    keep_mask = torch.ones((1, 8), dtype=torch.bool)
+
+    rotated = coords @ rot_matrix.T
+
+    aligned = custom_rigid_align(
+        rotated, coords, fit_mask, rotation_only=True, output_mask=keep_mask
+    )
+
+    # No atom is discarded, and none lands on the origin.
+    assert not torch.allclose(aligned[0, -2:], torch.zeros(2, 3), atol=1e-6)
+
+    # The unfitted atoms undergo exactly the transform fitted on the others,
+    # so the recovered cloud matches the original up to the residual translation.
+    recovered = aligned - aligned.mean(dim=-2, keepdim=True)
+    expected = coords - coords.mean(dim=-2, keepdim=True)
+    assert torch.allclose(recovered, expected, atol=1e-4)
+
+
+def test_fit_ignores_coordinates_outside_the_fit_mask(
+    coords: torch.Tensor, rot_matrix: torch.Tensor
+):
+    """Corrupting an unfitted atom must not perturb the fitted transform."""
+    fit_mask = torch.ones((1, 8), dtype=torch.bool)
+    fit_mask[0, -1] = False
+    keep_mask = torch.ones((1, 8), dtype=torch.bool)
+
+    rotated = coords @ rot_matrix.T
+    corrupted = rotated.clone()
+    corrupted[0, -1] += 1000.0
+
+    aligned = custom_rigid_align(
+        rotated, coords, fit_mask, rotation_only=True, output_mask=keep_mask
+    )
+    aligned_corrupted = custom_rigid_align(
+        corrupted, coords, fit_mask, rotation_only=True, output_mask=keep_mask
+    )
+
+    assert torch.allclose(aligned[0, :-1], aligned_corrupted[0, :-1], atol=1e-4)
+
+
+def test_translation_is_applied_only_to_kept_atoms(coords: torch.Tensor):
+    """With `rotation_only=False` the masked atoms stay at zero, not at +T."""
+    fit_mask = torch.ones((1, 8), dtype=torch.bool)
+    fit_mask[0, -2:] = False
+    keep_mask = fit_mask.clone()
+
+    translated = coords + torch.tensor([10.0, -5.0, 3.0])
+
+    aligned = custom_rigid_align(
+        translated, coords, fit_mask, rotation_only=False, output_mask=keep_mask
+    )
+
+    assert torch.allclose(aligned[0, :-2], coords[0, :-2], atol=1e-4)
+    assert torch.allclose(aligned[0, -2:], torch.zeros(2, 3), atol=1e-6)
+
+
+# ==========================================
+# `sample_train_input` end-to-end
+# ==========================================
+
+
+def make_folding_input() -> SimpleNamespace:
+    """Minimal stand-in for the fields `sample_train_input` reads."""
+    generator = torch.Generator().manual_seed(0)
+    label_coords = torch.randn((1, NUM_ATOMS, 3), generator=generator) * 10.0
+    prior_coords = torch.randn((1, NUM_ATOMS, 1, 3), generator=generator) * 10.0
+
+    resolved_mask = torch.zeros((1, NUM_ATOMS), dtype=torch.bool)
+    resolved_mask[0, :NUM_RESOLVED] = True
+    pad_mask = torch.zeros((1, NUM_ATOMS), dtype=torch.bool)
+    pad_mask[0, : NUM_RESOLVED + NUM_UNRESOLVED] = True
+
+    label_coords = label_coords.masked_fill(~resolved_mask[..., None], 0.0)
+    prior_coords = prior_coords.masked_fill(~pad_mask[..., None, None], 0.0)
+
+    return SimpleNamespace(
+        batch_size=1,
+        device=torch.device("cpu"),
+        atom=SimpleNamespace(
+            label_coords=label_coords,
+            prior_coords=prior_coords,
+            resolved_mask=resolved_mask,
+            pad_mask=pad_mask,
+        ),
+    )
+
+
+def test_unresolved_atoms_are_hidden_from_the_coordinate_stack():
+    """Unresolved atoms leave the training mask and carry no coordinate."""
+    module = KFoldECSI(KFoldECSI.Config(), None)
+    f_input = make_folding_input()
+
+    out = module.sample_train_input(f_input, diffusion_batch_size=2)
+
+    expected = f_input.atom.pad_mask & f_input.atom.resolved_mask
+    assert torch.equal(out["atom_mask"], expected)
+    assert not out["atom_mask"][:, UNRESOLVED].any()
+    assert not out["atom_mask"][:, PADDING].any()
+
+    # Hidden atoms sit at the origin in every channel, so a path that ignores the
+    # mask sees 0 rather than a prior-scale offset.
+    for key in ("x_0", "x_t", "x_T"):
+        assert torch.allclose(out[key][:, :, UNRESOLVED], torch.zeros(1), atol=1e-6)
+        assert torch.allclose(out[key][:, :, PADDING], torch.zeros(1), atol=1e-6)
+
+
+def test_resolved_atoms_keep_their_apo_geometry():
+    """Hiding the unresolved atoms must not disturb the ones that remain."""
+    module = KFoldECSI(KFoldECSI.Config(), None)
+    f_input = make_folding_input()
+    prior = f_input.atom.prior_coords[0, :, 0, :].clone()
+    kept = f_input.atom.resolved_mask[0]
+
+    out = module.sample_train_input(f_input, diffusion_batch_size=2)
+
+    assert out["x_T"][:, :, :NUM_RESOLVED].abs().max() > 1.0
+
+    # x_T is only rotated, so distances among the surviving atoms are unchanged.
+    expected = torch.cdist(prior[kept], prior[kept])
+    for sample in out["x_T"][0]:
+        assert torch.allclose(
+            torch.cdist(sample[kept], sample[kept]), expected, atol=1e-3
+        )
+
+
+def test_interpolation_is_exact_on_resolved_atoms():
+    """The interpolant is untouched where both endpoints are defined."""
+    # gamma_max = 0 removes the noise term, making the interpolant deterministic.
+    module = KFoldECSI(KFoldECSI.Config(gamma_max=0.0), None)
+    f_input = make_folding_input()
+
+    out = module.sample_train_input(f_input, diffusion_batch_size=2)
+    t = out["t"][:, :, None, None]
+
+    assert torch.allclose(
+        out["x_t"][:, :, :NUM_RESOLVED],
+        (1 - t) * out["x_0"][:, :, :NUM_RESOLVED] + t * out["x_T"][:, :, :NUM_RESOLVED],
+        atol=1e-4,
+    )
+
+
+def test_inference_prior_still_covers_every_padded_atom():
+    """The narrowing is training-only; `resolved_mask` does not exist at inference."""
+    module = KFoldECSI(KFoldECSI.Config(), None)
+    f_input = make_folding_input()
+
+    x_T = module.sample_prior(f_input, num_samples=2)
+
+    # Atoms hidden during training are live here, and only padding is at the origin.
+    assert x_T[:, :, UNRESOLVED].abs().max() > 1.0
+    assert torch.allclose(x_T[:, :, PADDING], torch.zeros(1), atol=1e-6)
+
+
+def test_narrowed_mask_reaches_the_score_model():
+    """`training_step` hands the coordinate stack the narrowed mask, not `pad_mask`."""
+    seen = {}
+
+    def train_step(f_input, r_noisy, c_noise, s_inputs, z, atom_mask=None):
+        seen["atom_mask"] = atom_mask
+        return torch.zeros(*r_noisy.shape[:-1], 3)
+
+    module = KFoldECSI(KFoldECSI.Config(), SimpleNamespace(train_step=train_step))
+    f_input = make_folding_input()
+
+    module.training_step(
+        f_input,
+        s_inputs=torch.zeros((1, 1, 8)),
+        z=torch.zeros((1, 1, 1, 8)),
+        diffusion_batch_size=2,
+    )
+
+    got = seen["atom_mask"]
+    assert got is not None, "atom_mask was not forwarded"
+    assert torch.equal(got, f_input.atom.pad_mask & f_input.atom.resolved_mask)
+    assert not torch.equal(got, f_input.atom.pad_mask)


### PR DESCRIPTION
Atoms the holo label leaves unresolved have no ground truth. `label_coords` is
`nan_to_num`-ed to 0 for them in featurization, so `x_0 = 0` and every point on
`x_t = alpha*x_0 + beta*x_T + gamma*noise` is meaningless there. They are masked
out of the diffusion loss by `resolved_mask` — but they still reached the score
model carrying that coordinate.

## How big is it

Two different numbers matter here, and conflating them overstates the problem.

**In the raw data**, scanned from the training LMDBs (`isfinite(chain.atom.coords)`,
the same definition `tokenization.py` uses for `resolved_mask`):

| dataset | sampled | unresolved atoms | structures affected | p99 | max |
|---|---|---|---|---|---|
| **rcsb-train** | 6,000 / 179,548 | **8.72%** | **83.6%** | 36.2% | 88.9% |
| rcsb-val | **1,280 / 1,280 (census)** | 11.56% | 95.2% | 47.3% | 76.6% |
| disordered_pdb | 4,000 / 37,027 | 0.08% | 6.7% | 1.5% | 14.0% |
| AF2-MGnify, AFDB, Rfam, TPD | 1,000–2,000 each | **0.00%** | 0% | — | — |

This is a crystal-data problem: the AF-predicted distillation sets measure exactly
zero. By chain type in rcsb-train, protein 94.3%, nucleic 5.4%, ligand 0.3%, and
82.6% of the affected atoms sit in fully unresolved residues.

**What training actually sees is far smaller**, because the spatial cropper
already excludes tokens whose center atom is unresolved —
`cropper/alphafold.py` sets `dists[~mask] = inf` with
`mask = resolved_mask[tokens, center_idx]`, and returns `np.where(mask)[0]` when
everything fits. Restricting protein residues to those with a resolved CA takes
the unresolved share from **9.04% to 0.66%**, and an earlier data audit measured
end-to-end exposure at a 384-token crop as **25.61% of training draws affected,
mean 1.385% of atoms**.

So the fully unresolved loops are largely gone before the model sees them; what
survives cropping is mostly **side-chain tips of otherwise resolved residues**
(CG, CD, OD1/OD2, OE1/OE2, NZ — overwhelmingly on ASP/GLU/LYS/ARG). Contiguous
crops and structures under `max_tokens` skip that filter and carry the full rate.

## The change

`sample_train_input` derives `train_mask = pad_mask & resolved_mask` and returns
it. It governs the geometric operations that build `x_t`, and it is forwarded to
the score model as the coordinate stack's atom mask. Those atoms then take no
part in:

- the coordinate input at all — `diffusion.py` already does
  `r_noisy = r_noisy * atom_mask[..., None]`, so both the `c_in * x_t` and the
  `r_T` channel are zeroed before any layer touches them;
- attention, where `primitives/attention.py` masks keys with `-inf`;
- atom-to-token pooling, where `folding/utils.py` routes masked atoms to a trash
  index.

A token whose atoms are all hidden therefore contributes nothing to the pooled
term and reduces to `proj(s)` from the trunk — note that before this PR the same
token pooled a coordinate that was pure origin-centred noise, so this replaces a
wrong term with an absent one rather than introducing a new asymmetry. Their
coordinates are zeroed in `sample_train_input` as well, so a path that ignores
the mask sees the origin rather than a prior-scale offset.

**Training only.** `resolved_mask` is all-false at inference — `model_input.py`
documents `label_coords` as "used as the ground truth for training, and may be
set to 0 for inference" — so `sample_structure` and `inference_step` keep using
`pad_mask` and predict every padded atom. `atom_mask` defaults to `pad_mask` at
every layer it was threaded through, so the EDM module and all inference paths
are unchanged.

### Deliberately not touched

- **The trunk.** It reads neither `label_coords` nor `resolved_mask`; this is
  entirely a diffusion-module problem.
- **The token set.** Cropping, the sampler's chain/interface anchors, bonds, and
  the distogram and confidence targets are unaffected. An earlier revision of this
  PR dropped whole tokens in the data pipeline instead; because `crop()` works on
  token rows and a standard residue is one row, that discarded 1.18% of
  *correctly resolved* atoms as collateral — a partially unresolved LYS took its
  resolved backbone with it, and a nucleotide missing only its 5'-phosphate took
  16 correct atoms. It also perturbed the crop budget and let the sampler's anchor
  chain vanish. That approach was dropped.
- **`token_mask`.** Hiding a fully unresolved residue from the token transformer
  would stop its neighbours from seeing that the residue exists in the chain,
  which is true information and is present at inference.

### `custom_rigid_align`

The function masked its **input coordinates** with the same mask it used as
alignment weights, and `0 @ RT == 0`, so aligning the apo prior with the holo
`resolved_mask` zeroed the prior at every unresolved atom — collapsing the
endpoint condition `r_T = x_T / sigma_data_end` to 0 there. The fit mask and the
output mask are now separate, and `output_mask` defaults to `mask` so the other
call site is unchanged.

Note that with the training mask above this fix is not load-bearing in the ECSI
path: `resolved_mask` is a subset of `pad_mask` by construction, so
`train_mask == resolved_mask` and this call now passes `output_mask == mask`. It
is kept for the `rotation_only=False` case, which used to leave masked atoms at
`+T` rather than 0, for the empty-fit-mask early return, and as a guard for
future callers. Its four unit tests exercise it directly.

## Verification

`tests/unit_tests/` passes **35/35**, including 9 in
`tests/unit_tests/test_ecsi_align_masks.py`:

- the narrowed mask actually reaches `score_model.train_step` and is not
  `pad_mask`;
- hidden atoms are absent from `atom_mask` and zero in `x_0`, `x_t` and `x_T`;
- resolved atoms keep their apo geometry — `x_T` is only rotated, so
  `cdist(x_T[resolved])` must match `cdist(prior[resolved])` exactly;
- the interpolant is exact on resolved atoms;
- `sample_prior` still covers every padded atom, so the narrowing is training-only;
- 4 on `custom_rigid_align` fit/output mask semantics.

`ruff check` and `ruff format --check` clean on the changed files.

## What this does not solve

There is still no ground truth for those atoms. This PR chooses to hide them
rather than guess, so the model gets neither a loss nor an input presence for them
and must place them cold at inference. Imputing `x_0` instead would keep those
positions in the learning signal; `prior_sampling.py` already solves the same
problem for the prior side via constrained Langevin relaxation, which would be the
natural route. Worth an A/B if disordered-region placement regresses.

Note also that Boltz and Protenix, the two open co-folding models with training
code, both feed unresolved atoms to the network with a placeholder coordinate and
gate only the loss — the same two-mask structure this repo had. Neither hides
them. Their prior is isotropic noise, so a placeholder is buried at high sigma; a
bridge model has no such margin. AF3 and Chai-1 released inference code only, so
they cannot answer the question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)