### PR TITLE
train: make uniform patch supervision opt-in

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -51,7 +51,9 @@ confidence_head:
   _yaml_: "module/confidence_head.yaml"
 
 patch_pair_geometry:
-  enabled: true
+  # Patch geometry supervision is opt-in. When enabled, supervision is
+  # uniform over valid inter-chain patch pairs and is permutation-agnostic.
+  enabled: false
   channel_z: 256
   num_bins: 64
   min_dist: 2.0
@@ -60,9 +62,6 @@ patch_pair_geometry:
   max_patches_per_chain: 8
   max_patch_pairs: 256
   pool_max_tokens_per_patch: 16
-  interface_cutoff: 12.0
-  positive_cutoff: 12.0
-  hard_negative_cutoff: 18.0
 
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -55,9 +55,6 @@ patch_pair_geometry:
   max_patches_per_chain: 8
   max_patch_pairs: 256
   pool_max_tokens_per_patch: 16
-  interface_cutoff: 12.0
-  positive_cutoff: 12.0
-  hard_negative_cutoff: 18.0
 
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -153,7 +153,8 @@ loss:
     chain_com: 0.0
     bond: 0.0 # 1 for fine-tuning (See Section 5.2 for the AF3 paper)
     smooth_lddt: 1.0
-    patch_geometry: 5e-2
+    # Uniform patch geometry supervision is opt-in per model/config.
+    patch_geometry: 0.0
     interface_contact: 0
 
   # Distogram loss
@@ -162,14 +163,14 @@ loss:
     min_dist: 2.0
     max_dist: 22.0
 
-  # Patch-pair COM geometry auxiliary loss.
-  # This is inert unless model.patch_pair_geometry.enabled=true.
+  # Uniform patch-pair COM geometry auxiliary loss. This is off by default;
+  # enable both model.patch_pair_geometry.enabled and this global weight for
+  # an explicit patch-supervision experiment.
   patch_geometry_loss:
     num_bins: 64
     min_dist: 2.0
     max_dist: 22.0
     near_cutoff: 12.0
-    hard_negative_weight: 3.0
 
   # Hard-pair exact-bin CE on active inter-chain interfaces.
   # This is inactive unless loss.weights.interface_contact is positive.

--- a/src/kfold/model/modules/patch_geometry.py
+++ b/src/kfold/model/modules/patch_geometry.py
@@ -22,8 +22,6 @@ class _PatchPairBatch(TypedDict):
     mask_i: torch.Tensor
     mask_j: torch.Tensor
     target: torch.Tensor
-    weight: torch.Tensor
-    hard_negative: torch.Tensor
 
 
 @configurable
@@ -39,9 +37,6 @@ class PatchPairGeometryHead(nn.Module):
         max_patches_per_chain: int = 8
         max_patch_pairs: int = 256
         pool_max_tokens_per_patch: int = 0
-        interface_cutoff: float = 12.0
-        positive_cutoff: float = 12.0
-        hard_negative_cutoff: float = 22.0
 
     def __init__(self, cfg: Config, channel_z: int | None = None):
         super().__init__()
@@ -56,8 +51,6 @@ class PatchPairGeometryHead(nn.Module):
         self.pool_max_tokens_per_patch: int = int(
             getattr(cfg, "pool_max_tokens_per_patch", 0)
         )
-        self.positive_cutoff: float = float(cfg.positive_cutoff)
-        self.hard_negative_cutoff: float = float(cfg.hard_negative_cutoff)
         if self.pool_max_tokens_per_patch < 0:
             raise ValueError("pool_max_tokens_per_patch must be non-negative.")
 
@@ -100,8 +93,6 @@ class PatchPairGeometryHead(nn.Module):
 
         per_batch_logits: list[torch.Tensor] = []
         per_batch_targets: list[torch.Tensor] = []
-        per_batch_weights: list[torch.Tensor] = []
-        per_batch_hard_negative: list[torch.Tensor] = []
 
         for b in range(z.shape[0]):
             patch_pairs = self._build_patch_pairs(f_input, b)
@@ -109,25 +100,17 @@ class PatchPairGeometryHead(nn.Module):
                 continue
             per_batch_logits.append(self._pool_patch_pairs(z[b], patch_pairs))
             per_batch_targets.append(patch_pairs["target"])
-            per_batch_weights.append(patch_pairs["weight"].to(dtype=z.dtype))
-            per_batch_hard_negative.append(patch_pairs["hard_negative"])
 
         if per_batch_logits:
             logits = torch.cat(per_batch_logits)
             target = torch.cat(per_batch_targets)
-            weight = torch.cat(per_batch_weights)
-            hard_negative = torch.cat(per_batch_hard_negative)
         else:
             logits = z.new_zeros((0, self.num_bins)) + self._zero_active_param_sum(z)
             target = torch.zeros((0,), device=z.device, dtype=torch.long)
-            weight = z.new_zeros((0,))
-            hard_negative = torch.zeros((0,), device=z.device, dtype=torch.bool)
 
         return {
             "logits": logits,
             "target": target,
-            "weight": weight,
-            "hard_negative": hard_negative,
         }
 
     def _build_patch_pairs(
@@ -142,17 +125,9 @@ class PatchPairGeometryHead(nn.Module):
             finite_mask = torch.isfinite(coords).all(dim=-1)
             valid = token_mask & repr_mask & finite_mask
             asym_id = f_input.token.asym_id[batch_idx]
-            entity_id = f_input.token.entity_id[batch_idx]
             chain_ids = asym_id[valid].unique(sorted=True)
             if chain_ids.numel() < 2:
                 return None
-            has_repeated_entity = entity_id[valid].unique().numel() < chain_ids.numel()
-
-            local_atom_index = torch.full_like(asym_id, -1)
-            repr_index = f_input.token.repr_index[batch_idx]
-            local_atom_index[valid] = f_input.atom.atom_index[batch_idx][
-                repr_index[valid]
-            ]
 
             patches: list[_Patch] = []
             for chain_id in chain_ids.unbind():
@@ -168,10 +143,6 @@ class PatchPairGeometryHead(nn.Module):
             patch_pairs = self._select_patch_pairs(
                 patches=patches,
                 coords=coords,
-                asym_id=asym_id,
-                entity_id=entity_id,
-                local_atom_index=local_atom_index,
-                has_repeated_entity=has_repeated_entity,
             )
         return patch_pairs
 
@@ -249,10 +220,6 @@ class PatchPairGeometryHead(nn.Module):
         self,
         patches: list[_Patch],
         coords: torch.Tensor,
-        asym_id: torch.Tensor,
-        entity_id: torch.Tensor,
-        local_atom_index: torch.Tensor,
-        has_repeated_entity: bool,
     ) -> _PatchPairBatch:
         n_patches = len(patches)
         device = coords.device
@@ -269,41 +236,6 @@ class PatchPairGeometryHead(nn.Module):
         )
         pool_mask = torch.arange(pool_idx.shape[1], device=device) < pool_lengths[:, None]
 
-        token_patch = torch.full(
-            (coords.shape[0],),
-            -1,
-            device=device,
-            dtype=torch.long,
-        )
-        for patch_idx, patch in enumerate(patches):
-            token_patch[patch["idx"]] = patch_idx
-
-        assigned = token_patch >= 0
-        assigned_patch = token_patch[assigned]
-        assigned_coords = coords[assigned].float()
-        assigned_asym_id = asym_id[assigned]
-        assigned_entity_id = entity_id[assigned]
-        assigned_local_atom_index = local_atom_index[assigned]
-        token_pair_patch = (
-            assigned_patch[:, None] * n_patches + assigned_patch[None, :]
-        ).reshape(-1)
-        token_diff = assigned_coords[:, None, :] - assigned_coords[None, :, :]
-        token_dist = token_diff.norm(dim=-1).reshape(-1)
-        patch_min_dist = torch.full(
-            (n_patches * n_patches,),
-            float("inf"),
-            device=device,
-            dtype=token_dist.dtype,
-        )
-        patch_min_dist.scatter_reduce_(
-            0,
-            token_pair_patch,
-            token_dist,
-            reduce="amin",
-            include_self=True,
-        )
-        patch_min_dist = patch_min_dist.view(n_patches, n_patches)
-
         patch_i, patch_j = torch.triu_indices(
             n_patches,
             n_patches,
@@ -313,47 +245,16 @@ class PatchPairGeometryHead(nn.Module):
         inter_chain = chain_id[patch_i] != chain_id[patch_j]
         patch_i = patch_i[inter_chain]
         patch_j = patch_j[inter_chain]
-        token_min_dist = patch_min_dist[patch_i, patch_j]
-        positive = token_min_dist < self.positive_cutoff
-
-        if has_repeated_entity:
-            symmetry_contact = self._symmetry_equivalent_patch_contact(
-                assigned_asym_id=assigned_asym_id,
-                assigned_entity_id=assigned_entity_id,
-                assigned_local_atom_index=assigned_local_atom_index,
-                token_pair_patch=token_pair_patch,
-                token_dist=token_dist,
-                n_patches=n_patches,
-            )
-            copy_ambiguous = symmetry_contact[patch_i, patch_j] & ~positive
-            keep = ~copy_ambiguous
-            patch_i = patch_i[keep]
-            patch_j = patch_j[keep]
-            token_min_dist = token_min_dist[keep]
-            positive = positive[keep]
-        hard_negative = token_min_dist > self.hard_negative_cutoff
 
         com_diff = com[patch_i] - com[patch_j]
         com_dist = (com_diff * com_diff).sum(dim=-1).sqrt()
         target = (com_dist[:, None] > self.boundaries).sum(dim=-1).long()
 
-        weight = torch.where(
-            hard_negative,
-            positive.new_tensor(0.5, dtype=coords.dtype),
-            torch.where(
-                positive,
-                positive.new_tensor(1.0, dtype=coords.dtype),
-                positive.new_tensor(0.25, dtype=coords.dtype),
-            ),
-        )
-        dist_term = torch.minimum(com_dist, com_dist.new_tensor(100.0)) / 1000.0
-        priority = torch.where(
-            positive,
-            3.0 - dist_term,
-            torch.where(hard_negative, 2.0 + dist_term, com_dist.new_ones(())),
-        )
-        n_select = min(self.max_patch_pairs, priority.numel())
-        selected = torch.topk(priority, n_select, sorted=False).indices
+        # Uniform supervision: every valid inter-chain patch pair is sampled
+        # with equal probability, independent of contact or hard-negative
+        # distance categories.
+        n_select = min(self.max_patch_pairs, patch_i.numel())
+        selected = torch.randperm(patch_i.numel(), device=device)[:n_select]
         selected_i = patch_i[selected]
         selected_j = patch_j[selected]
 
@@ -363,65 +264,7 @@ class PatchPairGeometryHead(nn.Module):
             "mask_i": pool_mask[selected_i],
             "mask_j": pool_mask[selected_j],
             "target": target[selected],
-            "weight": weight[selected],
-            "hard_negative": hard_negative[selected],
         }
-
-    def _symmetry_equivalent_patch_contact(
-        self,
-        assigned_asym_id: torch.Tensor,
-        assigned_entity_id: torch.Tensor,
-        assigned_local_atom_index: torch.Tensor,
-        token_pair_patch: torch.Tensor,
-        token_dist: torch.Tensor,
-        n_patches: int,
-    ) -> torch.Tensor:
-        # Same entity and chain-local representative atom index identifies a
-        # corresponding token position across interchangeable chain copies.
-        symmetry_position = torch.stack(
-            (assigned_entity_id, assigned_local_atom_index),
-            dim=-1,
-        )
-        symmetry_positions, symmetry_index = torch.unique(
-            symmetry_position,
-            dim=0,
-            return_inverse=True,
-        )
-        n_symmetry_positions = symmetry_positions.shape[0]
-
-        symmetry_pair = (
-            symmetry_index[:, None] * n_symmetry_positions + symmetry_index[None, :]
-        ).reshape(-1)
-        inter_chain = (assigned_asym_id[:, None] != assigned_asym_id[None, :]).reshape(-1)
-        contact = inter_chain & (token_dist < self.positive_cutoff)
-
-        symmetry_contact = torch.zeros(
-            n_symmetry_positions * n_symmetry_positions,
-            device=token_dist.device,
-            dtype=torch.bool,
-        )
-        symmetry_contact.scatter_reduce_(
-            0,
-            symmetry_pair,
-            contact,
-            reduce="amax",
-            include_self=True,
-        )
-        equivalent_contact = symmetry_contact[symmetry_pair] & inter_chain
-
-        patch_contact = torch.zeros(
-            n_patches * n_patches,
-            device=token_dist.device,
-            dtype=torch.bool,
-        )
-        patch_contact.scatter_reduce_(
-            0,
-            token_pair_patch,
-            equivalent_contact,
-            reduce="amax",
-            include_self=True,
-        )
-        return patch_contact.view(n_patches, n_patches)
 
     def _pool_patch_pairs(
         self,

--- a/src/kfold/training/loss/patch_geometry.py
+++ b/src/kfold/training/loss/patch_geometry.py
@@ -9,16 +9,12 @@ class PatchPairGeometryLoss(torch.nn.Module):
         max_dist: float = 22.0,
         num_bins: int = 64,
         near_cutoff: float = 12.0,
-        hard_negative_weight: float = 1.0,
-        eps: float = 1e-6,
     ) -> None:
         super().__init__()
         self.min_dist: float = min_dist
         self.max_dist: float = max_dist
         self.num_bins: int = num_bins
         self.near_cutoff: float = near_cutoff
-        self.hard_negative_weight: float = hard_negative_weight
-        self.eps: float = eps
 
         bin_size = (max_dist - min_dist) / num_bins
         first_bin = min_dist + bin_size
@@ -31,40 +27,27 @@ class PatchPairGeometryLoss(torch.nn.Module):
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         logits = patch_output["logits"]
         target = patch_output["target"]
-        weight = patch_output["weight"]
-        hard_negative = patch_output["hard_negative"]
 
         log_prob = F.log_softmax(logits, dim=-1)
         ce = -log_prob.gather(dim=-1, index=target[:, None]).squeeze(-1)
 
-        denom = weight.sum().clamp(min=1.0)
-        ce_loss = (ce * weight).sum() / denom
+        pair_count = logits.new_tensor(target.numel())
+        ce_loss = ce.sum() / pair_count.clamp(min=1.0)
 
         p_near = torch.logsumexp(
             log_prob[..., : self.near_bin + 1],
             dim=-1,
         ).exp()
-        hard_weight = weight * hard_negative.to(weight.dtype)
-        hard_denom = hard_weight.sum().clamp(min=1.0)
-        hard_loss = (
-            -torch.log1p(-p_near.clamp(max=1.0 - self.eps)) * hard_weight
-        ).sum() / hard_denom
-
-        loss = ce_loss + self.hard_negative_weight * hard_loss
         with torch.no_grad():
             near_target = target <= self.near_bin
             far_target = ~near_target
-            pair_count = torch.ones_like(weight).sum()
-            near_count = near_target.to(weight.dtype).sum()
-            far_count = far_target.to(weight.dtype).sum()
-            hard_count = hard_negative.to(weight.dtype).sum()
+            near_count = near_target.to(logits.dtype).sum()
+            far_count = far_target.to(logits.dtype).sum()
 
         metrics = {
-            "patch_geometry_loss": loss.detach(),
+            "patch_geometry_loss": ce_loss.detach(),
             "patch_geometry_ce_loss": ce_loss.detach(),
-            "patch_geometry_hard_negative_loss": hard_loss.detach(),
             "patch_geometry_valid_pairs": pair_count.detach(),
-            "patch_geometry_hard_negative_pairs": hard_count.detach(),
             "patch_geometry_near_pairs": near_count.detach(),
             "patch_geometry_far_pairs": far_count.detach(),
             "patch_geometry_target_near_rate": (
@@ -79,8 +62,5 @@ class PatchPairGeometryLoss(torch.nn.Module):
             "patch_geometry_false_positive_near_mass": (
                 (p_near * far_target).sum() / far_count.clamp(min=1.0)
             ).detach(),
-            "patch_geometry_hard_negative_p_near": (
-                (p_near * hard_negative).sum() / hard_count.clamp(min=1.0)
-            ).detach(),
         }
-        return loss, metrics
+        return ce_loss, metrics

--- a/tests/unit_tests/test_patch_geometry.py
+++ b/tests/unit_tests/test_patch_geometry.py
@@ -6,7 +6,7 @@ from kfold.model.modules.patch_geometry import PatchPairGeometryHead
 from kfold.training.loss.patch_geometry import PatchPairGeometryLoss
 
 
-def _fake_input():
+def _fake_input() -> SimpleNamespace:
     asym_id = torch.tensor([[1] * 8 + [2] * 8], dtype=torch.long)
     coords = torch.zeros(1, 16, 3)
     coords[0, :8, 0] = torch.arange(8, dtype=torch.float32)
@@ -30,15 +30,10 @@ def _fake_input():
         pad_mask=torch.tensor([[True, True]], dtype=torch.bool),
         asym_id=torch.tensor([[1, 2]], dtype=torch.long),
     )
-    return SimpleNamespace(
-        token=token,
-        atom=atom,
-        chain=chain,
-        is_batched=True,
-    )
+    return SimpleNamespace(token=token, atom=atom, chain=chain, is_batched=True)
 
 
-def _fake_single_chain_input():
+def _fake_single_chain_input() -> SimpleNamespace:
     f_input = _fake_input()
     f_input.token.entity_id = torch.ones(1, 16, dtype=torch.long)
     f_input.token.asym_id = torch.ones(1, 16, dtype=torch.long)
@@ -47,7 +42,7 @@ def _fake_single_chain_input():
     return f_input
 
 
-def _fake_repeated_entity_input():
+def _fake_repeated_entity_input() -> SimpleNamespace:
     asym_id = torch.tensor([[1] * 4 + [2] * 4 + [3] * 4], dtype=torch.long)
     entity_id = torch.tensor([[1] * 4 + [2] * 8], dtype=torch.long)
     coords = torch.zeros(1, 12, 3)
@@ -63,84 +58,25 @@ def _fake_repeated_entity_input():
         org_token_index=torch.arange(12, dtype=torch.long).view(1, 12),
     )
     atom = SimpleNamespace(
-        atom_index=torch.tensor(
-            [list(range(4)) * 3],
-            dtype=torch.long,
-        ),
+        atom_index=torch.tensor([list(range(4)) * 3], dtype=torch.long)
     )
     return SimpleNamespace(token=token, atom=atom, is_batched=True)
 
 
-def _fake_patch_level_symmetry_input():
-    asym_id = torch.tensor([[1] * 4 + [2] * 4 + [3] * 4], dtype=torch.long)
-    entity_id = torch.tensor([[1] * 4 + [2] * 8], dtype=torch.long)
-    coords = torch.tensor(
-        [
-            [0.0, 0.1, 100.0, 100.1],
-            [5.0, 5.1, 150.0, 150.1],
-            [60.0, 60.1, 200.0, 200.1],
-        ],
-        dtype=torch.float32,
-    ).reshape(1, 12, 1)
-    coords = torch.nn.functional.pad(coords, (0, 2))
-    token = SimpleNamespace(
-        pad_mask=torch.ones(1, 12, dtype=torch.bool),
-        repr_mask=torch.ones(1, 12, dtype=torch.bool),
-        entity_id=entity_id,
-        asym_id=asym_id,
-        repr_index=torch.arange(12, dtype=torch.long).view(1, 12),
-        repr_coords=coords,
-        org_token_index=torch.arange(12, dtype=torch.long).view(1, 12),
-    )
-    atom = SimpleNamespace(
-        atom_index=torch.tensor(
-            [list(range(4)) * 3],
-            dtype=torch.long,
-        ),
-    )
-    return SimpleNamespace(token=token, atom=atom, is_batched=True)
-
-
-def _active_params(module):
+def _active_params(module: torch.nn.Module) -> list[torch.nn.Parameter]:
     return [p for p in module.parameters() if p.requires_grad]
 
 
-def test_patch_geometry_head_freezes_when_disabled():
+def test_patch_geometry_head_freezes_when_disabled() -> None:
     head = PatchPairGeometryHead(
         PatchPairGeometryHead.Config(enabled=False, channel_z=16),
     )
 
     assert not any(p.requires_grad for p in head.parameters())
+    assert head(_fake_input(), torch.randn(1, 16, 16, 16)) == {}
 
 
-def test_patch_geometry_head_and_loss_on_spatial_hard_negatives():
-    cfg = PatchPairGeometryHead.Config(
-        enabled=True,
-        channel_z=16,
-        patch_size=4,
-        max_patches_per_chain=2,
-        max_patch_pairs=8,
-    )
-    head = PatchPairGeometryHead(cfg)
-    f_input = _fake_input()
-    z = torch.randn(1, 16, 16, 16)
-
-    out = head(f_input, z)
-    loss, metrics = PatchPairGeometryLoss()(out)
-
-    assert out["logits"].shape[0] > 0
-    assert out["hard_negative"].sum() > 0
-    assert torch.all(out["weight"] == 0.5)
-    assert "valid_mask" not in out
-    assert "timing" not in out
-    assert torch.isfinite(loss)
-    assert metrics["patch_geometry_valid_pairs"] > 0
-
-    loss.backward()
-    assert all(p.grad is not None for p in _active_params(head))
-
-
-def test_patch_geometry_head_touches_active_params_without_patch_pairs():
+def test_patch_geometry_head_and_loss_use_uniform_pair_supervision() -> None:
     head = PatchPairGeometryHead(
         PatchPairGeometryHead.Config(
             enabled=True,
@@ -150,20 +86,19 @@ def test_patch_geometry_head_touches_active_params_without_patch_pairs():
             max_patch_pairs=8,
         ),
     )
-    f_input = _fake_single_chain_input()
-    z = torch.randn(1, 16, 16, 16, requires_grad=True)
-
-    out = head(f_input, z)
+    out = head(_fake_input(), torch.randn(1, 16, 16, 16))
     loss, metrics = PatchPairGeometryLoss()(out)
-    loss.backward()
 
-    assert out["logits"].shape[0] == 0
+    assert set(out) == {"logits", "target"}
+    assert out["logits"].shape[0] == 4
     assert torch.isfinite(loss)
-    assert metrics["patch_geometry_valid_pairs"] == 0
+    assert metrics["patch_geometry_valid_pairs"] == 4
+
+    loss.backward()
     assert all(p.grad is not None for p in _active_params(head))
 
 
-def test_patch_geometry_head_masks_noncontacting_equivalent_chain_pair():
+def test_uniform_supervision_keeps_all_repeated_entity_pairs() -> None:
     head = PatchPairGeometryHead(
         PatchPairGeometryHead.Config(
             enabled=True,
@@ -173,19 +108,14 @@ def test_patch_geometry_head_masks_noncontacting_equivalent_chain_pair():
             max_patch_pairs=8,
         ),
     )
-    f_input = _fake_repeated_entity_input()
-    z = torch.randn(1, 12, 12, 16)
+    out = head(_fake_repeated_entity_input(), torch.randn(1, 12, 12, 16))
 
-    out = head(f_input, z)
-
-    # A1-B1 is in contact, so the noncontacting A1-B2 pair is ambiguous under
-    # exchange of the two B copies and is excluded. B1-B2 remains a valid
-    # homomeric hard negative because no equivalent B-B chain pair is positive.
-    assert out["logits"].shape == (2, head.num_bins)
-    assert out["hard_negative"].sum() == 1
+    # Three chains yield three inter-chain patch pairs. No copy-ambiguous pair
+    # is removed because this supervision is intentionally symmetry-agnostic.
+    assert out["logits"].shape == (3, head.num_bins)
 
 
-def test_patch_geometry_head_keeps_homomer_negative_without_equivalent_contact():
+def test_patch_geometry_head_touches_active_params_without_patch_pairs() -> None:
     head = PatchPairGeometryHead(
         PatchPairGeometryHead.Config(
             enabled=True,
@@ -195,33 +125,32 @@ def test_patch_geometry_head_keeps_homomer_negative_without_equivalent_contact()
             max_patch_pairs=8,
         ),
     )
-    f_input = _fake_input()
-    f_input.token.entity_id = torch.ones(1, 16, dtype=torch.long)
-    z = torch.randn(1, 16, 16, 16)
+    out = head(_fake_single_chain_input(), torch.randn(1, 16, 16, 16))
+    loss, metrics = PatchPairGeometryLoss()(out)
+    loss.backward()
 
-    out = head(f_input, z)
+    assert out["logits"].shape[0] == 0
+    assert torch.isfinite(loss)
+    assert metrics["patch_geometry_valid_pairs"] == 0
+    assert all(p.grad is not None for p in _active_params(head))
 
-    assert out["logits"].shape == (4, head.num_bins)
-    assert out["hard_negative"].sum() == 4
 
-
-def test_patch_geometry_head_masks_only_symmetry_equivalent_patch_pair():
-    head = PatchPairGeometryHead(
-        PatchPairGeometryHead.Config(
-            enabled=True,
-            channel_z=16,
-            patch_size=2,
-            max_patches_per_chain=2,
-            max_patch_pairs=32,
-        ),
+def test_patch_geometry_loss_is_unweighted_mean_cross_entropy() -> None:
+    logits = torch.tensor(
+        [[2.0, -1.0, 0.5], [-0.5, 0.0, 1.5]],
+        requires_grad=True,
     )
-    f_input = _fake_patch_level_symmetry_input()
-    z = torch.randn(1, 12, 12, 16)
+    target = torch.tensor([0, 2])
+    loss, metrics = PatchPairGeometryLoss(
+        min_dist=2.0,
+        max_dist=5.0,
+        num_bins=3,
+        near_cutoff=3.0,
+    )({"logits": logits, "target": target})
 
-    out = head(f_input, z)
+    expected = torch.nn.functional.cross_entropy(logits, target)
+    torch.testing.assert_close(loss, expected)
+    torch.testing.assert_close(metrics["patch_geometry_ce_loss"], expected.detach())
 
-    # Six patches form twelve inter-chain patch pairs. A1-p0 contacts B1-p0,
-    # so only the symmetry-equivalent A1-p0/B2-p0 negative is removed. The
-    # other three A1/B2 patch pairs remain valid hard negatives.
-    assert out["logits"].shape == (11, head.num_bins)
-    assert out["hard_negative"].sum() == 10
+    loss.backward()
+    assert logits.grad is not None


### PR DESCRIPTION
Patch distogram loss: simplify logic (remove symm correction + uniform weighting) & turn off config added (default - off)