### PR TITLE
feat: add ranking-only patch loss

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -62,6 +62,7 @@ patch_pair_geometry:
   max_patches_per_chain: 8
   max_patch_pairs: 256
   pool_max_tokens_per_patch: 16
+  ranking_contact_cutoff: 8.0
 
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -55,6 +55,7 @@ patch_pair_geometry:
   max_patches_per_chain: 8
   max_patch_pairs: 256
   pool_max_tokens_per_patch: 16
+  ranking_contact_cutoff: 8.0
 
 # Training preconditioning
 diffusion_conditioning_drop_rate: 0.2

--- a/configs/train/full.yaml
+++ b/configs/train/full.yaml
@@ -148,6 +148,7 @@ loss:
   # an explicit patch-supervision experiment.
   patch_geometry_loss:
     near_cutoff: 12.0
+    ranking_weight: 1.0
 
   # Hard-pair exact-bin CE on active inter-chain interfaces.
   # This is inactive unless loss.weights.interface_contact is positive.

--- a/configs/train/stage_2_patch.yaml
+++ b/configs/train/stage_2_patch.yaml
@@ -1,0 +1,79 @@
+_yaml_: "full.yaml"
+
+seed: 2
+
+global_hparams:
+  diffusion_batch_size: 32
+
+loss:
+  weights:
+    bond: 1.0 # Turn on bond loss (See Section 5.2 for the AF3 paper)
+    patch_geometry: 0.001
+
+data:
+  max_chains: 20
+  max_tokens: 640
+  max_sequence_tokens: 1280
+
+  ccd_path: /cache/wykim_lab/kfold_data/v260701_af3/ccd-train.pkl
+  data_root: /cache/wykim_lab/kfold_data/v260701_af3/dataset/
+  train_datasets:
+    # RCSB PDB (50%)
+    - _yaml_: "../dataset/rcsb-train.yaml"
+      name: rcsb-train-upd
+      weight: 0.500
+
+    # Disordered PDB datasets (1%)
+    - _yaml_: "../dataset/disordered_pdb.yaml"
+      name: disordered_pdb
+      weight: 0.010
+
+    # Protein Monomer (30%)
+    - _yaml_: "../dataset/distill-monomer.yaml"
+      name: AF2-MGnify-long
+      weight: 0.250
+    - _yaml_: "../dataset/distill-monomer.yaml"
+      name: AF2-MGnify-short
+      weight: 0.002
+
+    - _yaml_: "../dataset/distill-monomer.yaml"
+      name: AFDB-long
+      weight: 0.040
+    - _yaml_: "../dataset/distill-monomer.yaml"
+      name: AFDB-short
+      weight: 0.008
+
+    # RNA Monomer (2%)
+    - _yaml_: "../dataset/distill-rna-monomer.yaml"
+      name: Rfam
+      weight: 0.020
+
+    # Protein-Protein (13%)
+    - _yaml_: "../dataset/distill-homodimer.yaml"
+      manifest_path: /cache/wykim_lab/kfold_data/v260701_af3/dataset/AFDB-homodimer/manifest_08.msgpack
+      name: AFDB-homodimer
+      weight: 0.100
+
+    - _yaml_: "../dataset/distill-heterodimer.yaml"
+      manifest_path: /cache/wykim_lab/kfold_data/v260701_af3/dataset/AFDB-heterodimer/manifest_08.msgpack
+      name: AFDB-heterodimer
+      weight: 0.030
+
+    # Protein-DNA (2%)
+    - _yaml_: "../dataset/distill-complex-uniform.yaml"
+      name: JASPAR
+      weight: 0.020
+
+    # Protein-RNA (1%)
+    - _yaml_: "../dataset/distill-complex-cluster.yaml"
+      name: ENCORE
+      weight: 0.010
+
+    # Protein-ligand, TPD (1%)
+    - _yaml_: "../dataset/distill-complex-cluster.yaml"
+      name: TPD
+      weight: 0.010
+
+  val_datasets:
+    - _yaml_: "../dataset/rcsb-val.yaml"
+      name: rcsb-val

--- a/src/kfold/model/modules/patch_geometry.py
+++ b/src/kfold/model/modules/patch_geometry.py
@@ -22,6 +22,8 @@ class _PatchPairBatch(TypedDict):
     mask_i: torch.Tensor
     mask_j: torch.Tensor
     target: torch.Tensor
+    contact_strength: torch.Tensor
+    rank_group: torch.Tensor
 
 
 @configurable
@@ -37,6 +39,7 @@ class PatchPairGeometryHead(nn.Module):
         max_patches_per_chain: int = 8
         max_patch_pairs: int = 256
         pool_max_tokens_per_patch: int = 0
+        ranking_contact_cutoff: float = 8.0
 
     def __init__(self, cfg: Config, channel_z: int | None = None):
         super().__init__()
@@ -51,8 +54,11 @@ class PatchPairGeometryHead(nn.Module):
         self.pool_max_tokens_per_patch: int = int(
             getattr(cfg, "pool_max_tokens_per_patch", 0)
         )
+        self.ranking_contact_cutoff: float = float(cfg.ranking_contact_cutoff)
         if self.pool_max_tokens_per_patch < 0:
             raise ValueError("pool_max_tokens_per_patch must be non-negative.")
+        if self.ranking_contact_cutoff <= 0:
+            raise ValueError("ranking_contact_cutoff must be positive.")
 
         bin_size = (self.max_dist - self.min_dist) / self.num_bins
         first_bin = self.min_dist + bin_size
@@ -70,6 +76,7 @@ class PatchPairGeometryHead(nn.Module):
             Linear(4 * self.channel_z, self.channel_z),
         )
         self.out = Linear(self.channel_z, self.num_bins, init="final")
+        self.rank_out = Linear(self.channel_z, 1, init="final")
         if not self.enabled:
             for param in self.parameters():
                 param.requires_grad_(False)
@@ -92,26 +99,46 @@ class PatchPairGeometryHead(nn.Module):
             raise ValueError("PatchPairGeometryHead expects batched FoldingInput.")
 
         per_batch_logits: list[torch.Tensor] = []
+        per_batch_rank_scores: list[torch.Tensor] = []
         per_batch_targets: list[torch.Tensor] = []
+        per_batch_contact_strengths: list[torch.Tensor] = []
+        per_batch_rank_groups: list[torch.Tensor] = []
+        rank_group_offset = 0
 
         for b in range(z.shape[0]):
             patch_pairs = self._build_patch_pairs(f_input, b)
             if patch_pairs is None:
                 continue
-            per_batch_logits.append(self._pool_patch_pairs(z[b], patch_pairs))
+            logits, rank_score = self._pool_patch_pairs(z[b], patch_pairs)
+            per_batch_logits.append(logits)
+            per_batch_rank_scores.append(rank_score)
             per_batch_targets.append(patch_pairs["target"])
+            per_batch_contact_strengths.append(patch_pairs["contact_strength"])
+            local_rank_group = patch_pairs["rank_group"]
+            per_batch_rank_groups.append(local_rank_group + rank_group_offset)
+            if local_rank_group.numel() > 0:
+                rank_group_offset += int(local_rank_group.max().item()) + 1
 
         if per_batch_logits:
             logits = torch.cat(per_batch_logits)
+            rank_score = torch.cat(per_batch_rank_scores)
             target = torch.cat(per_batch_targets)
+            contact_strength = torch.cat(per_batch_contact_strengths)
+            rank_group = torch.cat(per_batch_rank_groups)
         else:
             logits = z.new_zeros((0, self.num_bins)) + self._zero_active_param_sum(z)
             target = torch.zeros((0,), device=z.device, dtype=torch.long)
+            contact_strength = z.new_zeros((0,))
+            rank_group = torch.zeros((0,), device=z.device, dtype=torch.long)
+            rank_score = z.new_zeros((0,)) + self._zero_active_param_sum(z)
 
         return {
             "logits": logits,
+            "rank_score": rank_score,
             "bin_boundaries": self.bin_boundaries,
             "target": target,
+            "contact_strength": contact_strength,
+            "rank_group": rank_group,
         }
 
     def _build_patch_pairs(
@@ -252,12 +279,32 @@ class PatchPairGeometryHead(nn.Module):
         target = (com_dist[:, None] > self.bin_boundaries).sum(dim=-1).long()
 
         # Uniform supervision: every valid inter-chain patch pair is sampled
-        # with equal probability, independent of contact or hard-negative
-        # distance categories.
+        # with equal probability. Contact density is only a ranking target;
+        # it does not change pair selection or CE weighting.
         n_select = min(self.max_patch_pairs, patch_i.numel())
         selected = torch.randperm(patch_i.numel(), device=device)[:n_select]
         selected_i = patch_i[selected]
         selected_j = patch_j[selected]
+        contact_strength = torch.stack(
+            [
+                self._contact_strength(coords[p_i["idx"]], coords[p_j["idx"]])
+                for p_i, p_j in zip(
+                    [patches[idx] for idx in selected_i.tolist()],
+                    [patches[idx] for idx in selected_j.tolist()],
+                    strict=True,
+                )
+            ]
+        )
+        selected_chain_i = chain_id[selected_i]
+        selected_chain_j = chain_id[selected_j]
+        chain_pair = torch.stack(
+            (
+                torch.minimum(selected_chain_i, selected_chain_j),
+                torch.maximum(selected_chain_i, selected_chain_j),
+            ),
+            dim=-1,
+        )
+        _, rank_group = torch.unique(chain_pair, dim=0, return_inverse=True)
 
         return {
             "idx_i": pool_idx[selected_i],
@@ -265,16 +312,26 @@ class PatchPairGeometryHead(nn.Module):
             "mask_i": pool_mask[selected_i],
             "mask_j": pool_mask[selected_j],
             "target": target[selected],
+            "contact_strength": contact_strength,
+            "rank_group": rank_group,
         }
+
+    def _contact_strength(
+        self,
+        coords_i: torch.Tensor,
+        coords_j: torch.Tensor,
+    ) -> torch.Tensor:
+        distance_squared = (coords_i[:, None] - coords_j[None, :]).square().sum(dim=-1)
+        return (distance_squared < self.ranking_contact_cutoff**2).float().mean()
 
     def _pool_patch_pairs(
         self,
         z: torch.Tensor,
         patch_pairs: _PatchPairBatch,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         n_pairs = patch_pairs["target"].numel()
         if n_pairs == 0:
-            return z.new_zeros((0, self.num_bins))
+            return z.new_zeros((0, self.num_bins)), z.new_zeros((0,))
 
         z_flat = z.reshape(-1, self.channel_z)
         seq_len = z.shape[0]
@@ -303,4 +360,4 @@ class PatchPairGeometryHead(nn.Module):
         pooled_z = torch.einsum("pn,pnc->pc", alpha, flat_z)
         pooled = self.pool_value(pooled_z)
         pooled = pooled + self.transition(pooled)
-        return self.out(pooled)
+        return self.out(pooled), self.rank_out(pooled).squeeze(-1)

--- a/src/kfold/training/loss/patch_geometry.py
+++ b/src/kfold/training/loss/patch_geometry.py
@@ -6,9 +6,63 @@ class PatchPairGeometryLoss(torch.nn.Module):
     def __init__(
         self,
         near_cutoff: float = 12.0,
+        ranking_weight: float = 0.0,
+        eps: float = 1e-6,
     ) -> None:
         super().__init__()
         self.near_cutoff: float = near_cutoff
+        self.ranking_weight: float = ranking_weight
+        self.eps: float = eps
+        if ranking_weight < 0:
+            raise ValueError("ranking_weight must be non-negative.")
+
+    def _ranking_loss(
+        self,
+        score: torch.Tensor,
+        target: torch.Tensor,
+        group: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Rank contact-density targets within each unordered chain pair."""
+        group_losses: list[torch.Tensor] = []
+        weighted_correct = score.new_zeros(())
+        ranking_weight_sum = score.new_zeros(())
+        ranking_pair_count = score.new_zeros(())
+
+        for group_id in torch.unique(group):
+            in_group = group == group_id
+            group_score = score[in_group]
+            if group_score.numel() < 2:
+                continue
+            group_target = target[in_group]
+
+            target_diff = group_target[:, None] - group_target[None, :]
+            score_diff = group_score[:, None] - group_score[None, :]
+            upper_triangle = torch.ones_like(target_diff, dtype=torch.bool).triu(
+                diagonal=1
+            )
+            comparable = upper_triangle & (target_diff != 0)
+            if not comparable.any():
+                continue
+
+            comparison_weight = target_diff.abs() * comparable.to(score.dtype)
+            denom = comparison_weight.sum().clamp(min=self.eps)
+            signed_score_diff = target_diff.sign() * score_diff
+            group_losses.append(
+                (F.softplus(-signed_score_diff) * comparison_weight).sum() / denom
+            )
+            weighted_correct = (
+                weighted_correct
+                + ((signed_score_diff > 0).to(score.dtype) * comparison_weight).sum()
+            )
+            ranking_weight_sum = ranking_weight_sum + comparison_weight.sum()
+            ranking_pair_count = ranking_pair_count + comparable.to(score.dtype).sum()
+
+        ranking_loss = (
+            torch.stack(group_losses).mean() if group_losses else score.sum() * 0.0
+        )
+        ranking_accuracy = weighted_correct / ranking_weight_sum.clamp(min=self.eps)
+        ranking_group_count = score.new_tensor(len(group_losses))
+        return ranking_loss, ranking_accuracy, ranking_pair_count, ranking_group_count
 
     def forward(
         self,
@@ -26,6 +80,30 @@ class PatchPairGeometryLoss(torch.nn.Module):
         pair_count = logits.new_tensor(target.numel())
         ce_loss = ce.sum() / pair_count.clamp(min=1.0)
 
+        ranking_loss = logits.sum() * 0.0
+        ranking_accuracy = logits.new_zeros(())
+        ranking_pair_count = logits.new_zeros(())
+        ranking_group_count = logits.new_zeros(())
+        if self.ranking_weight > 0:
+            try:
+                (
+                    ranking_loss,
+                    ranking_accuracy,
+                    ranking_pair_count,
+                    ranking_group_count,
+                ) = self._ranking_loss(
+                    score=patch_output["rank_score"],
+                    target=patch_output["contact_strength"],
+                    group=patch_output["rank_group"],
+                )
+            except KeyError as exc:
+                raise KeyError(
+                    "Patch ranking requires rank_score, contact_strength, and "
+                    "rank_group model outputs."
+                ) from exc
+
+        loss = ce_loss + self.ranking_weight * ranking_loss
+
         p_near = torch.logsumexp(
             log_prob[..., : near_bin + 1],
             dim=-1,
@@ -37,8 +115,12 @@ class PatchPairGeometryLoss(torch.nn.Module):
             far_count = far_target.to(logits.dtype).sum()
 
         metrics = {
-            "patch_geometry_loss": ce_loss.detach(),
+            "patch_geometry_loss": loss.detach(),
             "patch_geometry_ce_loss": ce_loss.detach(),
+            "patch_geometry_ranking_loss": ranking_loss.detach(),
+            "patch_geometry_ranking_accuracy": ranking_accuracy.detach(),
+            "patch_geometry_ranking_pairs": ranking_pair_count.detach(),
+            "patch_geometry_ranking_groups": ranking_group_count.detach(),
             "patch_geometry_valid_pairs": pair_count.detach(),
             "patch_geometry_near_pairs": near_count.detach(),
             "patch_geometry_far_pairs": far_count.detach(),
@@ -55,4 +137,4 @@ class PatchPairGeometryLoss(torch.nn.Module):
                 (p_near * far_target).sum() / far_count.clamp(min=1.0)
             ).detach(),
         }
-        return ce_loss, metrics
+        return loss, metrics

--- a/tests/unit_tests/test_patch_geometry.py
+++ b/tests/unit_tests/test_patch_geometry.py
@@ -87,9 +87,16 @@ def test_patch_geometry_head_and_loss_use_uniform_pair_supervision() -> None:
         ),
     )
     out = head(_fake_input(), torch.randn(1, 16, 16, 16))
-    loss, metrics = PatchPairGeometryLoss()(out)
+    loss, metrics = PatchPairGeometryLoss(ranking_weight=1.0)(out)
 
-    assert set(out) == {"logits", "bin_boundaries", "target"}
+    assert set(out) == {
+        "logits",
+        "rank_score",
+        "bin_boundaries",
+        "target",
+        "contact_strength",
+        "rank_group",
+    }
     assert out["logits"].shape[0] == 4
     assert torch.isfinite(loss)
     assert metrics["patch_geometry_valid_pairs"] == 4
@@ -155,3 +162,28 @@ def test_patch_geometry_loss_is_unweighted_mean_cross_entropy() -> None:
 
     loss.backward()
     assert logits.grad is not None
+
+
+def test_patch_geometry_ranking_uses_contact_density_within_chain_pairs() -> None:
+    logits = torch.zeros(4, 3, requires_grad=True)
+    rank_score = torch.tensor([2.0, -1.0, 3.0, 0.0], requires_grad=True)
+    out = {
+        "logits": logits,
+        "bin_boundaries": torch.tensor([3.0, 4.0]),
+        "target": torch.tensor([0, 1, 1, 2]),
+        # Only the first two pairs share a chain-pair group. Their desired
+        # order is intentionally the opposite of rank_score.
+        "contact_strength": torch.tensor([0.1, 0.9, 0.2, 0.8]),
+        "rank_group": torch.tensor([0, 0, 1, 1]),
+        "rank_score": rank_score,
+    }
+
+    loss, metrics = PatchPairGeometryLoss(ranking_weight=1.0)(out)
+    ce_loss = torch.nn.functional.cross_entropy(logits, out["target"])
+
+    assert loss > ce_loss
+    assert metrics["patch_geometry_ranking_pairs"] == 2
+    assert metrics["patch_geometry_ranking_groups"] == 2
+
+    loss.backward()
+    assert rank_score.grad is not None


### PR DESCRIPTION
## What changed

- Enable patch loss with the existing patch CE and contact-density ranking objective.
- Exclude the legacy hard-negative loss, hard-negative weighting, and hard-negative sampling behavior.
- Add `configs/train/stage_2_patch.yaml` with an effective total-loss coefficient of `0.001` for both patch CE and ranking (`patch_geometry: 0.001`, `ranking_weight: 1.0`).

## Validation

- `python -m pytest tests/unit_tests/test_patch_geometry.py -q` — 6 passed
- Pre-commit hooks: ruff check/format, YAML validation, and merge-conflict checks passed.
