### PR TITLE
Remove SVGD sampling spread

### DIFF
--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -29,12 +29,6 @@ churn_step_power: 1.0
 ode_step_power: 2.0
 stepwarp_power: 0.5
 
-# SVGD sample spreading
-svgd_step: 1.0
-svgd_cap_frac: 0.05
-svgd_num_eps: 1e-8
-svgd_skip_rms: 1e-6
-
 # Training time schedule
 train_time_schedule: logistic
 train_time_schedule_params: [-2.15, 2.25]

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -207,14 +207,6 @@ class KFoldECSI(BaseStructureModule):
         stepwarp_power : float
             Exponent used to redistribute high-churn schedule knots. A value of
             1.0 preserves the native schedule without applying the warp.
-        svgd_step : float
-            Multiplier for the SVGD repulsion displacement.
-        svgd_cap_frac : float
-            Maximum SVGD displacement relative to the ensemble spread.
-        svgd_num_eps : float
-            Numerical floor used by the SVGD bandwidth and normalization.
-        svgd_skip_rms : float
-            Spread threshold below which SVGD is skipped.
 
         # Training time scheduling
         train_time_schedule : str
@@ -251,12 +243,6 @@ class KFoldECSI(BaseStructureModule):
         churn_step_power: float = 1.0
         ode_step_power: float = 2.0
         stepwarp_power: float = 0.5
-
-        # SVGD sample spreading
-        svgd_step: float = 1.0
-        svgd_cap_frac: float = 0.05
-        svgd_num_eps: float = 1e-8
-        svgd_skip_rms: float = 1e-6
 
         # Train time scheduling
         train_time_schedule: str = "logistic"
@@ -314,16 +300,11 @@ class KFoldECSI(BaseStructureModule):
             raise ValueError("ECSI sampler_step_scale must be positive.")
         if cfg.sampler_switch_gamma is not None and cfg.sampler_switch_gamma < 0:
             raise ValueError("ECSI sampler_switch_gamma must be non-negative.")
-        if cfg.svgd_num_eps <= 0:
-            raise ValueError("ECSI svgd_num_eps must be positive.")
         if any(
             value < 0
             for value in (
                 cfg.churn_max_multiplier,
                 cfg.stepwarp_power,
-                cfg.svgd_step,
-                cfg.svgd_cap_frac,
-                cfg.svgd_skip_rms,
             )
         ):
             raise ValueError("ECSI sampler parameters must be non-negative.")
@@ -340,10 +321,6 @@ class KFoldECSI(BaseStructureModule):
         self.churn_step_power: float = cfg.churn_step_power
         self.ode_step_power: float = cfg.ode_step_power
         self.stepwarp_power: float = cfg.stepwarp_power
-        self.svgd_step: float = cfg.svgd_step
-        self.svgd_cap_frac: float = cfg.svgd_cap_frac
-        self.svgd_num_eps: float = cfg.svgd_num_eps
-        self.svgd_skip_rms: float = cfg.svgd_skip_rms
 
         # NOTE: centering should be disabled.
         self.random_augmentation = CenterRandomAugmentation()
@@ -724,9 +701,6 @@ class KFoldECSI(BaseStructureModule):
             # Centering the predicted x_0_hat
             x_0_hat = do_centering(x_0_hat, mask=mask)
 
-            # Redistribute endpoint estimates without another score evaluation.
-            x_0_hat = self._apply_svgd_spread(x_0_hat, mask)
-
             sampler_mode, sampler_ode_type = self._select_update_method(t)
 
             # Update x_t
@@ -858,95 +832,6 @@ class KFoldECSI(BaseStructureModule):
         # Output preconditioning: \hat{x}_0 = c_{skip} * x_t + c_{out} * F_\theta
         x_out = c_skip * x_t + c_out * r_update
         return x_out
-
-    def _apply_svgd_spread(
-        self,
-        x: torch.Tensor,
-        atom_mask: torch.Tensor,
-    ) -> torch.Tensor:
-        """Spread endpoint samples without moving their masked centroid."""
-        num_samples = x.shape[1]
-        if num_samples < 2:
-            return x
-
-        mask = atom_mask.to(dtype=x.dtype)
-        mask_4d = mask.unsqueeze(-1)
-
-        if x.dtype in (torch.float16, torch.bfloat16):
-            deviation = x.float()
-            deviation.sub_(deviation.mean(dim=1, keepdim=True))
-            deviation.mul_(mask_4d)
-        else:
-            deviation = (x - x.mean(dim=1, keepdim=True)) * mask_4d
-        deviation_flat = deviation.flatten(start_dim=2)
-        distance_flat = deviation_flat
-
-        num_real = mask.sum(dim=-1, dtype=distance_flat.dtype).clamp_min(1.0)
-        denominator = (3.0 * num_samples * num_real).clamp_min(1.0)
-        spread_rms = torch.sqrt(
-            (distance_flat * distance_flat).sum(dim=(1, 2)).clamp_min(0.0)
-            / denominator.squeeze(-1)
-        )
-        if float(spread_rms.max()) <= self.svgd_skip_rms:
-            return x
-
-        # Avoid materializing pairwise atom-coordinate differences.
-        distance_sq = torch.bmm(distance_flat, distance_flat.transpose(1, 2))
-        norm_sq = distance_sq.diagonal(dim1=1, dim2=2).clone()
-        distance_sq.mul_(-2.0)
-        distance_sq.add_(norm_sq.unsqueeze(2))
-        distance_sq.add_(norm_sq.unsqueeze(1))
-        distance_sq.clamp_min_(0.0)
-        distance_sq.div_(3.0 * num_real.unsqueeze(-1))
-
-        off_diagonal = ~torch.eye(
-            num_samples,
-            dtype=torch.bool,
-            device=x.device,
-        )
-
-        # NOTE: This is same to median(dim=...), but deterministic.
-        pairwise_distance_sq = distance_sq[:, off_diagonal]
-        pairwise_distance_sq = pairwise_distance_sq.sort(dim=-1).values
-        median_index = (pairwise_distance_sq.shape[-1] - 1) // 2
-        bandwidth = pairwise_distance_sq[:, median_index]
-
-        bandwidth = bandwidth.clamp_min(self.svgd_num_eps)
-        bandwidth = bandwidth.view(-1, 1, 1)
-
-        kernel = distance_sq.div_(bandwidth).neg_().exp_()
-        coefficient = kernel.square_()
-        coefficient.mul_(2.0 / bandwidth)
-        coefficient.masked_fill_(~off_diagonal.unsqueeze(0), 0.0)
-
-        row_sum = coefficient.sum(dim=-1, keepdim=True)
-        displacement_flat = torch.bmm(coefficient, distance_flat).neg_()
-        displacement_flat.addcmul_(distance_flat, row_sum)
-        displacement_flat.div_(num_samples)
-        del coefficient, distance_flat, deviation_flat, deviation
-        del norm_sq, distance_sq, kernel, bandwidth, row_sum
-        displacement = displacement_flat.reshape_as(x)
-        del displacement_flat
-        displacement.mul_(mask_4d)
-        displacement.sub_(displacement.mean(dim=1, keepdim=True))
-        displacement.mul_(mask_4d)
-
-        displacement_rms = torch.sqrt(
-            (displacement * displacement).sum(dim=(1, 2, 3)) / denominator.squeeze(-1)
-            + self.svgd_num_eps
-        )
-        cap = self.svgd_cap_frac * spread_rms
-        scale = (cap / displacement_rms.clamp_min(self.svgd_num_eps)).clamp_max(1.0)
-        displacement.mul_(scale.view(-1, 1, 1, 1))
-        if displacement.dtype != x.dtype:
-            displacement = displacement.to(dtype=x.dtype)
-            displacement.sub_(displacement.mean(dim=1, keepdim=True))
-            displacement.mul_(mask_4d)
-
-        output = torch.add(x, displacement, alpha=self.svgd_step)
-        if not torch.isfinite(output).all():
-            raise RuntimeError("svgd-spread-t24: non-finite repulsion output")
-        return output
 
     def get_sampling_schedule(self, num_steps: int) -> list[float]:
         r"""Get the time schedule for diffusion sampling.


### PR DESCRIPTION
## Summary

- Remove the endpoint-spreading SVGD step from ECSI sampling.
- Delete the `svgd_*` module configuration, validation, runtime attributes,
  and implementation.
- Pass centered `x_0_hat` directly to the existing ODE/SDE sampler update.

## Why

The sampler should no longer apply the SVGD endpoint-repulsion heuristic.

## Validation

- `git diff --check`
- Confirmed no tracked `svgd` references remain.
- Automated tests were not run (not requested).
