### PR TITLE
consider the symmetry for patch geom loss

### DIFF
--- a/src/kfold/model/modules/patch_geometry.py
+++ b/src/kfold/model/modules/patch_geometry.py
@@ -142,9 +142,17 @@ class PatchPairGeometryHead(nn.Module):
             finite_mask = torch.isfinite(coords).all(dim=-1)
             valid = token_mask & repr_mask & finite_mask
             asym_id = f_input.token.asym_id[batch_idx]
+            entity_id = f_input.token.entity_id[batch_idx]
             chain_ids = asym_id[valid].unique(sorted=True)
             if chain_ids.numel() < 2:
                 return None
+            has_repeated_entity = entity_id[valid].unique().numel() < chain_ids.numel()
+
+            local_atom_index = torch.full_like(asym_id, -1)
+            repr_index = f_input.token.repr_index[batch_idx]
+            local_atom_index[valid] = f_input.atom.atom_index[batch_idx][
+                repr_index[valid]
+            ]
 
             patches: list[_Patch] = []
             for chain_id in chain_ids.unbind():
@@ -157,7 +165,14 @@ class PatchPairGeometryHead(nn.Module):
                     )
                 )
 
-            patch_pairs = self._select_patch_pairs(patches, coords)
+            patch_pairs = self._select_patch_pairs(
+                patches=patches,
+                coords=coords,
+                asym_id=asym_id,
+                entity_id=entity_id,
+                local_atom_index=local_atom_index,
+                has_repeated_entity=has_repeated_entity,
+            )
         return patch_pairs
 
     def _spatial_patches(
@@ -234,6 +249,10 @@ class PatchPairGeometryHead(nn.Module):
         self,
         patches: list[_Patch],
         coords: torch.Tensor,
+        asym_id: torch.Tensor,
+        entity_id: torch.Tensor,
+        local_atom_index: torch.Tensor,
+        has_repeated_entity: bool,
     ) -> _PatchPairBatch:
         n_patches = len(patches)
         device = coords.device
@@ -262,6 +281,9 @@ class PatchPairGeometryHead(nn.Module):
         assigned = token_patch >= 0
         assigned_patch = token_patch[assigned]
         assigned_coords = coords[assigned].float()
+        assigned_asym_id = asym_id[assigned]
+        assigned_entity_id = entity_id[assigned]
+        assigned_local_atom_index = local_atom_index[assigned]
         token_pair_patch = (
             assigned_patch[:, None] * n_patches + assigned_patch[None, :]
         ).reshape(-1)
@@ -293,6 +315,22 @@ class PatchPairGeometryHead(nn.Module):
         patch_j = patch_j[inter_chain]
         token_min_dist = patch_min_dist[patch_i, patch_j]
         positive = token_min_dist < self.positive_cutoff
+
+        if has_repeated_entity:
+            symmetry_contact = self._symmetry_equivalent_patch_contact(
+                assigned_asym_id=assigned_asym_id,
+                assigned_entity_id=assigned_entity_id,
+                assigned_local_atom_index=assigned_local_atom_index,
+                token_pair_patch=token_pair_patch,
+                token_dist=token_dist,
+                n_patches=n_patches,
+            )
+            copy_ambiguous = symmetry_contact[patch_i, patch_j] & ~positive
+            keep = ~copy_ambiguous
+            patch_i = patch_i[keep]
+            patch_j = patch_j[keep]
+            token_min_dist = token_min_dist[keep]
+            positive = positive[keep]
         hard_negative = token_min_dist > self.hard_negative_cutoff
 
         com_diff = com[patch_i] - com[patch_j]
@@ -328,6 +366,62 @@ class PatchPairGeometryHead(nn.Module):
             "weight": weight[selected],
             "hard_negative": hard_negative[selected],
         }
+
+    def _symmetry_equivalent_patch_contact(
+        self,
+        assigned_asym_id: torch.Tensor,
+        assigned_entity_id: torch.Tensor,
+        assigned_local_atom_index: torch.Tensor,
+        token_pair_patch: torch.Tensor,
+        token_dist: torch.Tensor,
+        n_patches: int,
+    ) -> torch.Tensor:
+        # Same entity and chain-local representative atom index identifies a
+        # corresponding token position across interchangeable chain copies.
+        symmetry_position = torch.stack(
+            (assigned_entity_id, assigned_local_atom_index),
+            dim=-1,
+        )
+        symmetry_positions, symmetry_index = torch.unique(
+            symmetry_position,
+            dim=0,
+            return_inverse=True,
+        )
+        n_symmetry_positions = symmetry_positions.shape[0]
+
+        symmetry_pair = (
+            symmetry_index[:, None] * n_symmetry_positions + symmetry_index[None, :]
+        ).reshape(-1)
+        inter_chain = (assigned_asym_id[:, None] != assigned_asym_id[None, :]).reshape(-1)
+        contact = inter_chain & (token_dist < self.positive_cutoff)
+
+        symmetry_contact = torch.zeros(
+            n_symmetry_positions * n_symmetry_positions,
+            device=token_dist.device,
+            dtype=torch.bool,
+        )
+        symmetry_contact.scatter_reduce_(
+            0,
+            symmetry_pair,
+            contact,
+            reduce="amax",
+            include_self=True,
+        )
+        equivalent_contact = symmetry_contact[symmetry_pair] & inter_chain
+
+        patch_contact = torch.zeros(
+            n_patches * n_patches,
+            device=token_dist.device,
+            dtype=torch.bool,
+        )
+        patch_contact.scatter_reduce_(
+            0,
+            token_pair_patch,
+            equivalent_contact,
+            reduce="amax",
+            include_self=True,
+        )
+        return patch_contact.view(n_patches, n_patches)
 
     def _pool_patch_pairs(
         self,

--- a/tests/unit_tests/test_patch_geometry.py
+++ b/tests/unit_tests/test_patch_geometry.py
@@ -14,9 +14,17 @@ def _fake_input():
     token = SimpleNamespace(
         pad_mask=torch.ones(1, 16, dtype=torch.bool),
         repr_mask=torch.ones(1, 16, dtype=torch.bool),
+        entity_id=asym_id.clone(),
         asym_id=asym_id,
+        repr_index=torch.arange(16, dtype=torch.long).view(1, 16),
         repr_coords=coords,
         org_token_index=torch.arange(16, dtype=torch.long).view(1, 16),
+    )
+    atom = SimpleNamespace(
+        atom_index=torch.tensor(
+            [list(range(8)) + list(range(8))],
+            dtype=torch.long,
+        ),
     )
     chain = SimpleNamespace(
         pad_mask=torch.tensor([[True, True]], dtype=torch.bool),
@@ -24,6 +32,7 @@ def _fake_input():
     )
     return SimpleNamespace(
         token=token,
+        atom=atom,
         chain=chain,
         is_batched=True,
     )
@@ -31,10 +40,65 @@ def _fake_input():
 
 def _fake_single_chain_input():
     f_input = _fake_input()
+    f_input.token.entity_id = torch.ones(1, 16, dtype=torch.long)
     f_input.token.asym_id = torch.ones(1, 16, dtype=torch.long)
     f_input.chain.pad_mask = torch.tensor([[True, False]], dtype=torch.bool)
     f_input.chain.asym_id = torch.tensor([[1, 0]], dtype=torch.long)
     return f_input
+
+
+def _fake_repeated_entity_input():
+    asym_id = torch.tensor([[1] * 4 + [2] * 4 + [3] * 4], dtype=torch.long)
+    entity_id = torch.tensor([[1] * 4 + [2] * 8], dtype=torch.long)
+    coords = torch.zeros(1, 12, 3)
+    coords[0, 4:8, 0] = 5.0
+    coords[0, 8:, 0] = 60.0
+    token = SimpleNamespace(
+        pad_mask=torch.ones(1, 12, dtype=torch.bool),
+        repr_mask=torch.ones(1, 12, dtype=torch.bool),
+        entity_id=entity_id,
+        asym_id=asym_id,
+        repr_index=torch.arange(12, dtype=torch.long).view(1, 12),
+        repr_coords=coords,
+        org_token_index=torch.arange(12, dtype=torch.long).view(1, 12),
+    )
+    atom = SimpleNamespace(
+        atom_index=torch.tensor(
+            [list(range(4)) * 3],
+            dtype=torch.long,
+        ),
+    )
+    return SimpleNamespace(token=token, atom=atom, is_batched=True)
+
+
+def _fake_patch_level_symmetry_input():
+    asym_id = torch.tensor([[1] * 4 + [2] * 4 + [3] * 4], dtype=torch.long)
+    entity_id = torch.tensor([[1] * 4 + [2] * 8], dtype=torch.long)
+    coords = torch.tensor(
+        [
+            [0.0, 0.1, 100.0, 100.1],
+            [5.0, 5.1, 150.0, 150.1],
+            [60.0, 60.1, 200.0, 200.1],
+        ],
+        dtype=torch.float32,
+    ).reshape(1, 12, 1)
+    coords = torch.nn.functional.pad(coords, (0, 2))
+    token = SimpleNamespace(
+        pad_mask=torch.ones(1, 12, dtype=torch.bool),
+        repr_mask=torch.ones(1, 12, dtype=torch.bool),
+        entity_id=entity_id,
+        asym_id=asym_id,
+        repr_index=torch.arange(12, dtype=torch.long).view(1, 12),
+        repr_coords=coords,
+        org_token_index=torch.arange(12, dtype=torch.long).view(1, 12),
+    )
+    atom = SimpleNamespace(
+        atom_index=torch.tensor(
+            [list(range(4)) * 3],
+            dtype=torch.long,
+        ),
+    )
+    return SimpleNamespace(token=token, atom=atom, is_batched=True)
 
 
 def _active_params(module):
@@ -97,3 +161,67 @@ def test_patch_geometry_head_touches_active_params_without_patch_pairs():
     assert torch.isfinite(loss)
     assert metrics["patch_geometry_valid_pairs"] == 0
     assert all(p.grad is not None for p in _active_params(head))
+
+
+def test_patch_geometry_head_masks_noncontacting_equivalent_chain_pair():
+    head = PatchPairGeometryHead(
+        PatchPairGeometryHead.Config(
+            enabled=True,
+            channel_z=16,
+            patch_size=4,
+            max_patches_per_chain=1,
+            max_patch_pairs=8,
+        ),
+    )
+    f_input = _fake_repeated_entity_input()
+    z = torch.randn(1, 12, 12, 16)
+
+    out = head(f_input, z)
+
+    # A1-B1 is in contact, so the noncontacting A1-B2 pair is ambiguous under
+    # exchange of the two B copies and is excluded. B1-B2 remains a valid
+    # homomeric hard negative because no equivalent B-B chain pair is positive.
+    assert out["logits"].shape == (2, head.num_bins)
+    assert out["hard_negative"].sum() == 1
+
+
+def test_patch_geometry_head_keeps_homomer_negative_without_equivalent_contact():
+    head = PatchPairGeometryHead(
+        PatchPairGeometryHead.Config(
+            enabled=True,
+            channel_z=16,
+            patch_size=4,
+            max_patches_per_chain=2,
+            max_patch_pairs=8,
+        ),
+    )
+    f_input = _fake_input()
+    f_input.token.entity_id = torch.ones(1, 16, dtype=torch.long)
+    z = torch.randn(1, 16, 16, 16)
+
+    out = head(f_input, z)
+
+    assert out["logits"].shape == (4, head.num_bins)
+    assert out["hard_negative"].sum() == 4
+
+
+def test_patch_geometry_head_masks_only_symmetry_equivalent_patch_pair():
+    head = PatchPairGeometryHead(
+        PatchPairGeometryHead.Config(
+            enabled=True,
+            channel_z=16,
+            patch_size=2,
+            max_patches_per_chain=2,
+            max_patch_pairs=32,
+        ),
+    )
+    f_input = _fake_patch_level_symmetry_input()
+    z = torch.randn(1, 12, 12, 16)
+
+    out = head(f_input, z)
+
+    # Six patches form twelve inter-chain patch pairs. A1-p0 contacts B1-p0,
+    # so only the symmetry-equivalent A1-p0/B2-p0 negative is removed. The
+    # other three A1/B2 patch pairs remain valid hard negatives.
+    assert out["logits"].shape == (11, head.num_bins)
+    assert out["hard_negative"].sum() == 10


### PR DESCRIPTION
# fix: account for symmetry in patch geometry loss

## Summary

- Account for repeated symmetric chain copies when computing patch geometry loss.
- Identify symmetry-equivalent contacts using entity IDs and chain-local atom indices.
- Exclude ambiguous non-contact pairs when an equivalent chain copy forms a contact.
- Preserve valid negative samples between homomeric chain pairs.

## Changes

- Added symmetry detection to `PatchPairGeometryHead`.
- Added filtering for symmetry-equivalent patch pairs.
- Added unit tests covering repeated entities and patch-level symmetry.

## Tests

- `.venv/bin/pytest tests/unit_tests/test_patch_geometry.py -q`
- Result: `6 passed`

## Notes

- Only the current commit’s changes are included in this PR.
- Untracked files in the working tree are unrelated and excluded.