### PR TITLE
feat(ecsi): add sigma-matched SDE churn sampler

### DIFF
--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -23,6 +23,12 @@ sampler_step_scale: 1.0
 sampler_switch_gamma: 3.6
 sampler_after_switch_mode: ode
 sampler_after_switch_ode_type: si
+# Optional reverse-update routing. null preserves the global profile above.
+# An explicit list uses SI ODE for unselected atoms and the existing
+# SDE/ECSI-to-SI schedule for selected components. Valid classes: ligand,
+# peptide, rna, dna. Churn remains global and is never routed by atom class.
+# For example: [ligand]. An empty list makes every atom use SI ODE.
+sampler_sde_atom_classes: null
 churn_factor: 0.1
 churn_max_multiplier: 4.0
 churn_end_time: 0.5

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -20,16 +20,11 @@ align_x_0_hat_to_x_t: true
 sampler_mode: sde
 sampler_ode_type: ecsi
 sampler_step_scale: 1.0
-# t <= this value uses fixed SI ODE; null disables the low-time phase.
+# Use SI ODE at or below this time; null disables the switch.
 sampler_switch_time: 0.1
-# Reverse-update routing. [all] preserves the global profile above; [] uses SI
-# ODE for every atom. A molecular list uses SI ODE for unselected atoms and the
-# existing SDE/ECSI-to-SI schedule for selected atoms. Valid classes: protein,
-# ligand, peptide, rna, dna. protein includes peptide chains; [peptide] selects
-# protein chains with fewer than 16 residues. [ligand] selects only ligand-token
-# atoms; it does not expand into a covalently bonded protein chain. Modified
-# protein-chain residues are not ligand tokens. Churn remains global and is
-# never routed by atom class. A target with no selected atoms uses SI ODE.
+# SDE routing: [all], [], or any of protein/peptide/ligand/rna/dna.
+# Unselected atoms use SI ODE; peptide means protein chains under 16 residues.
+# Ligand selects ligand tokens only. Churn remains global.
 sampler_sde_atom_classes: [all]
 churn_factor: 0.1
 churn_max_multiplier: 4.0

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -20,7 +20,8 @@ align_x_0_hat_to_x_t: true
 sampler_mode: sde
 sampler_ode_type: ecsi
 sampler_step_scale: 1.0
-sampler_switch_gamma: 3.6
+# t <= this value uses the low-time sampler below; null disables the switch.
+sampler_switch_time: 0.1
 sampler_after_switch_mode: ode
 sampler_after_switch_ode_type: si
 # Reverse-update routing. [all] preserves the global profile above; [] uses SI

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -25,9 +25,11 @@ sampler_after_switch_mode: ode
 sampler_after_switch_ode_type: si
 # Reverse-update routing. [all] preserves the global profile above; [] uses SI
 # ODE for every atom. A molecular list uses SI ODE for unselected atoms and the
-# existing SDE/ECSI-to-SI schedule for selected components. Valid classes:
-# protein, ligand, peptide, rna, dna. Churn remains global and is never routed
-# by atom class. For example: [ligand].
+# existing SDE/ECSI-to-SI schedule for selected atoms. Valid classes: protein,
+# ligand, peptide, rna, dna. [ligand] selects only ligand-token atoms; it does
+# not expand into a covalently bonded protein chain. Modified protein-chain
+# residues are not ligand tokens. Churn remains global and is never routed by
+# atom class. A target with no selected atoms uses SI ODE for every atom.
 sampler_sde_atom_classes: [all]
 churn_factor: 0.1
 churn_max_multiplier: 4.0

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -15,15 +15,19 @@ eta: 1.0
 
 # Inference time schedule
 align_x_0_hat_to_x_t: true
-sampler_mode: ode
-sampler_ode_type: si
+# This bundle records the selected policy for provenance. `churn_factor` is the
+# only supported numerical sweep axis; the remaining values are fixed defaults.
+sampler_mode: sde
+sampler_ode_type: ecsi
 sampler_step_scale: 1.0
-sampler_switch_gamma: null
+sampler_switch_gamma: 3.6
 sampler_after_switch_mode: ode
 sampler_after_switch_ode_type: si
 churn_factor: 0.1
 churn_max_multiplier: 4.0
 churn_end_time: 0.5
+# null resolves to time_max; the upper bound is excluded, including the initial step.
+churn_max_time: null
 churn_step_fraction: 0.4
 churn_step_power: 1.0
 ode_step_power: 2.0

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -20,17 +20,16 @@ align_x_0_hat_to_x_t: true
 sampler_mode: sde
 sampler_ode_type: ecsi
 sampler_step_scale: 1.0
-# t <= this value uses the low-time sampler below; null disables the switch.
+# t <= this value uses fixed SI ODE; null disables the low-time phase.
 sampler_switch_time: 0.1
-sampler_after_switch_mode: ode
-sampler_after_switch_ode_type: si
 # Reverse-update routing. [all] preserves the global profile above; [] uses SI
 # ODE for every atom. A molecular list uses SI ODE for unselected atoms and the
 # existing SDE/ECSI-to-SI schedule for selected atoms. Valid classes: protein,
-# ligand, peptide, rna, dna. [ligand] selects only ligand-token atoms; it does
-# not expand into a covalently bonded protein chain. Modified protein-chain
-# residues are not ligand tokens. Churn remains global and is never routed by
-# atom class. A target with no selected atoms uses SI ODE for every atom.
+# ligand, peptide, rna, dna. protein includes peptide chains; [peptide] selects
+# protein chains with fewer than 16 residues. [ligand] selects only ligand-token
+# atoms; it does not expand into a covalently bonded protein chain. Modified
+# protein-chain residues are not ligand tokens. Churn remains global and is
+# never routed by atom class. A target with no selected atoms uses SI ODE.
 sampler_sde_atom_classes: [all]
 churn_factor: 0.1
 churn_max_multiplier: 4.0

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -23,12 +23,12 @@ sampler_step_scale: 1.0
 sampler_switch_gamma: 3.6
 sampler_after_switch_mode: ode
 sampler_after_switch_ode_type: si
-# Optional reverse-update routing. null preserves the global profile above.
-# An explicit list uses SI ODE for unselected atoms and the existing
-# SDE/ECSI-to-SI schedule for selected components. Valid classes: ligand,
-# peptide, rna, dna. Churn remains global and is never routed by atom class.
-# For example: [ligand]. An empty list makes every atom use SI ODE.
-sampler_sde_atom_classes: null
+# Reverse-update routing. [all] preserves the global profile above; [] uses SI
+# ODE for every atom. A molecular list uses SI ODE for unselected atoms and the
+# existing SDE/ECSI-to-SI schedule for selected components. Valid classes:
+# protein, ligand, peptide, rna, dna. Churn remains global and is never routed
+# by atom class. For example: [ligand].
+sampler_sde_atom_classes: [all]
 churn_factor: 0.1
 churn_max_multiplier: 4.0
 churn_end_time: 0.5

--- a/scripts/analysis/aggregate_sampler_sweep.py
+++ b/scripts/analysis/aggregate_sampler_sweep.py
@@ -39,6 +39,7 @@ SAMPLER_SETTINGS = (
     "sampler_switch_gamma",
     "sampler_after_switch_mode",
     "sampler_after_switch_ode_type",
+    "sampler_sde_atom_classes",
     "churn_factor",
     "churn_max_multiplier",
     "churn_end_time",
@@ -333,7 +334,14 @@ def settings_from_config(path: Path) -> dict[str, Any]:
         raise ValueError(f"{path}: missing model.diffusion_head") from error
     if not isinstance(head, Mapping):
         raise ValueError(f"{path}: model.diffusion_head is not a mapping")
-    return {setting: head.get(setting) for setting in SAMPLER_SETTINGS}
+    settings: dict[str, Any] = {}
+    for setting in SAMPLER_SETTINGS:
+        value = head.get(setting)
+        if isinstance(value, (list, tuple)):
+            settings[setting] = json.dumps(value)
+        else:
+            settings[setting] = value
+    return settings
 
 
 def collect_target_records(sweep_root: Path) -> list[dict[str, Any]]:

--- a/scripts/analysis/aggregate_sampler_sweep.py
+++ b/scripts/analysis/aggregate_sampler_sweep.py
@@ -1,0 +1,636 @@
+"""Create provenance-preserving summaries for an ECSI sampler sweep.
+
+The input directory contains one run root per sweep wave. This script never
+collapses OST and DockQv2 rows into one modality: each raw scorer file remains
+a separate metric surface with its own hash and target-level outcomes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+LIGAND_KEY = ("pdb_id", "native_chain_id_1", "native_chain_id_2", "ligand_id")
+INTERFACE_KEY = ("pdb_id", "interface_chain_id_1", "interface_chain_id_2")
+DOCKQ_THRESHOLDS = {
+    "dockq_acc": 0.23,
+    "dockq_med": 0.49,
+    "dockq_high": 0.80,
+}
+METRIC_SOURCES = ("ost", "dockqv2")
+PRIMARY_SOURCE_OVERRIDES = {
+    "protein_dna": "dockqv2",
+    "protein_rna": "dockqv2",
+}
+SAMPLER_SETTINGS = (
+    "gamma_power",
+    "sampler_mode",
+    "sampler_ode_type",
+    "sampler_switch_gamma",
+    "sampler_after_switch_mode",
+    "sampler_after_switch_ode_type",
+    "churn_factor",
+    "churn_max_multiplier",
+    "churn_end_time",
+    "churn_max_time",
+    "churn_step_fraction",
+    "churn_step_power",
+    "ode_step_power",
+    "stepwarp_power",
+    "svgd_step",
+)
+
+TARGET_FIELDS = (
+    "root",
+    "arm",
+    "modality",
+    "metric_source",
+    "is_primary_surface",
+    "metric_name",
+    "target_key",
+    "sample_count",
+    "oracle_success",
+    "rank_success",
+    "oracle_dockq",
+    "rank_dockq",
+    "oracle_rmsd",
+    "oracle_lddtpli",
+    "rank_rmsd",
+    "rank_lddtpli",
+    "key_columns",
+    "raw_csv",
+    "raw_sha256",
+    "raw_row_count",
+    "config_sha256",
+    "manifest_sha256",
+    "checkpoint_path",
+    "checkpoint_sha256",
+    "target_query_count",
+    "scored_marker",
+    *SAMPLER_SETTINGS,
+)
+SUMMARY_FIELDS = (
+    "root",
+    "arm",
+    "modality",
+    "metric_source",
+    "is_primary_surface",
+    "metric_name",
+    "target_count",
+    "oracle_success_count",
+    "rank_success_count",
+    "oracle_rank_gap",
+    "sample_count_min",
+    "sample_count_max",
+    "key_columns",
+    "raw_csv",
+    "raw_sha256",
+    "raw_row_count",
+    "config_sha256",
+    "manifest_sha256",
+    "checkpoint_path",
+    "checkpoint_sha256",
+    "target_query_count",
+    "scored_marker",
+    *SAMPLER_SETTINGS,
+)
+PAIRED_FIELDS = (
+    "baseline_root",
+    "baseline_arm",
+    "candidate_root",
+    "candidate_arm",
+    "modality",
+    "metric_source",
+    "is_primary_surface",
+    "metric_name",
+    "outcome",
+    "paired_target_count",
+    "baseline_success_count",
+    "candidate_success_count",
+    "candidate_only_success_count",
+    "baseline_only_success_count",
+    "two_sided_exact_mcnemar_p",
+    "baseline_unpaired_target_count",
+    "candidate_unpaired_target_count",
+)
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 of an immutable input artifact."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_float(row: Mapping[str, str], column: str, path: Path) -> float:
+    """Read one finite numerical metric or fail rather than silently dropping it."""
+    raw = row.get(column)
+    if raw is None or raw == "":
+        raise ValueError(f"{path}: missing required {column!r} value")
+    value = float(raw)
+    if not math.isfinite(value):
+        raise ValueError(f"{path}: non-finite {column!r} value {raw!r}")
+    return value
+
+
+def metric_surface_from_path(path: Path) -> tuple[str, str] | None:
+    """Extract ``(modality, scorer)`` from an interface evaluator filename."""
+    for source in METRIC_SOURCES:
+        suffix = f"_{source}.csv"
+        if path.name.startswith("interface_") and path.name.endswith(suffix):
+            modality = path.name[len("interface_") : -len(suffix)]
+            return modality, source
+    return None
+
+
+def primary_source_for_modality(modality: str) -> str:
+    """Use DockQv2 for nucleic-acid surfaces and OST elsewhere."""
+    return PRIMARY_SOURCE_OVERRIDES.get(modality, "ost")
+
+
+def stable_target_key(
+    row: Mapping[str, str],
+    columns: Sequence[str],
+    path: Path,
+) -> str:
+    """Encode a full target identifier without losing the source column names."""
+    missing = [column for column in columns if row.get(column) in (None, "")]
+    if missing:
+        raise ValueError(f"{path}: missing target-key columns {missing}")
+    return json.dumps({column: row[column] for column in columns}, sort_keys=True)
+
+
+def read_raw_rows(path: Path) -> list[dict[str, str]]:
+    """Read one raw scorer CSV and require a real header and at least one row."""
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"{path}: CSV has no header")
+        rows = list(reader)
+    if not rows:
+        raise ValueError(f"{path}: CSV has no metric rows")
+    return rows
+
+
+def required_columns(
+    rows: Sequence[Mapping[str, str]],
+    columns: Sequence[str],
+    path: Path,
+) -> None:
+    """Fail early if a scorer export cannot support the requested metric surface."""
+    available = set(rows[0])
+    missing = sorted(set(columns) - available)
+    if missing:
+        raise ValueError(f"{path}: missing required columns {missing}")
+
+
+def group_rows(
+    rows: Iterable[Mapping[str, str]],
+    key_columns: Sequence[str],
+    path: Path,
+) -> dict[str, list[Mapping[str, str]]]:
+    """Group raw samples by their lossless JSON target key."""
+    grouped: dict[str, list[Mapping[str, str]]] = defaultdict(list)
+    for row in rows:
+        grouped[stable_target_key(row, key_columns, path)].append(row)
+    return grouped
+
+
+def base_target_record(
+    *,
+    run_root: str,
+    arm: str,
+    modality: str,
+    metric_source: str,
+    metric_name: str,
+    target_key: str,
+    sample_count: int,
+    key_columns: Sequence[str],
+    raw_path: Path,
+    raw_sha256: str,
+    raw_row_count: int,
+    config_sha256: str,
+    manifest_sha256: str,
+    checkpoint_path: str,
+    checkpoint_sha256: str,
+    target_query_count: int | None,
+    scored_marker: bool,
+    settings: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build fields shared by every target-level metric row."""
+    record: dict[str, Any] = {
+        "root": run_root,
+        "arm": arm,
+        "modality": modality,
+        "metric_source": metric_source,
+        "is_primary_surface": metric_source == primary_source_for_modality(modality),
+        "metric_name": metric_name,
+        "target_key": target_key,
+        "sample_count": sample_count,
+        "key_columns": json.dumps(key_columns),
+        "raw_csv": str(raw_path),
+        "raw_sha256": raw_sha256,
+        "raw_row_count": raw_row_count,
+        "config_sha256": config_sha256,
+        "manifest_sha256": manifest_sha256,
+        "checkpoint_path": checkpoint_path,
+        "checkpoint_sha256": checkpoint_sha256,
+        "target_query_count": target_query_count,
+        "scored_marker": scored_marker,
+    }
+    record.update({setting: settings.get(setting) for setting in SAMPLER_SETTINGS})
+    return record
+
+
+def protein_ligand_records(
+    *,
+    grouped: Mapping[str, Sequence[Mapping[str, str]]],
+    base_kwargs: Mapping[str, Any],
+    path: Path,
+) -> list[dict[str, Any]]:
+    """Return PL joint-success target records for oracle and confidence rank."""
+    records: list[dict[str, Any]] = []
+    for target_key, samples in grouped.items():
+        ranked = max(samples, key=lambda row: parse_float(row, "ranking_score", path))
+        rmsds = [parse_float(row, "rmsd", path) for row in samples]
+        lddtplis = [parse_float(row, "lddt-pli", path) for row in samples]
+        oracle_success = any(
+            rmsd < 2.0 and lddtpli > 0.8
+            for rmsd, lddtpli in zip(rmsds, lddtplis, strict=True)
+        )
+        rank_rmsd = parse_float(ranked, "rmsd", path)
+        rank_lddtpli = parse_float(ranked, "lddt-pli", path)
+        record = base_target_record(
+            metric_name="pl_joint",
+            target_key=target_key,
+            sample_count=len(samples),
+            **base_kwargs,
+        )
+        record.update(
+            {
+                "oracle_success": oracle_success,
+                "rank_success": rank_rmsd < 2.0 and rank_lddtpli > 0.8,
+                "oracle_rmsd": min(rmsds),
+                "oracle_lddtpli": max(lddtplis),
+                "rank_rmsd": rank_rmsd,
+                "rank_lddtpli": rank_lddtpli,
+            }
+        )
+        records.append(record)
+    return records
+
+
+def docking_records(
+    *,
+    grouped: Mapping[str, Sequence[Mapping[str, str]]],
+    base_kwargs: Mapping[str, Any],
+    path: Path,
+) -> list[dict[str, Any]]:
+    """Return one target record per DockQ success threshold."""
+    records: list[dict[str, Any]] = []
+    for target_key, samples in grouped.items():
+        scores = [parse_float(row, "dockq_score", path) for row in samples]
+        ranked = max(samples, key=lambda row: parse_float(row, "ranking_score", path))
+        oracle_dockq = max(scores)
+        rank_dockq = parse_float(ranked, "dockq_score", path)
+        for metric_name, threshold in DOCKQ_THRESHOLDS.items():
+            record = base_target_record(
+                metric_name=metric_name,
+                target_key=target_key,
+                sample_count=len(samples),
+                **base_kwargs,
+            )
+            record.update(
+                {
+                    "oracle_success": oracle_dockq >= threshold,
+                    "rank_success": rank_dockq >= threshold,
+                    "oracle_dockq": oracle_dockq,
+                    "rank_dockq": rank_dockq,
+                }
+            )
+            records.append(record)
+    return records
+
+
+def settings_from_config(path: Path) -> dict[str, Any]:
+    """Read only sampler settings from one resolved arm configuration."""
+    payload = yaml.safe_load(path.read_text())
+    try:
+        head = payload["model"]["diffusion_head"]
+    except (KeyError, TypeError) as error:
+        raise ValueError(f"{path}: missing model.diffusion_head") from error
+    if not isinstance(head, Mapping):
+        raise ValueError(f"{path}: model.diffusion_head is not a mapping")
+    return {setting: head.get(setting) for setting in SAMPLER_SETTINGS}
+
+
+def collect_target_records(sweep_root: Path) -> list[dict[str, Any]]:
+    """Collect target-level results while retaining every scorer's provenance."""
+    records: list[dict[str, Any]] = []
+    for manifest_path in sorted(sweep_root.glob("*/sweep_manifest.json")):
+        run_path = manifest_path.parent
+        manifest = json.loads(manifest_path.read_text())
+        arms = manifest.get("arms")
+        if not isinstance(arms, list) or not all(isinstance(arm, str) for arm in arms):
+            raise ValueError(f"{manifest_path}: arms must be a list of strings")
+        checkpoint = manifest.get("checkpoint")
+        if not isinstance(checkpoint, Mapping):
+            raise ValueError(f"{manifest_path}: missing checkpoint identity")
+        checkpoint_path = checkpoint.get("path")
+        checkpoint_sha256 = checkpoint.get("sha256")
+        if not isinstance(checkpoint_path, str) or not isinstance(checkpoint_sha256, str):
+            raise ValueError(f"{manifest_path}: invalid checkpoint identity")
+        targets = manifest.get("targets")
+        target_query_count = (
+            targets.get("query_count") if isinstance(targets, Mapping) else None
+        )
+        if target_query_count is not None and not isinstance(target_query_count, int):
+            raise ValueError(f"{manifest_path}: targets.query_count must be an integer")
+        manifest_sha256 = sha256_file(manifest_path)
+
+        for arm in sorted(arms):
+            config_path = run_path / "configs" / f"{arm}.yaml"
+            if not config_path.is_file():
+                raise FileNotFoundError(
+                    f"Missing resolved config for {run_path.name}/{arm}"
+                )
+            settings = settings_from_config(config_path)
+            config_sha256 = sha256_file(config_path)
+            raw_dir = run_path / "evaluation" / arm / "raw"
+            if not raw_dir.is_dir():
+                continue
+
+            for raw_path in sorted(raw_dir.glob("interface_*.csv")):
+                surface = metric_surface_from_path(raw_path)
+                if surface is None:
+                    continue
+                modality, metric_source = surface
+                rows = read_raw_rows(raw_path)
+                key_columns = (
+                    LIGAND_KEY if modality == "protein_ligand" else INTERFACE_KEY
+                )
+                required = [*key_columns, "ranking_score"]
+                required.extend(
+                    ("rmsd", "lddt-pli")
+                    if modality == "protein_ligand"
+                    else ("dockq_score",)
+                )
+                required_columns(rows, required, raw_path)
+                grouped = group_rows(rows, key_columns, raw_path)
+                base_kwargs = {
+                    "run_root": run_path.name,
+                    "arm": arm,
+                    "modality": modality,
+                    "metric_source": metric_source,
+                    "key_columns": key_columns,
+                    "raw_path": raw_path.relative_to(sweep_root),
+                    "raw_sha256": sha256_file(raw_path),
+                    "raw_row_count": len(rows),
+                    "config_sha256": config_sha256,
+                    "manifest_sha256": manifest_sha256,
+                    "checkpoint_path": checkpoint_path,
+                    "checkpoint_sha256": checkpoint_sha256,
+                    "target_query_count": target_query_count,
+                    "scored_marker": (
+                        run_path / "evaluation" / arm / ".scored"
+                    ).is_file(),
+                    "settings": settings,
+                }
+                if modality == "protein_ligand":
+                    records.extend(
+                        protein_ligand_records(
+                            grouped=grouped,
+                            base_kwargs=base_kwargs,
+                            path=raw_path,
+                        )
+                    )
+                else:
+                    records.extend(
+                        docking_records(
+                            grouped=grouped,
+                            base_kwargs=base_kwargs,
+                            path=raw_path,
+                        )
+                    )
+    return records
+
+
+def summary_rows(records: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Summarize target records without co-mingling scorer surfaces."""
+    grouped: dict[tuple[Any, ...], list[Mapping[str, Any]]] = defaultdict(list)
+    group_fields = (
+        "root",
+        "arm",
+        "modality",
+        "metric_source",
+        "is_primary_surface",
+        "metric_name",
+        "key_columns",
+        "raw_csv",
+        "raw_sha256",
+        "raw_row_count",
+        "config_sha256",
+        "manifest_sha256",
+        "checkpoint_path",
+        "checkpoint_sha256",
+        "target_query_count",
+        "scored_marker",
+        *SAMPLER_SETTINGS,
+    )
+    for record in records:
+        grouped[tuple(record[field] for field in group_fields)].append(record)
+
+    summaries: list[dict[str, Any]] = []
+    for group_key, group_records in sorted(
+        grouped.items(),
+        key=lambda item: tuple(str(value) for value in item[0]),
+    ):
+        summary = dict(zip(group_fields, group_key, strict=True))
+        oracle_count = sum(bool(record["oracle_success"]) for record in group_records)
+        rank_count = sum(bool(record["rank_success"]) for record in group_records)
+        sample_counts = [int(record["sample_count"]) for record in group_records]
+        summary.update(
+            {
+                "target_count": len(group_records),
+                "oracle_success_count": oracle_count,
+                "rank_success_count": rank_count,
+                "oracle_rank_gap": oracle_count - rank_count,
+                "sample_count_min": min(sample_counts),
+                "sample_count_max": max(sample_counts),
+            }
+        )
+        summaries.append(summary)
+    return summaries
+
+
+def exact_two_sided_mcnemar_p(candidate_only: int, baseline_only: int) -> float:
+    """Return the exact two-sided McNemar p-value for discordant target pairs."""
+    discordant = candidate_only + baseline_only
+    if discordant == 0:
+        return 1.0
+    tail = sum(
+        math.comb(discordant, count)
+        for count in range(min(candidate_only, baseline_only) + 1)
+    )
+    return min(1.0, 2.0 * tail / (2**discordant))
+
+
+def paired_rows(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    baseline_root: str,
+    baseline_arm: str,
+    candidate_root: str,
+    candidate_arm: str,
+) -> list[dict[str, Any]]:
+    """Compare two arms on shared target keys for each isolated scorer surface."""
+    all_records = list(records)
+    surfaces: dict[
+        tuple[str, str, bool, str],
+        dict[str, dict[str, Mapping[str, Any]]],
+    ] = {}
+    identities = {
+        "baseline": (baseline_root, baseline_arm),
+        "candidate": (candidate_root, candidate_arm),
+    }
+    for label, identity in identities.items():
+        for record in all_records:
+            if (record["root"], record["arm"]) != identity:
+                continue
+            surface = (
+                str(record["modality"]),
+                str(record["metric_source"]),
+                bool(record["is_primary_surface"]),
+                str(record["metric_name"]),
+            )
+            target_values = surfaces.setdefault(surface, {}).setdefault(label, {})
+            target_key = str(record["target_key"])
+            if target_key in target_values:
+                raise ValueError(
+                    "Duplicate target metric for "
+                    f"{identity}/{surface}/{target_key}; scorer rows were co-mingled."
+                )
+            target_values[target_key] = record
+
+    results: list[dict[str, Any]] = []
+    for surface, surface_records in sorted(surfaces.items()):
+        baseline = surface_records.get("baseline", {})
+        candidate = surface_records.get("candidate", {})
+        if not baseline or not candidate:
+            continue
+        shared = sorted(set(baseline) & set(candidate))
+        modality, metric_source, is_primary_surface, metric_name = surface
+        for outcome, field in (("oracle", "oracle_success"), ("rank", "rank_success")):
+            candidate_only = sum(
+                not bool(baseline[key][field]) and bool(candidate[key][field])
+                for key in shared
+            )
+            baseline_only = sum(
+                bool(baseline[key][field]) and not bool(candidate[key][field])
+                for key in shared
+            )
+            results.append(
+                {
+                    "baseline_root": baseline_root,
+                    "baseline_arm": baseline_arm,
+                    "candidate_root": candidate_root,
+                    "candidate_arm": candidate_arm,
+                    "modality": modality,
+                    "metric_source": metric_source,
+                    "is_primary_surface": is_primary_surface,
+                    "metric_name": metric_name,
+                    "outcome": outcome,
+                    "paired_target_count": len(shared),
+                    "baseline_success_count": sum(
+                        bool(baseline[key][field]) for key in shared
+                    ),
+                    "candidate_success_count": sum(
+                        bool(candidate[key][field]) for key in shared
+                    ),
+                    "candidate_only_success_count": candidate_only,
+                    "baseline_only_success_count": baseline_only,
+                    "two_sided_exact_mcnemar_p": exact_two_sided_mcnemar_p(
+                        candidate_only,
+                        baseline_only,
+                    ),
+                    "baseline_unpaired_target_count": len(
+                        set(baseline) - set(candidate)
+                    ),
+                    "candidate_unpaired_target_count": len(
+                        set(candidate) - set(baseline)
+                    ),
+                }
+            )
+    return results
+
+
+def write_csv(
+    path: Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, Any]],
+) -> None:
+    """Write a stable CSV with all declared columns, including empty metrics."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="raise")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sweep_root", type=Path)
+    parser.add_argument("--summary-out", required=True, type=Path)
+    parser.add_argument("--targets-out", required=True, type=Path)
+    parser.add_argument(
+        "--pair",
+        nargs=4,
+        metavar=("BASELINE_ROOT", "BASELINE_ARM", "CANDIDATE_ROOT", "CANDIDATE_ARM"),
+        help="Emit oracle and rank McNemar rows for this exact pair.",
+    )
+    parser.add_argument(
+        "--paired-out",
+        type=Path,
+        help="Destination for --pair output; required when --pair is supplied.",
+    )
+    args = parser.parse_args()
+    if args.pair is not None and args.paired_out is None:
+        parser.error("--paired-out is required with --pair")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    records = collect_target_records(args.sweep_root)
+    if not records:
+        raise ValueError(f"{args.sweep_root}: no scorer CSVs found under run manifests")
+
+    write_csv(args.targets_out, TARGET_FIELDS, records)
+    write_csv(args.summary_out, SUMMARY_FIELDS, summary_rows(records))
+    if args.pair is not None:
+        baseline_root, baseline_arm, candidate_root, candidate_arm = args.pair
+        paired = paired_rows(
+            records,
+            baseline_root=baseline_root,
+            baseline_arm=baseline_arm,
+            candidate_root=candidate_root,
+            candidate_arm=candidate_arm,
+        )
+        write_csv(args.paired_out, PAIRED_FIELDS, paired)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/aggregate_sampler_sweep.py
+++ b/scripts/analysis/aggregate_sampler_sweep.py
@@ -37,8 +37,6 @@ SAMPLER_SETTINGS = (
     "sampler_mode",
     "sampler_ode_type",
     "sampler_switch_time",
-    "sampler_after_switch_mode",
-    "sampler_after_switch_ode_type",
     "sampler_sde_atom_classes",
     "churn_factor",
     "churn_max_multiplier",

--- a/scripts/analysis/aggregate_sampler_sweep.py
+++ b/scripts/analysis/aggregate_sampler_sweep.py
@@ -36,7 +36,7 @@ SAMPLER_SETTINGS = (
     "gamma_power",
     "sampler_mode",
     "sampler_ode_type",
-    "sampler_switch_gamma",
+    "sampler_switch_time",
     "sampler_after_switch_mode",
     "sampler_after_switch_ode_type",
     "sampler_sde_atom_classes",

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -197,8 +197,10 @@ class KFoldECSI(BaseStructureModule):
             High-time ECSI/SI update family. The default is ``ecsi``.
         sampler_step_scale : float
             Multiplier for deterministic ODE update displacement.
-        sampler_switch_gamma : float | None
-            Gamma threshold for the fixed low-time ODE/SI phase.
+        sampler_switch_time : float | None
+            Reverse-time boundary for the fixed low-time ODE/SI phase. Values
+            at or below the boundary use the low-time sampler; ``None``
+            disables the phase.
         sampler_after_switch_mode : str
             Low-time update mode. The default is ``ode``.
         sampler_after_switch_ode_type : str
@@ -251,7 +253,7 @@ class KFoldECSI(BaseStructureModule):
         sampler_mode: str = "sde"
         sampler_ode_type: str = "ecsi"
         sampler_step_scale: float = 1.0
-        sampler_switch_gamma: float | None = 3.6
+        sampler_switch_time: float | None = 0.1
         sampler_after_switch_mode: str = "ode"
         sampler_after_switch_ode_type: str = "si"
         sampler_sde_atom_classes: tuple[str, ...] = ("all",)
@@ -318,8 +320,12 @@ class KFoldECSI(BaseStructureModule):
             )
         if cfg.sampler_step_scale <= 0:
             raise ValueError("ECSI sampler_step_scale must be positive.")
-        if cfg.sampler_switch_gamma is not None and cfg.sampler_switch_gamma < 0:
-            raise ValueError("ECSI sampler_switch_gamma must be non-negative.")
+        if cfg.sampler_switch_time is not None and not (
+            cfg.time_min <= cfg.sampler_switch_time <= cfg.time_max
+        ):
+            raise ValueError(
+                "ECSI sampler_switch_time must lie within the trained time support."
+            )
         if cfg.gamma_power <= 0:
             raise ValueError("ECSI gamma_power must be positive.")
         if not 0.0 <= cfg.churn_end_time <= cfg.time_max:
@@ -352,7 +358,7 @@ class KFoldECSI(BaseStructureModule):
         self.sampler_mode: str = cfg.sampler_mode
         self.sampler_ode_type: str = cfg.sampler_ode_type
         self.sampler_step_scale: float = cfg.sampler_step_scale
-        self.sampler_switch_gamma: float | None = cfg.sampler_switch_gamma
+        self.sampler_switch_time: float | None = cfg.sampler_switch_time
         self.sampler_after_switch_mode: str = cfg.sampler_after_switch_mode
         self.sampler_after_switch_ode_type: str = cfg.sampler_after_switch_ode_type
         self.sampler_sde_atom_classes = self._normalize_sde_atom_classes(
@@ -1137,13 +1143,10 @@ class KFoldECSI(BaseStructureModule):
         return torch.where(sde_atom_mask[:, None, :, None], x_sde, x_ode)
 
     def _select_update_method(self, t: float) -> tuple[str, str]:
-        if self.sampler_switch_gamma is None:
-            return self.sampler_mode, self.sampler_ode_type
-
-        # Reverse sampling starts near t=1 where gamma is also small. The switch is
-        # intended for the late low-gamma phase after the gamma envelope has peaked.
-        gamma_peak_time = 0.5 ** (1.0 / self.coeff.gamma_power)
-        if t <= gamma_peak_time and self.coeff.gamma(t) <= self.sampler_switch_gamma:
+        if (
+            self.sampler_switch_time is not None
+            and t <= self.sampler_switch_time
+        ):
             return self.sampler_after_switch_mode, self.sampler_after_switch_ode_type
         return self.sampler_mode, self.sampler_ode_type
 

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -203,11 +203,10 @@ class KFoldECSI(BaseStructureModule):
             Low-time update mode. The default is ``ode``.
         sampler_after_switch_ode_type : str
             Low-time update family. The default is ``si``.
-        sampler_sde_atom_classes : tuple[str, ...] | None
-            Optional atom classes that receive a high-time SDE/ECSI update.
-            ``None`` preserves the global sampler; an explicit list makes every
-            unselected atom use SI ODE. Covalently connected chains are routed
-            as one component.
+        sampler_sde_atom_classes : tuple[str, ...]
+            Explicit classes that receive the sampler profile. ``("all",)``
+            preserves the global sampler, while ``()`` makes every atom use SI
+            ODE. Covalently connected chains are routed as one component.
         churn_factor : float
             Fractional effective-noise inflation ``chi`` before the fixed
             high-time ramp. This is the only numerical sampler knob.
@@ -254,7 +253,7 @@ class KFoldECSI(BaseStructureModule):
         sampler_switch_gamma: float | None = 3.6
         sampler_after_switch_mode: str = "ode"
         sampler_after_switch_ode_type: str = "si"
-        sampler_sde_atom_classes: tuple[str, ...] | None = None
+        sampler_sde_atom_classes: tuple[str, ...] = ("all",)
         churn_factor: float = 0.1
         churn_max_multiplier: float = 4.0
         churn_end_time: float = 0.5
@@ -372,18 +371,24 @@ class KFoldECSI(BaseStructureModule):
 
     @staticmethod
     def _normalize_sde_atom_classes(
-        atom_classes: tuple[str, ...] | None,
-    ) -> tuple[str, ...] | None:
-        """Validate the opt-in atom classes for class-routed SDE updates."""
+        atom_classes: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        """Validate the explicit classes for class-routed sampler updates."""
         if atom_classes is None:
-            return None
+            raise ValueError(
+                "ECSI sampler_sde_atom_classes must be explicit. Use ('all',) "
+                "for the global sampler or () for SI ODE."
+            )
         if isinstance(atom_classes, str):
             raise ValueError(
                 "ECSI sampler_sde_atom_classes must be a sequence, not a string."
             )
 
         normalized = tuple(atom_classes)
-        valid_classes = {"ligand", "peptide", "rna", "dna"}
+        if any(not isinstance(atom_class, str) for atom_class in normalized):
+            raise ValueError("ECSI sampler_sde_atom_classes must contain strings.")
+
+        valid_classes = {"all", "protein", "ligand", "peptide", "rna", "dna"}
         unknown = sorted(set(normalized) - valid_classes)
         if unknown:
             raise ValueError(
@@ -393,6 +398,10 @@ class KFoldECSI(BaseStructureModule):
         if len(set(normalized)) != len(normalized):
             raise ValueError(
                 "ECSI sampler_sde_atom_classes must not contain duplicates."
+            )
+        if "all" in normalized and len(normalized) != 1:
+            raise ValueError(
+                "ECSI sampler_sde_atom_classes 'all' must be used alone."
             )
         return normalized
 
@@ -694,16 +703,18 @@ class KFoldECSI(BaseStructureModule):
             expanded = expanded | (connected_chains & f_input.chain.pad_mask)
         return expanded
 
-    def _get_sde_atom_mask(self, f_input: FoldingInput) -> torch.Tensor | None:
+    def _get_sde_atom_mask(self, f_input: FoldingInput) -> torch.Tensor:
         """Return selected atom components for class-routed SDE updates.
 
         Global churn is deliberately outside this selector: every atom reaches
         the same post-churn time before the shared score-model call.
         """
-        if self.sampler_sde_atom_classes is None:
-            return None
+        if self.sampler_sde_atom_classes == ("all",):
+            return f_input.atom.pad_mask
 
         selected_chain = torch.zeros_like(f_input.chain.pad_mask)
+        if "protein" in self.sampler_sde_atom_classes:
+            selected_chain |= f_input.chain.is_protein
         if "ligand" in self.sampler_sde_atom_classes:
             selected_chain |= f_input.chain.is_ligand
         if "rna" in self.sampler_sde_atom_classes:
@@ -784,7 +795,9 @@ class KFoldECSI(BaseStructureModule):
         x_t = x_T.clone()
         mask = f_input.atom.pad_mask[..., None, :]  # (B, 1, Natom)
         sde_atom_mask = self._get_sde_atom_mask(f_input)
-        has_sde_atoms = sde_atom_mask is not None and bool(sde_atom_mask.any())
+        has_sde_atoms = self.sampler_sde_atom_classes == ("all",) or bool(
+            sde_atom_mask.any()
+        )
 
         # Compute time-independent variables
         z = model.get_pair_conditioning(f_input, z)
@@ -825,41 +838,16 @@ class KFoldECSI(BaseStructureModule):
             # Centering the predicted x_0_hat
             x_0_hat = do_centering(x_0_hat, mask=mask)
 
-            if sde_atom_mask is None:
-                sampler_mode, sampler_ode_type = self._select_update_method(t)
-                x_t = self._update_step(
-                    x_noisy,
-                    x_0_hat,
-                    x_T,
-                    mask,
-                    t,
-                    t_next,
-                    mode=sampler_mode,
-                    ode_type=sampler_ode_type,
-                    step_scale=self.sampler_step_scale,
-                )
-            elif has_sde_atoms:
-                x_t = self._apply_class_selective_update(
-                    x_noisy,
-                    x_0_hat,
-                    x_T,
-                    mask,
-                    sde_atom_mask,
-                    t,
-                    t_next,
-                )
-            else:
-                x_t = self._update_step(
-                    x_noisy,
-                    x_0_hat,
-                    x_T,
-                    mask,
-                    t,
-                    t_next,
-                    mode="ode",
-                    ode_type="si",
-                    step_scale=self.sampler_step_scale,
-                )
+            x_t = self._apply_class_selective_update(
+                x_noisy,
+                x_0_hat,
+                x_T,
+                mask,
+                sde_atom_mask,
+                has_sde_atoms,
+                t,
+                t_next,
+            )
             append_traj(x_t)
 
         sample_out: dict[str, torch.Tensor] = {}
@@ -1125,10 +1113,25 @@ class KFoldECSI(BaseStructureModule):
         x_T: torch.Tensor,
         mask: torch.Tensor,
         sde_atom_mask: torch.Tensor,
+        has_sde_atoms: bool,
         t: float,
         t_next: float,
     ) -> torch.Tensor:
-        """Use one score call, then splice component SDE and SI-ODE updates."""
+        """Preserve [all] or overlay selected updates on an SI-ODE base."""
+        selected_mode, selected_ode_type = self._select_update_method(t)
+        if self.sampler_sde_atom_classes == ("all",):
+            return self._update_step(
+                x_t,
+                x_0_hat,
+                x_T,
+                mask,
+                t,
+                t_next,
+                mode=selected_mode,
+                ode_type=selected_ode_type,
+                step_scale=self.sampler_step_scale,
+            )
+
         x_ode = self._update_step(
             x_t,
             x_0_hat,
@@ -1140,7 +1143,9 @@ class KFoldECSI(BaseStructureModule):
             ode_type="si",
             step_scale=self.sampler_step_scale,
         )
-        selected_mode, selected_ode_type = self._select_update_method(t)
+        if not has_sde_atoms:
+            return x_ode
+
         if selected_mode == "ode" and selected_ode_type == "si":
             return x_ode
 

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -203,6 +203,11 @@ class KFoldECSI(BaseStructureModule):
             Low-time update mode. The default is ``ode``.
         sampler_after_switch_ode_type : str
             Low-time update family. The default is ``si``.
+        sampler_sde_atom_classes : tuple[str, ...] | None
+            Optional atom classes that receive a high-time SDE/ECSI update.
+            ``None`` preserves the global sampler; an explicit list makes every
+            unselected atom use SI ODE. Covalently connected chains are routed
+            as one component.
         churn_factor : float
             Fractional effective-noise inflation ``chi`` before the fixed
             high-time ramp. This is the only numerical sampler knob.
@@ -249,6 +254,7 @@ class KFoldECSI(BaseStructureModule):
         sampler_switch_gamma: float | None = 3.6
         sampler_after_switch_mode: str = "ode"
         sampler_after_switch_ode_type: str = "si"
+        sampler_sde_atom_classes: tuple[str, ...] | None = None
         churn_factor: float = 0.1
         churn_max_multiplier: float = 4.0
         churn_end_time: float = 0.5
@@ -349,6 +355,9 @@ class KFoldECSI(BaseStructureModule):
         self.sampler_switch_gamma: float | None = cfg.sampler_switch_gamma
         self.sampler_after_switch_mode: str = cfg.sampler_after_switch_mode
         self.sampler_after_switch_ode_type: str = cfg.sampler_after_switch_ode_type
+        self.sampler_sde_atom_classes = self._normalize_sde_atom_classes(
+            cfg.sampler_sde_atom_classes
+        )
         self.churn_factor: float = cfg.churn_factor
         self.churn_max_multiplier: float = cfg.churn_max_multiplier
         self.churn_end_time: float = cfg.churn_end_time
@@ -360,6 +369,32 @@ class KFoldECSI(BaseStructureModule):
 
         # NOTE: centering should be disabled.
         self.random_augmentation = CenterRandomAugmentation()
+
+    @staticmethod
+    def _normalize_sde_atom_classes(
+        atom_classes: tuple[str, ...] | None,
+    ) -> tuple[str, ...] | None:
+        """Validate the opt-in atom classes for class-routed SDE updates."""
+        if atom_classes is None:
+            return None
+        if isinstance(atom_classes, str):
+            raise ValueError(
+                "ECSI sampler_sde_atom_classes must be a sequence, not a string."
+            )
+
+        normalized = tuple(atom_classes)
+        valid_classes = {"ligand", "peptide", "rna", "dna"}
+        unknown = sorted(set(normalized) - valid_classes)
+        if unknown:
+            raise ValueError(
+                "ECSI sampler_sde_atom_classes contains unsupported classes: "
+                f"{unknown}. Expected a subset of {sorted(valid_classes)}."
+            )
+        if len(set(normalized)) != len(normalized):
+            raise ValueError(
+                "ECSI sampler_sde_atom_classes must not contain duplicates."
+            )
+        return normalized
 
     # === Bridge Preconditioning Coefficients === #
     def _get_bridge_scalings(self, t: _T) -> tuple[_T, _T, _T]:
@@ -635,6 +670,70 @@ class KFoldECSI(BaseStructureModule):
             "atom_mask": train_mask,
         }
 
+    @staticmethod
+    def _expand_covalent_chain_components(
+        f_input: FoldingInput,
+        selected_chain: torch.Tensor,
+    ) -> torch.Tensor:
+        """Expand a chain selection over valid covalent bond components."""
+        chain_ids = f_input.chain.asym_id
+        bond_ids = f_input.bond.asym_id
+        chain_matches_bond = chain_ids[:, :, None, None] == bond_ids[:, None, :, :]
+        expanded = selected_chain
+
+        # At most one round per chain is sufficient for transitive components.
+        # The fixed loop avoids a device synchronization for every bond graph.
+        for _ in range(expanded.shape[1]):
+            selected_bond_ends = (
+                chain_matches_bond & expanded[:, :, None, None]
+            ).any(dim=1)
+            connected_bonds = selected_bond_ends.any(dim=-1) & f_input.bond.pad_mask
+            connected_chains = (
+                chain_matches_bond & connected_bonds[:, None, :, None]
+            ).any(dim=(2, 3))
+            expanded = expanded | (connected_chains & f_input.chain.pad_mask)
+        return expanded
+
+    def _get_sde_atom_mask(self, f_input: FoldingInput) -> torch.Tensor | None:
+        """Return selected atom components for class-routed SDE updates.
+
+        Global churn is deliberately outside this selector: every atom reaches
+        the same post-churn time before the shared score-model call.
+        """
+        if self.sampler_sde_atom_classes is None:
+            return None
+
+        selected_chain = torch.zeros_like(f_input.chain.pad_mask)
+        if "ligand" in self.sampler_sde_atom_classes:
+            selected_chain |= f_input.chain.is_ligand
+        if "rna" in self.sampler_sde_atom_classes:
+            selected_chain |= f_input.chain.is_rna
+        if "dna" in self.sampler_sde_atom_classes:
+            selected_chain |= f_input.chain.is_dna
+        if "peptide" in self.sampler_sde_atom_classes:
+            selected_chain |= f_input.chain.is_protein & (
+                f_input.chain.num_residues < 16
+            )
+        selected_chain &= f_input.chain.pad_mask
+        selected_chain = self._expand_covalent_chain_components(
+            f_input,
+            selected_chain,
+        )
+
+        token_matches_chain = (
+            f_input.token.asym_id[:, :, None] == f_input.chain.asym_id[:, None, :]
+        )
+        selected_token = (
+            token_matches_chain & selected_chain[:, None, :]
+        ).any(dim=-1)
+        selected_token &= f_input.token.pad_mask
+        selected_atom = torch.gather(
+            selected_token,
+            1,
+            f_input.atom.token_index,
+        )
+        return selected_atom & f_input.atom.pad_mask
+
     # ============================================================
     # For inference
     # ============================================================
@@ -684,6 +783,8 @@ class KFoldECSI(BaseStructureModule):
         x_T = self.sample_prior(f_input, num_samples)  # (B, N, Natom, 3)
         x_t = x_T.clone()
         mask = f_input.atom.pad_mask[..., None, :]  # (B, 1, Natom)
+        sde_atom_mask = self._get_sde_atom_mask(f_input)
+        has_sde_atoms = sde_atom_mask is not None and bool(sde_atom_mask.any())
 
         # Compute time-independent variables
         z = model.get_pair_conditioning(f_input, z)
@@ -724,20 +825,41 @@ class KFoldECSI(BaseStructureModule):
             # Centering the predicted x_0_hat
             x_0_hat = do_centering(x_0_hat, mask=mask)
 
-            sampler_mode, sampler_ode_type = self._select_update_method(t)
-
-            # Update x_t
-            x_t = self._update_step(
-                x_noisy,
-                x_0_hat,
-                x_T,
-                mask,
-                t,
-                t_next,
-                mode=sampler_mode,
-                ode_type=sampler_ode_type,
-                step_scale=self.sampler_step_scale,
-            )
+            if sde_atom_mask is None:
+                sampler_mode, sampler_ode_type = self._select_update_method(t)
+                x_t = self._update_step(
+                    x_noisy,
+                    x_0_hat,
+                    x_T,
+                    mask,
+                    t,
+                    t_next,
+                    mode=sampler_mode,
+                    ode_type=sampler_ode_type,
+                    step_scale=self.sampler_step_scale,
+                )
+            elif has_sde_atoms:
+                x_t = self._apply_class_selective_update(
+                    x_noisy,
+                    x_0_hat,
+                    x_T,
+                    mask,
+                    sde_atom_mask,
+                    t,
+                    t_next,
+                )
+            else:
+                x_t = self._update_step(
+                    x_noisy,
+                    x_0_hat,
+                    x_T,
+                    mask,
+                    t,
+                    t_next,
+                    mode="ode",
+                    ode_type="si",
+                    step_scale=self.sampler_step_scale,
+                )
             append_traj(x_t)
 
         sample_out: dict[str, torch.Tensor] = {}
@@ -995,6 +1117,46 @@ class KFoldECSI(BaseStructureModule):
             t,
             chi=self._churn_factor_at_time(t),
         )
+
+    def _apply_class_selective_update(
+        self,
+        x_t: torch.Tensor,
+        x_0_hat: torch.Tensor,
+        x_T: torch.Tensor,
+        mask: torch.Tensor,
+        sde_atom_mask: torch.Tensor,
+        t: float,
+        t_next: float,
+    ) -> torch.Tensor:
+        """Use one score call, then splice component SDE and SI-ODE updates."""
+        x_ode = self._update_step(
+            x_t,
+            x_0_hat,
+            x_T,
+            mask,
+            t,
+            t_next,
+            mode="ode",
+            ode_type="si",
+            step_scale=self.sampler_step_scale,
+        )
+        selected_mode, selected_ode_type = self._select_update_method(t)
+        if selected_mode == "ode" and selected_ode_type == "si":
+            return x_ode
+
+        sde_mask = mask & sde_atom_mask[:, None, :]
+        x_sde = self._update_step(
+            x_t,
+            x_0_hat,
+            x_T,
+            sde_mask,
+            t,
+            t_next,
+            mode=selected_mode,
+            ode_type=selected_ode_type,
+            step_scale=self.sampler_step_scale,
+        )
+        return torch.where(sde_atom_mask[:, None, :, None], x_sde, x_ode)
 
     def _select_update_method(self, t: float) -> tuple[str, str]:
         if self.sampler_switch_gamma is None:

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -26,9 +26,6 @@ from kfold.utils.registry import STRUCTURE_MODULE
 from .sample_diffusion import BaseStructureModule
 from .score_model import DiffusionModule
 
-RIGID_ALIGN = 0  # conduct centering ; kabsch align
-NO_ALIGN = 1  # no centering; no kabsch align
-
 _T = TypeVar("_T", float, torch.Tensor)
 
 
@@ -125,6 +122,14 @@ class SICoeffs:
         denom = _sqrt(t_pow * (1 - t_pow))  # type: ignore
         return (self.gamma_max / 4) * coeff * (1 - 2 * t_pow) / _clip(denom)  # type: ignore
 
+    def sigma_eff(self, t: _T) -> _T:
+        r"""Return the analytical effective noise scale ``gamma(t) / alpha(t)``.
+
+        This value selects a sigma-matched churn time only. It does not transform
+        the coordinates supplied to the score model.
+        """
+        return self.gamma(t) / _clip(self.alpha(t))  # type: ignore
+
     # Compute \epsilon = \eta (\gamma \dot{\gamma} - \dot{\alpha}/\alpha \gamma^2)
     def eps(self, t: _T) -> _T:
         alpha, alpha_dot = self.alpha(t), self.alpha_deriv(t)
@@ -183,30 +188,38 @@ class KFoldECSI(BaseStructureModule):
             remain fixed as `alpha_t = 1 - t` and `beta_t = t`.
         eta : float
             Stochasticity control parameter for ECSI sampling.
-
         # Inference sampling parameters
         align_x_0_hat_to_x_t : bool
             Whether to rigidly align the predicted x_0_hat to x_t at each sampling step.
+        sampler_mode : str
+            Update mode: ``sde`` for the default hybrid or ``ode`` for rollback.
+        sampler_ode_type : str
+            High-time ECSI/SI update family. The default is ``ecsi``.
         sampler_step_scale : float
-            Multiplier for deterministic ODE update displacement. A value of 1.5
-            mirrors the step scale convention used by AF3/EDM samplers.
+            Multiplier for deterministic ODE update displacement.
+        sampler_switch_gamma : float | None
+            Gamma threshold for the fixed low-time ODE/SI phase.
+        sampler_after_switch_mode : str
+            Low-time update mode. The default is ``ode``.
+        sampler_after_switch_ode_type : str
+            Low-time update family. The default is ``si``.
         churn_factor : float
-            The factor controlling the magnitude of forward-pinned churn noise.
+            Fractional effective-noise inflation ``chi`` before the fixed
+            high-time ramp. This is the only numerical sampler knob.
         churn_max_multiplier : float
-            Maximum multiplier applied to churn_factor in the high-time ramp.
+            Maximum high-time multiplier applied to ``churn_factor``.
         churn_end_time : float
-            The time value at which to end forward-pinned churn.
-
-        # Inference time scheduling parameters
+            End of the forward-pinned churn window.
+        churn_max_time : float | None
+            Exclusive upper churn bound. ``None`` resolves to ``time_max``.
         churn_step_fraction : float
-            The fraction of the total sampling steps to apply churn.
+            Fraction of sampling steps in the churn phase.
         churn_step_power : float
-            The exponent controlling the time schedule for churn steps.
+            Churn-phase schedule exponent.
         ode_step_power : float
-            The exponent controlling the time schedule for ODE steps.
+            ODE-phase schedule exponent.
         stepwarp_power : float
-            Exponent used to redistribute high-churn schedule knots. A value of
-            1.0 preserves the native schedule without applying the warp.
+            High-churn knot redistribution exponent.
 
         # Training time scheduling
         train_time_schedule : str
@@ -230,15 +243,16 @@ class KFoldECSI(BaseStructureModule):
 
         # Inference sampling
         align_x_0_hat_to_x_t: bool = True
-        sampler_mode: str = "ode"
-        sampler_ode_type: str = "si"
+        sampler_mode: str = "sde"
+        sampler_ode_type: str = "ecsi"
         sampler_step_scale: float = 1.0
-        sampler_switch_gamma: float | None = None
+        sampler_switch_gamma: float | None = 3.6
         sampler_after_switch_mode: str = "ode"
         sampler_after_switch_ode_type: str = "si"
         churn_factor: float = 0.1
         churn_max_multiplier: float = 4.0
         churn_end_time: float = 0.5
+        churn_max_time: float | None = None
         churn_step_fraction: float = 0.4
         churn_step_power: float = 1.0
         ode_step_power: float = 2.0
@@ -300,9 +314,30 @@ class KFoldECSI(BaseStructureModule):
             raise ValueError("ECSI sampler_step_scale must be positive.")
         if cfg.sampler_switch_gamma is not None and cfg.sampler_switch_gamma < 0:
             raise ValueError("ECSI sampler_switch_gamma must be non-negative.")
+        if cfg.gamma_power <= 0:
+            raise ValueError("ECSI gamma_power must be positive.")
+        if not 0.0 <= cfg.churn_end_time <= cfg.time_max:
+            raise ValueError(
+                "ECSI churn_end_time must lie within the trained time support."
+            )
+        churn_max_time = (
+            cfg.time_max if cfg.churn_max_time is None else cfg.churn_max_time
+        )
+        if churn_max_time > cfg.time_max:
+            raise ValueError(
+                f"ECSI churn_max_time ({churn_max_time}) must not exceed time_max "
+                f"({cfg.time_max}); the score model is untrained beyond time_max."
+            )
+        if churn_max_time < cfg.churn_end_time:
+            raise ValueError(
+                f"ECSI churn_max_time ({churn_max_time}) must not be below "
+                f"churn_end_time ({cfg.churn_end_time})."
+            )
         if any(
             value < 0
             for value in (
+                cfg.eta,
+                cfg.churn_factor,
                 cfg.churn_max_multiplier,
                 cfg.stepwarp_power,
             )
@@ -317,6 +352,7 @@ class KFoldECSI(BaseStructureModule):
         self.churn_factor: float = cfg.churn_factor
         self.churn_max_multiplier: float = cfg.churn_max_multiplier
         self.churn_end_time: float = cfg.churn_end_time
+        self.churn_max_time: float = churn_max_time
         self.churn_step_fraction: float = cfg.churn_step_fraction
         self.churn_step_power: float = cfg.churn_step_power
         self.ode_step_power: float = cfg.ode_step_power
@@ -676,20 +712,7 @@ class KFoldECSI(BaseStructureModule):
             t = times[step_idx]
             t_next = times[step_idx + 1]
 
-            # Early-stage forward-pinned churn.
-            span = float(times[0]) - self.churn_end_time
-            weight = (float(t) - self.churn_end_time) / span if span > 0.0 else 0.0
-            weight = min(max(weight, 0.0), 1.0) ** 2
-            effective_churn_factor = self.churn_factor * (
-                1.0 + (self.churn_max_multiplier - 1.0) * weight
-            )
-            x_noisy, t = self._apply_forward_pinned_churn(
-                x_t,
-                x_T,
-                mask,
-                t,
-                churn_factor=effective_churn_factor,
-            )
+            x_noisy, t = self._apply_forward_pinned_churn(x_t, x_T, mask, t)
 
             # Get denoised prediction \hat{x}_0
             x_0_hat = run_step(x_noisy, t)
@@ -881,40 +904,97 @@ class KFoldECSI(BaseStructureModule):
         times.append(0.0)
         return times
 
-    def _apply_forward_pinned_churn(
+    def _sigma_eff_to_time(self, target: float, lo: float, hi: float) -> float:
+        r"""Return a churn time in ``[lo, hi]`` for an effective-noise target.
+
+        ``sigma_eff`` is monotonic over the sampling interval. The upper endpoint
+        is returned when the requested inflation cannot fit inside the configured
+        churn band, preserving the trained-time support instead of extrapolating.
+        """
+        if hi <= lo:
+            return lo
+
+        coeff = self.coeff
+        lo_sigma = float(coeff.sigma_eff(lo))
+        hi_sigma = float(coeff.sigma_eff(hi))
+        if target <= lo_sigma:
+            return lo
+        if target >= hi_sigma:
+            return hi
+
+        low, high = lo, hi
+        for _ in range(60):
+            mid = 0.5 * (low + high)
+            if float(coeff.sigma_eff(mid)) < target:
+                low = mid
+            else:
+                high = mid
+        return high
+
+    def _apply_sigma_matched_churn(
         self,
         x_t: torch.Tensor,
         x_T: torch.Tensor,
         mask: torch.Tensor,
         t: float,
         *,
-        churn_factor: float | None = None,
+        chi: float,
     ) -> tuple[torch.Tensor, float]:
-        if t <= self.churn_end_time:
-            # No churn applied before or at churn_end
+        r"""Apply a bridge conditional with ``sigma_eff`` inflated by ``chi``.
+
+        The model still receives x-space coordinates. ``sigma_eff`` only chooses
+        ``t_hat`` such that ``sigma_eff(t_hat) = (1 + chi) * sigma_eff(t)``, when
+        that target lies inside the configured churn band.
+        """
+        if chi <= 0.0:
             return x_t, t
 
-        effective_churn_factor = (
-            self.churn_factor if churn_factor is None else churn_factor
+        coeff = self.coeff
+        target = (1.0 + chi) * float(coeff.sigma_eff(t))
+        t_hat = self._sigma_eff_to_time(target, t, self.churn_max_time)
+        if t_hat <= t:
+            return x_t, t
+
+        alpha_ratio = float(coeff.alpha(t_hat)) / _clip(float(coeff.alpha(t)))
+        variance = (
+            float(coeff.gamma(t_hat)) ** 2 - (alpha_ratio**2) * float(coeff.gamma(t)) ** 2
         )
-        dt = (1 - t) * effective_churn_factor
+        if variance <= 0.0:
+            return x_t, t
 
-        C = self.coeff
-        alpha_t, beta_t = C.alpha(t), C.beta(t)
-        alpha_dot, beta_dot = C.alpha_deriv(t), C.beta_deriv(t)
-        eps: float = C.eps(t)
-
-        # Forward-pinned churn step
         noise = torch.randn_like(x_t).masked_fill_(~mask[..., None], 0.0)
+        x_hat = (
+            alpha_ratio * x_t
+            + (float(coeff.beta(t_hat)) - alpha_ratio * float(coeff.beta(t))) * x_T
+            + math.sqrt(variance) * noise
+        )
+        return x_hat, t_hat
 
-        f_t = alpha_dot / alpha_t
-        s_t = beta_dot - f_t * beta_t
-        drift = f_t * x_t + s_t * x_T
+    def _churn_factor_at_time(self, t: float) -> float:
+        span = self.time_max - self.churn_end_time
+        weight = (t - self.churn_end_time) / span if span > 0.0 else 0.0
+        weight = min(max(weight, 0.0), 1.0) ** 2
+        return self.churn_factor * (1.0 + (self.churn_max_multiplier - 1.0) * weight)
 
-        x_tm = x_t + drift * dt + _sqrt(2 * eps * dt) * noise
-        tm = t + dt
+    def _apply_forward_pinned_churn(
+        self,
+        x_t: torch.Tensor,
+        x_T: torch.Tensor,
+        mask: torch.Tensor,
+        t: float,
+    ) -> tuple[torch.Tensor, float]:
+        # The schedule starts at ``time_max``. Keep both churn bounds open so
+        # that the initial state is never perturbed or consumes RNG.
+        if not self.churn_end_time < t < self.churn_max_time:
+            return x_t, t
 
-        return x_tm, tm
+        return self._apply_sigma_matched_churn(
+            x_t,
+            x_T,
+            mask,
+            t,
+            chi=self._churn_factor_at_time(t),
+        )
 
     def _select_update_method(self, t: float) -> tuple[str, str]:
         if self.sampler_switch_gamma is None:
@@ -961,9 +1041,7 @@ class KFoldECSI(BaseStructureModule):
         ode_type : str, optional
             Type of update: 'si' or 'ecsi'.
         step_scale : float, optional
-            Multiplier for the deterministic ODE displacement, analogous to the
-            step scale used in AF3/EDM samplers.
-
+            Multiplier for the deterministic ODE displacement.
         """
         C = self.coeff
         alpha_t, alpha_dot = C.alpha(t), C.alpha_deriv(t)

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -206,7 +206,8 @@ class KFoldECSI(BaseStructureModule):
         sampler_sde_atom_classes : tuple[str, ...]
             Explicit classes that receive the sampler profile. ``("all",)``
             preserves the global sampler, while ``()`` makes every atom use SI
-            ODE. Covalently connected chains are routed as one component.
+            ODE. Molecular classes select their matching token atoms only; they
+            do not expand over covalent bonds.
         churn_factor : float
             Fractional effective-noise inflation ``chi`` before the fixed
             high-time ramp. This is the only numerical sampler knob.
@@ -679,32 +680,8 @@ class KFoldECSI(BaseStructureModule):
             "atom_mask": train_mask,
         }
 
-    @staticmethod
-    def _expand_covalent_chain_components(
-        f_input: FoldingInput,
-        selected_chain: torch.Tensor,
-    ) -> torch.Tensor:
-        """Expand a chain selection over valid covalent bond components."""
-        chain_ids = f_input.chain.asym_id
-        bond_ids = f_input.bond.asym_id
-        chain_matches_bond = chain_ids[:, :, None, None] == bond_ids[:, None, :, :]
-        expanded = selected_chain
-
-        # At most one round per chain is sufficient for transitive components.
-        # The fixed loop avoids a device synchronization for every bond graph.
-        for _ in range(expanded.shape[1]):
-            selected_bond_ends = (
-                chain_matches_bond & expanded[:, :, None, None]
-            ).any(dim=1)
-            connected_bonds = selected_bond_ends.any(dim=-1) & f_input.bond.pad_mask
-            connected_chains = (
-                chain_matches_bond & connected_bonds[:, None, :, None]
-            ).any(dim=(2, 3))
-            expanded = expanded | (connected_chains & f_input.chain.pad_mask)
-        return expanded
-
     def _get_sde_atom_mask(self, f_input: FoldingInput) -> torch.Tensor:
-        """Return selected atom components for class-routed SDE updates.
+        """Return selected atoms for class-routed SDE updates.
 
         Global churn is deliberately outside this selector: every atom reaches
         the same post-churn time before the shared score-model call.
@@ -712,31 +689,27 @@ class KFoldECSI(BaseStructureModule):
         if self.sampler_sde_atom_classes == ("all",):
             return f_input.atom.pad_mask
 
-        selected_chain = torch.zeros_like(f_input.chain.pad_mask)
+        selected_token = torch.zeros_like(f_input.token.pad_mask)
         if "protein" in self.sampler_sde_atom_classes:
-            selected_chain |= f_input.chain.is_protein
+            selected_token |= f_input.token.is_protein
         if "ligand" in self.sampler_sde_atom_classes:
-            selected_chain |= f_input.chain.is_ligand
+            selected_token |= f_input.token.is_ligand
         if "rna" in self.sampler_sde_atom_classes:
-            selected_chain |= f_input.chain.is_rna
+            selected_token |= f_input.token.is_rna
         if "dna" in self.sampler_sde_atom_classes:
-            selected_chain |= f_input.chain.is_dna
+            selected_token |= f_input.token.is_dna
         if "peptide" in self.sampler_sde_atom_classes:
-            selected_chain |= f_input.chain.is_protein & (
+            peptide_chain = f_input.chain.is_protein & (
                 f_input.chain.num_residues < 16
             )
-        selected_chain &= f_input.chain.pad_mask
-        selected_chain = self._expand_covalent_chain_components(
-            f_input,
-            selected_chain,
-        )
-
-        token_matches_chain = (
-            f_input.token.asym_id[:, :, None] == f_input.chain.asym_id[:, None, :]
-        )
-        selected_token = (
-            token_matches_chain & selected_chain[:, None, :]
-        ).any(dim=-1)
+            peptide_chain &= f_input.chain.pad_mask
+            token_matches_peptide = (
+                f_input.token.asym_id[:, :, None]
+                == f_input.chain.asym_id[:, None, :]
+            )
+            selected_token |= (
+                token_matches_peptide & peptide_chain[:, None, :]
+            ).any(dim=-1)
         selected_token &= f_input.token.pad_mask
         selected_atom = torch.gather(
             selected_token,
@@ -1081,7 +1054,7 @@ class KFoldECSI(BaseStructureModule):
         return x_hat, t_hat
 
     def _churn_factor_at_time(self, t: float) -> float:
-        span = self.time_max - self.churn_end_time
+        span = self.churn_max_time - self.churn_end_time
         weight = (t - self.churn_end_time) / span if span > 0.0 else 0.0
         weight = min(max(weight, 0.0), 1.0) ** 2
         return self.churn_factor * (1.0 + (self.churn_max_multiplier - 1.0) * weight)

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -198,18 +198,15 @@ class KFoldECSI(BaseStructureModule):
         sampler_step_scale : float
             Multiplier for deterministic ODE update displacement.
         sampler_switch_time : float | None
-            Reverse-time boundary for the fixed low-time ODE/SI phase. Values
-            at or below the boundary use the low-time sampler; ``None``
-            disables the phase.
-        sampler_after_switch_mode : str
-            Low-time update mode. The default is ``ode``.
-        sampler_after_switch_ode_type : str
-            Low-time update family. The default is ``si``.
+            Reverse-time boundary for the fixed low-time SI-ODE phase. Values
+            at or below the boundary use SI ODE; ``None`` disables the phase.
         sampler_sde_atom_classes : tuple[str, ...]
             Explicit classes that receive the sampler profile. ``("all",)``
             preserves the global sampler, while ``()`` makes every atom use SI
             ODE. Molecular classes select their matching token atoms only; they
-            do not expand over covalent bonds.
+            do not expand over covalent bonds. ``protein`` includes peptide
+            chains; ``peptide`` selects protein chains with fewer than 16
+            residues.
         churn_factor : float
             Fractional effective-noise inflation ``chi`` before the fixed
             high-time ramp. This is the only numerical sampler knob.
@@ -254,8 +251,6 @@ class KFoldECSI(BaseStructureModule):
         sampler_ode_type: str = "ecsi"
         sampler_step_scale: float = 1.0
         sampler_switch_time: float | None = 0.1
-        sampler_after_switch_mode: str = "ode"
-        sampler_after_switch_ode_type: str = "si"
         sampler_sde_atom_classes: tuple[str, ...] = ("all",)
         churn_factor: float = 0.1
         churn_max_multiplier: float = 4.0
@@ -309,15 +304,6 @@ class KFoldECSI(BaseStructureModule):
             raise ValueError(f"Unknown ECSI sampler_mode: {cfg.sampler_mode}")
         if cfg.sampler_ode_type not in {"si", "ecsi"}:
             raise ValueError(f"Unknown ECSI sampler_ode_type: {cfg.sampler_ode_type}")
-        if cfg.sampler_after_switch_mode not in {"ode", "sde"}:
-            raise ValueError(
-                f"Unknown ECSI sampler_after_switch_mode: {cfg.sampler_after_switch_mode}"
-            )
-        if cfg.sampler_after_switch_ode_type not in {"si", "ecsi"}:
-            raise ValueError(
-                f"Unknown ECSI sampler_after_switch_ode_type: "
-                f"{cfg.sampler_after_switch_ode_type}"
-            )
         if cfg.sampler_step_scale <= 0:
             raise ValueError("ECSI sampler_step_scale must be positive.")
         if cfg.sampler_switch_time is not None and not (
@@ -359,8 +345,6 @@ class KFoldECSI(BaseStructureModule):
         self.sampler_ode_type: str = cfg.sampler_ode_type
         self.sampler_step_scale: float = cfg.sampler_step_scale
         self.sampler_switch_time: float | None = cfg.sampler_switch_time
-        self.sampler_after_switch_mode: str = cfg.sampler_after_switch_mode
-        self.sampler_after_switch_ode_type: str = cfg.sampler_after_switch_ode_type
         self.sampler_sde_atom_classes = self._normalize_sde_atom_classes(
             cfg.sampler_sde_atom_classes
         )
@@ -1143,11 +1127,12 @@ class KFoldECSI(BaseStructureModule):
         return torch.where(sde_atom_mask[:, None, :, None], x_sde, x_ode)
 
     def _select_update_method(self, t: float) -> tuple[str, str]:
+        """Use the high-time profile or the fixed low-time SI-ODE phase."""
         if (
             self.sampler_switch_time is not None
             and t <= self.sampler_switch_time
         ):
-            return self.sampler_after_switch_mode, self.sampler_after_switch_ode_type
+            return "ode", "si"
         return self.sampler_mode, self.sampler_ode_type
 
     def _update_step(

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -1,6 +1,7 @@
 """Targeted correctness tests for the minimal ECSI churn sampler."""
 
 import math
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -34,6 +35,33 @@ def make_state() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     return x_t, x_T, mask
 
 
+def make_class_routing_input() -> SimpleNamespace:
+    """Return a minimal batched input with a covalent ligand-chain component."""
+    return SimpleNamespace(
+        chain=SimpleNamespace(
+            asym_id=torch.tensor([[10, 20, 30, 40, 50]]),
+            pad_mask=torch.tensor([[True, True, True, True, True]]),
+            is_protein=torch.tensor([[True, False, True, False, False]]),
+            is_ligand=torch.tensor([[False, True, False, False, False]]),
+            is_rna=torch.tensor([[False, False, False, True, False]]),
+            is_dna=torch.tensor([[False, False, False, False, True]]),
+            num_residues=torch.tensor([[100, 1, 8, 12, 12]]),
+        ),
+        token=SimpleNamespace(
+            asym_id=torch.tensor([[10, 20, 30, 40, 50]]),
+            pad_mask=torch.tensor([[True, True, True, True, True]]),
+        ),
+        atom=SimpleNamespace(
+            token_index=torch.tensor([[0, 1, 2, 3, 4, 0]]),
+            pad_mask=torch.tensor([[True, True, True, True, True, False]]),
+        ),
+        bond=SimpleNamespace(
+            asym_id=torch.tensor([[[20, 10]]]),
+            pad_mask=torch.tensor([[True]]),
+        ),
+    )
+
+
 def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     config = KFoldECSI.Config()
 
@@ -46,8 +74,45 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     assert config.gamma_power == 1.0
     assert config.churn_end_time == CHURN_END_TIME
     assert config.churn_max_time is None
+    assert config.sampler_sde_atom_classes is None
     assert not hasattr(config, "churn_space")
     assert not hasattr(config, "svgd_step")
+
+
+def test_class_sde_mask_selects_classes_and_covalent_components() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("ligand", "peptide", "rna"))
+
+    selected = sampler._get_sde_atom_mask(make_class_routing_input())
+
+    assert selected is not None
+    assert torch.equal(
+        selected,
+        torch.tensor([[True, True, True, True, False, False]]),
+    )
+
+
+def test_null_and_empty_class_selectors_remain_distinct() -> None:
+    f_input = make_class_routing_input()
+
+    assert make_sampler()._get_sde_atom_mask(f_input) is None
+    selected = make_sampler(sampler_sde_atom_classes=())._get_sde_atom_mask(f_input)
+    assert selected is not None
+    assert not selected.any()
+
+
+def test_class_sde_selector_rejects_unknown_or_duplicate_classes() -> None:
+    with pytest.raises(ValueError, match="unsupported classes"):
+        make_sampler(sampler_sde_atom_classes=("protein",))
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        make_sampler(sampler_sde_atom_classes=("ligand", "ligand"))
+
+
+def test_class_sde_routing_uses_the_global_hybrid_profile() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("ligand",))
+
+    assert sampler._select_update_method(0.9) == ("sde", "ecsi")
+    assert sampler._select_update_method(0.3) == ("sde", "ecsi")
+    assert sampler._select_update_method(0.05) == ("ode", "si")
 
 
 def test_sigma_matched_churn_hits_requested_noise_inflation() -> None:
@@ -160,6 +225,84 @@ def test_sigma_matched_churn_clamps_to_trained_time_support() -> None:
     x_high, t_high = sampler._apply_sigma_matched_churn(x_t, x_T, mask, 0.8, chi=0.5)
     assert t_high == 0.8
     torch.testing.assert_close(x_high, x_t, rtol=0.0, atol=0.0)
+
+
+def test_class_selective_update_keeps_unselected_atoms_on_si_ode() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("ligand",))
+    x_t, x_T, mask = make_state()
+    x_0_hat = torch.full_like(x_t, 0.25)
+    selected_atoms = torch.tensor([[False, True, False, False, False]])
+
+    expected_ode = sampler._update_step(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        0.7,
+        0.6,
+        mode="ode",
+        ode_type="si",
+        step_scale=sampler.sampler_step_scale,
+    )
+    torch.manual_seed(47)
+    observed = sampler._apply_class_selective_update(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        selected_atoms,
+        0.7,
+        0.6,
+    )
+
+    unselected = ~selected_atoms[0]
+    torch.testing.assert_close(
+        observed[:, :, unselected, :],
+        expected_ode[:, :, unselected, :],
+        rtol=0.0,
+        atol=0.0,
+    )
+    assert not torch.equal(observed[:, :, 1, :], expected_ode[:, :, 1, :])
+
+
+def test_class_sde_low_time_fallback_does_not_consume_rng() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("ligand",))
+    x_t, x_T, mask = make_state()
+    x_0_hat = torch.full_like(x_t, 0.25)
+    selected_atoms = torch.tensor([[False, True, False, False, False]])
+
+    expected_ode = sampler._update_step(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        0.05,
+        0.01,
+        mode="ode",
+        ode_type="si",
+        step_scale=sampler.sampler_step_scale,
+    )
+    torch.manual_seed(61)
+    expected_next_noise = torch.randn_like(x_t)
+    torch.manual_seed(61)
+    observed = sampler._apply_class_selective_update(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        selected_atoms,
+        0.05,
+        0.01,
+    )
+    actual_next_noise = torch.randn_like(x_t)
+
+    torch.testing.assert_close(observed, expected_ode, rtol=0.0, atol=0.0)
+    torch.testing.assert_close(
+        actual_next_noise,
+        expected_next_noise,
+        rtol=0.0,
+        atol=0.0,
+    )
 
 
 def test_sde_to_ode_rollback_keeps_the_same_churn_move() -> None:

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -74,7 +74,7 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     assert config.gamma_power == 1.0
     assert config.churn_end_time == CHURN_END_TIME
     assert config.churn_max_time is None
-    assert config.sampler_sde_atom_classes is None
+    assert config.sampler_sde_atom_classes == ("all",)
     assert not hasattr(config, "churn_space")
     assert not hasattr(config, "svgd_step")
 
@@ -91,20 +91,37 @@ def test_class_sde_mask_selects_classes_and_covalent_components() -> None:
     )
 
 
-def test_null_and_empty_class_selectors_remain_distinct() -> None:
+def test_protein_class_selects_protein_and_covalent_components() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("protein",))
+
+    selected = sampler._get_sde_atom_mask(make_class_routing_input())
+
+    assert torch.equal(
+        selected,
+        torch.tensor([[True, True, True, False, False, False]]),
+    )
+
+
+def test_all_and_empty_class_selectors_are_explicit() -> None:
     f_input = make_class_routing_input()
 
-    assert make_sampler()._get_sde_atom_mask(f_input) is None
+    assert torch.equal(
+        make_sampler()._get_sde_atom_mask(f_input),
+        f_input.atom.pad_mask,
+    )
     selected = make_sampler(sampler_sde_atom_classes=())._get_sde_atom_mask(f_input)
-    assert selected is not None
     assert not selected.any()
 
 
 def test_class_sde_selector_rejects_unknown_or_duplicate_classes() -> None:
+    with pytest.raises(ValueError, match="must be explicit"):
+        make_sampler(sampler_sde_atom_classes=None)
     with pytest.raises(ValueError, match="unsupported classes"):
-        make_sampler(sampler_sde_atom_classes=("protein",))
+        make_sampler(sampler_sde_atom_classes=("carbohydrate",))
     with pytest.raises(ValueError, match="must not contain duplicates"):
         make_sampler(sampler_sde_atom_classes=("ligand", "ligand"))
+    with pytest.raises(ValueError, match="must be used alone"):
+        make_sampler(sampler_sde_atom_classes=("all", "ligand"))
 
 
 def test_class_sde_routing_uses_the_global_hybrid_profile() -> None:
@@ -251,6 +268,7 @@ def test_class_selective_update_keeps_unselected_atoms_on_si_ode() -> None:
         x_T,
         mask,
         selected_atoms,
+        True,
         0.7,
         0.6,
     )
@@ -263,6 +281,82 @@ def test_class_selective_update_keeps_unselected_atoms_on_si_ode() -> None:
         atol=0.0,
     )
     assert not torch.equal(observed[:, :, 1, :], expected_ode[:, :, 1, :])
+
+
+@pytest.mark.parametrize("sampler_mode", ["sde", "ode"])
+def test_all_class_selector_matches_the_global_update(sampler_mode: str) -> None:
+    sampler = make_sampler(sampler_mode=sampler_mode)
+    x_t, x_T, mask = make_state()
+    x_0_hat = torch.full_like(x_t, 0.25)
+    selected_atoms = torch.ones(mask.shape[0], mask.shape[-1], dtype=torch.bool)
+    mode, ode_type = sampler._select_update_method(0.7)
+
+    torch.manual_seed(53)
+    expected = sampler._update_step(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        0.7,
+        0.6,
+        mode=mode,
+        ode_type=ode_type,
+        step_scale=sampler.sampler_step_scale,
+    )
+    torch.manual_seed(53)
+    observed = sampler._apply_class_selective_update(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        selected_atoms,
+        True,
+        0.7,
+        0.6,
+    )
+
+    torch.testing.assert_close(observed, expected, rtol=0.0, atol=0.0)
+
+
+def test_empty_class_selector_uses_si_ode_without_consuming_rng() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=())
+    x_t, x_T, mask = make_state()
+    x_0_hat = torch.full_like(x_t, 0.25)
+    selected_atoms = torch.zeros(mask.shape[0], mask.shape[-1], dtype=torch.bool)
+
+    expected_ode = sampler._update_step(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        0.7,
+        0.6,
+        mode="ode",
+        ode_type="si",
+        step_scale=sampler.sampler_step_scale,
+    )
+    torch.manual_seed(59)
+    expected_next_noise = torch.randn_like(x_t)
+    torch.manual_seed(59)
+    observed = sampler._apply_class_selective_update(
+        x_t,
+        x_0_hat,
+        x_T,
+        mask,
+        selected_atoms,
+        False,
+        0.7,
+        0.6,
+    )
+    actual_next_noise = torch.randn_like(x_t)
+
+    torch.testing.assert_close(observed, expected_ode, rtol=0.0, atol=0.0)
+    torch.testing.assert_close(
+        actual_next_noise,
+        expected_next_noise,
+        rtol=0.0,
+        atol=0.0,
+    )
 
 
 def test_class_sde_low_time_fallback_does_not_consume_rng() -> None:
@@ -291,6 +385,7 @@ def test_class_sde_low_time_fallback_does_not_consume_rng() -> None:
         x_T,
         mask,
         selected_atoms,
+        True,
         0.05,
         0.01,
     )

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -68,7 +68,7 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
 
     assert config.sampler_mode == "sde"
     assert config.sampler_ode_type == "ecsi"
-    assert config.sampler_switch_gamma == 3.6
+    assert config.sampler_switch_time == 0.1
     assert config.sampler_after_switch_mode == "ode"
     assert config.sampler_after_switch_ode_type == "si"
     assert config.churn_factor == 0.1
@@ -77,6 +77,7 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     assert config.churn_max_time is None
     assert config.sampler_sde_atom_classes == ("all",)
     assert not hasattr(config, "churn_space")
+    assert not hasattr(config, "sampler_switch_gamma")
     assert not hasattr(config, "svgd_step")
 
 
@@ -140,8 +141,26 @@ def test_class_sde_routing_uses_the_global_hybrid_profile() -> None:
     sampler = make_sampler(sampler_sde_atom_classes=("ligand",))
 
     assert sampler._select_update_method(0.9) == ("sde", "ecsi")
-    assert sampler._select_update_method(0.3) == ("sde", "ecsi")
+    assert sampler._select_update_method(0.1001) == ("sde", "ecsi")
+    assert sampler._select_update_method(0.1) == ("ode", "si")
     assert sampler._select_update_method(0.05) == ("ode", "si")
+
+
+def test_sampler_switch_time_is_optional_and_bounded() -> None:
+    no_switch = make_sampler(sampler_switch_time=None)
+
+    assert no_switch._select_update_method(0.05) == ("sde", "ecsi")
+    with pytest.raises(ValueError, match="must lie within the trained time support"):
+        make_sampler(sampler_switch_time=0.0)
+    with pytest.raises(ValueError, match="must lie within the trained time support"):
+        make_sampler(sampler_switch_time=TIME_MAX + 1e-4)
+
+
+def test_sampler_switch_time_is_independent_of_the_gamma_schedule() -> None:
+    sampler = make_sampler(gamma_power=2.0)
+
+    assert sampler._select_update_method(0.1001) == ("sde", "ecsi")
+    assert sampler._select_update_method(0.1) == ("ode", "si")
 
 
 def test_sigma_matched_churn_hits_requested_noise_inflation() -> None:

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -36,20 +36,21 @@ def make_state() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
 
 def make_class_routing_input() -> SimpleNamespace:
-    """Return a minimal batched input with a covalent ligand-chain component."""
+    """Return a minimal batched input with a ligand bonded to protein."""
     return SimpleNamespace(
         chain=SimpleNamespace(
+            asym_id=torch.tensor([[10, 20, 30, 40, 50]]),
+            pad_mask=torch.tensor([[True, True, True, True, True]]),
+            is_protein=torch.tensor([[True, False, True, False, False]]),
+            num_residues=torch.tensor([[100, 1, 8, 12, 12]]),
+        ),
+        token=SimpleNamespace(
             asym_id=torch.tensor([[10, 20, 30, 40, 50]]),
             pad_mask=torch.tensor([[True, True, True, True, True]]),
             is_protein=torch.tensor([[True, False, True, False, False]]),
             is_ligand=torch.tensor([[False, True, False, False, False]]),
             is_rna=torch.tensor([[False, False, False, True, False]]),
             is_dna=torch.tensor([[False, False, False, False, True]]),
-            num_residues=torch.tensor([[100, 1, 8, 12, 12]]),
-        ),
-        token=SimpleNamespace(
-            asym_id=torch.tensor([[10, 20, 30, 40, 50]]),
-            pad_mask=torch.tensor([[True, True, True, True, True]]),
         ),
         atom=SimpleNamespace(
             token_index=torch.tensor([[0, 1, 2, 3, 4, 0]]),
@@ -79,7 +80,7 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     assert not hasattr(config, "svgd_step")
 
 
-def test_class_sde_mask_selects_classes_and_covalent_components() -> None:
+def test_class_sde_mask_selects_only_requested_atoms() -> None:
     sampler = make_sampler(sampler_sde_atom_classes=("ligand", "peptide", "rna"))
 
     selected = sampler._get_sde_atom_mask(make_class_routing_input())
@@ -87,18 +88,29 @@ def test_class_sde_mask_selects_classes_and_covalent_components() -> None:
     assert selected is not None
     assert torch.equal(
         selected,
-        torch.tensor([[True, True, True, True, False, False]]),
+        torch.tensor([[False, True, True, True, False, False]]),
     )
 
 
-def test_protein_class_selects_protein_and_covalent_components() -> None:
+def test_ligand_class_does_not_expand_to_covalently_bonded_protein() -> None:
+    sampler = make_sampler(sampler_sde_atom_classes=("ligand",))
+
+    selected = sampler._get_sde_atom_mask(make_class_routing_input())
+
+    assert torch.equal(
+        selected,
+        torch.tensor([[False, True, False, False, False, False]]),
+    )
+
+
+def test_protein_class_selects_only_protein_tokens() -> None:
     sampler = make_sampler(sampler_sde_atom_classes=("protein",))
 
     selected = sampler._get_sde_atom_mask(make_class_routing_input())
 
     assert torch.equal(
         selected,
-        torch.tensor([[True, True, True, False, False, False]]),
+        torch.tensor([[True, False, True, False, False, False]]),
     )
 
 
@@ -242,6 +254,13 @@ def test_sigma_matched_churn_clamps_to_trained_time_support() -> None:
     x_high, t_high = sampler._apply_sigma_matched_churn(x_t, x_T, mask, 0.8, chi=0.5)
     assert t_high == 0.8
     torch.testing.assert_close(x_high, x_t, rtol=0.0, atol=0.0)
+
+
+def test_churn_ramp_reaches_multiplier_at_configured_upper_bound() -> None:
+    sampler = make_sampler(time_max=0.8, churn_max_time=0.7)
+
+    assert sampler._churn_factor_at_time(CHURN_END_TIME) == pytest.approx(0.1)
+    assert sampler._churn_factor_at_time(0.7) == pytest.approx(0.4)
 
 
 def test_class_selective_update_keeps_unselected_atoms_on_si_ode() -> None:

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -1,0 +1,180 @@
+"""Targeted correctness tests for the minimal ECSI churn sampler."""
+
+import math
+
+import pytest
+import torch
+
+from kfold.model.modules.structure.ecsi import KFoldECSI
+
+TIME_MAX = 0.9999
+CHURN_END_TIME = 0.5
+
+
+def make_sampler(**overrides: object) -> KFoldECSI:
+    """Build a sampler without requiring a score model for sampler-only tests."""
+    config_values: dict[str, object] = {
+        "time_max": TIME_MAX,
+        "churn_end_time": CHURN_END_TIME,
+        "churn_max_time": None,
+    }
+    config_values.update(overrides)
+    config = KFoldECSI.Config(**config_values)
+    return KFoldECSI(config, score_model=object())  # type: ignore[arg-type]
+
+
+def make_state() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return a float64 CPU state with one masked atom per sample."""
+    generator = torch.Generator().manual_seed(17)
+    shape = (1, 2, 5, 3)
+    x_t = torch.randn(shape, generator=generator, dtype=torch.float64)
+    x_T = torch.randn(shape, generator=generator, dtype=torch.float64)
+    mask = torch.ones(shape[:-1], dtype=torch.bool)
+    mask[..., -1] = False
+    return x_t, x_T, mask
+
+
+def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
+    config = KFoldECSI.Config()
+
+    assert config.sampler_mode == "sde"
+    assert config.sampler_ode_type == "ecsi"
+    assert config.sampler_switch_gamma == 3.6
+    assert config.sampler_after_switch_mode == "ode"
+    assert config.sampler_after_switch_ode_type == "si"
+    assert config.churn_factor == 0.1
+    assert config.gamma_power == 1.0
+    assert config.churn_end_time == CHURN_END_TIME
+    assert config.churn_max_time is None
+    assert not hasattr(config, "churn_space")
+    assert not hasattr(config, "svgd_step")
+
+
+def test_sigma_matched_churn_hits_requested_noise_inflation() -> None:
+    sampler = make_sampler(gamma_power=2.0)
+    x_t, x_T, mask = make_state()
+    chi = 0.1
+    t = 0.7
+
+    _, t_hat = sampler._apply_sigma_matched_churn(x_t, x_T, mask, t, chi=chi)
+
+    expected_sigma = (1.0 + chi) * float(sampler.coeff.sigma_eff(t))
+    actual_sigma = float(sampler.coeff.sigma_eff(t_hat))
+    assert math.isclose(actual_sigma, expected_sigma, rel_tol=1e-10)
+
+
+def test_sigma_matched_churn_uses_the_default_bridge_closed_form() -> None:
+    sampler = make_sampler()
+    x_t, x_T, mask = make_state()
+    chi = 0.1
+    t = 0.7
+
+    _, t_hat = sampler._apply_sigma_matched_churn(x_t, x_T, mask, t, chi=chi)
+
+    expected_odds = (1.0 + chi) ** 2 * t / (1.0 - t)
+    expected_time = expected_odds / (1.0 + expected_odds)
+    assert t_hat == pytest.approx(expected_time)
+
+
+def test_gamma_power_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="gamma_power must be positive"):
+        make_sampler(gamma_power=0.0)
+
+
+def test_sigma_matched_churn_uses_the_bridge_conditional() -> None:
+    sampler = make_sampler()
+    x_t, x_T, mask = make_state()
+    chi = 0.1
+    t = 0.7
+
+    torch.manual_seed(23)
+    expected_noise = torch.randn_like(x_t).masked_fill_(~mask[..., None], 0.0)
+    torch.manual_seed(23)
+    observed, t_hat = sampler._apply_sigma_matched_churn(x_t, x_T, mask, t, chi=chi)
+
+    coeff = sampler.coeff
+    alpha_ratio = float(coeff.alpha(t_hat)) / float(coeff.alpha(t))
+    variance = (
+        float(coeff.gamma(t_hat)) ** 2 - alpha_ratio**2 * float(coeff.gamma(t)) ** 2
+    )
+    expected = (
+        alpha_ratio * x_t
+        + (float(coeff.beta(t_hat)) - alpha_ratio * float(coeff.beta(t))) * x_T
+        + math.sqrt(variance) * expected_noise
+    )
+    torch.testing.assert_close(observed, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_churn_is_a_no_op_for_zero_chi_and_outside_its_window() -> None:
+    sampler = make_sampler()
+    x_t, x_T, mask = make_state()
+
+    x_zero, t_zero = sampler._apply_sigma_matched_churn(x_t, x_T, mask, 0.7, chi=0.0)
+    assert t_zero == 0.7
+    torch.testing.assert_close(x_zero, x_t, rtol=0.0, atol=0.0)
+
+    x_end, t_end = sampler._apply_forward_pinned_churn(
+        x_t,
+        x_T,
+        mask,
+        CHURN_END_TIME,
+    )
+    assert t_end == CHURN_END_TIME
+    torch.testing.assert_close(x_end, x_t, rtol=0.0, atol=0.0)
+
+
+def test_initial_sampling_time_is_excluded_from_churn_without_consuming_rng() -> None:
+    sampler = make_sampler(time_max=0.8)
+    x_t, x_T, mask = make_state()
+    initial_time = sampler.get_sampling_schedule(num_steps=5)[0]
+
+    assert initial_time == pytest.approx(sampler.time_max)
+    torch.manual_seed(29)
+    expected_next_noise = torch.randn_like(x_t)
+    torch.manual_seed(29)
+    x_initial, churn_time = sampler._apply_forward_pinned_churn(
+        x_t,
+        x_T,
+        mask,
+        initial_time,
+    )
+    actual_next_noise = torch.randn_like(x_t)
+
+    assert churn_time == initial_time
+    torch.testing.assert_close(x_initial, x_t, rtol=0.0, atol=0.0)
+    torch.testing.assert_close(
+        actual_next_noise,
+        expected_next_noise,
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def test_sigma_matched_churn_clamps_to_trained_time_support() -> None:
+    sampler = make_sampler(time_max=0.8)
+    x_t, x_T, mask = make_state()
+
+    _, t_hat = sampler._apply_sigma_matched_churn(x_t, x_T, mask, 0.75, chi=0.5)
+    assert t_hat == pytest.approx(0.8)
+
+    x_high, t_high = sampler._apply_sigma_matched_churn(x_t, x_T, mask, 0.8, chi=0.5)
+    assert t_high == 0.8
+    torch.testing.assert_close(x_high, x_t, rtol=0.0, atol=0.0)
+
+
+def test_sde_to_ode_rollback_keeps_the_same_churn_move() -> None:
+    sde_sampler = make_sampler()
+    ode_sampler = make_sampler(sampler_mode="ode")
+    x_t, x_T, mask = make_state()
+
+    assert sde_sampler._select_update_method(0.9) == ("sde", "ecsi")
+    assert sde_sampler._select_update_method(0.01) == ("ode", "si")
+    assert ode_sampler._select_update_method(0.9) == ("ode", "ecsi")
+
+    torch.manual_seed(41)
+    sde_out, sde_time = sde_sampler._apply_forward_pinned_churn(x_t, x_T, mask, 0.7)
+    torch.manual_seed(41)
+    ode_out, ode_time = ode_sampler._apply_forward_pinned_churn(x_t, x_T, mask, 0.7)
+
+    assert ode_time == sde_time
+    torch.testing.assert_close(ode_out, sde_out, rtol=0.0, atol=0.0)

--- a/tests/unit_tests/test_ecsi_sigma_matched_churn.py
+++ b/tests/unit_tests/test_ecsi_sigma_matched_churn.py
@@ -69,14 +69,14 @@ def test_global_sampler_defaults_are_the_fixed_sde_hybrid_bundle() -> None:
     assert config.sampler_mode == "sde"
     assert config.sampler_ode_type == "ecsi"
     assert config.sampler_switch_time == 0.1
-    assert config.sampler_after_switch_mode == "ode"
-    assert config.sampler_after_switch_ode_type == "si"
     assert config.churn_factor == 0.1
     assert config.gamma_power == 1.0
     assert config.churn_end_time == CHURN_END_TIME
     assert config.churn_max_time is None
     assert config.sampler_sde_atom_classes == ("all",)
     assert not hasattr(config, "churn_space")
+    assert not hasattr(config, "sampler_after_switch_mode")
+    assert not hasattr(config, "sampler_after_switch_ode_type")
     assert not hasattr(config, "sampler_switch_gamma")
     assert not hasattr(config, "svgd_step")
 
@@ -104,7 +104,7 @@ def test_ligand_class_does_not_expand_to_covalently_bonded_protein() -> None:
     )
 
 
-def test_protein_class_selects_only_protein_tokens() -> None:
+def test_protein_class_selects_protein_tokens_including_peptides() -> None:
     sampler = make_sampler(sampler_sde_atom_classes=("protein",))
 
     selected = sampler._get_sde_atom_mask(make_class_routing_input())
@@ -446,6 +446,7 @@ def test_sde_to_ode_rollback_keeps_the_same_churn_move() -> None:
     assert sde_sampler._select_update_method(0.9) == ("sde", "ecsi")
     assert sde_sampler._select_update_method(0.01) == ("ode", "si")
     assert ode_sampler._select_update_method(0.9) == ("ode", "ecsi")
+    assert ode_sampler._select_update_method(0.01) == ("ode", "si")
 
     torch.manual_seed(41)
     sde_out, sde_time = sde_sampler._apply_forward_pinned_churn(x_t, x_T, mask, 0.7)


### PR DESCRIPTION
## Stacked dependency

Depends on #364. This draft intentionally uses `codex/remove-svgd-sampling` as its base, so #364 solely owns the SVGD removal. Retarget this PR to `develop` after #364 merges.

## Changes

- Make the default sampler high-time SDE/ECSI, then low-time ODE/SI at `gamma=3.6`.
- Apply canonical sigma-matched, bridge-conditional churn with `churn_factor=0.1` and a score-support clamp.
- Treat the churn window as open at its upper bound: the initial `time_max` state is not churned and consumes no churn RNG.
- Retain `gamma_power` as the bridge-schedule parameter and use a bounded inverse map for every positive value.
- Remove the redundant `churn_space` config surface; the runtime always uses sigma-matched churn.
- Add targeted sampler-contract coverage and a provenance-preserving sweep aggregator.

## Decision boundary

This is a selected deployment policy, not a claim of universal modality improvement. Direct PL-114 evidence was oracle 69 to 75 with 6/0 paired flips; the same SDE profile had known PP High and confidence-rank costs. `churn_factor` remains the official sampler sweep knob; `gamma_power` is retained for bridge compatibility rather than promoted as a default sweep axis. Confidence retraining and new GPU evaluation are out of scope.

## Verification

- `git diff --check` passed.
- Targeted unit tests were added but not run in this change.
