### PR TITLE
Add Exact-Markov mid-time SOAR and high-time x0 perturbation

### DIFF
--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -40,9 +40,7 @@ stepwarp_power: 0.5
 train_time_schedule: logistic
 train_time_schedule_params: [-2.15, 2.25]
 
-# Optional base-bridge x0 perturbation. Disabled by default.
-train_x_0_perturb_time_min: 0.4
-train_x_0_perturb_time_max: 0.8
+# Optional high-time chain-rigid x0 perturbation. Disabled by default.
+train_x_0_perturb_time_min: 0.7
 train_x_0_perturb_prob: 0.0
-train_x_0_perturb_rotation_deg: 0.0
-train_x_0_perturb_translation_distance: 0.0
+train_x_0_perturb_translation_std: 0.0

--- a/configs/model/module/ecsi.yaml
+++ b/configs/model/module/ecsi.yaml
@@ -39,3 +39,10 @@ stepwarp_power: 0.5
 # Training time schedule
 train_time_schedule: logistic
 train_time_schedule_params: [-2.15, 2.25]
+
+# Optional base-bridge x0 perturbation. Disabled by default.
+train_x_0_perturb_time_min: 0.4
+train_x_0_perturb_time_max: 0.8
+train_x_0_perturb_prob: 0.0
+train_x_0_perturb_rotation_deg: 0.0
+train_x_0_perturb_translation_distance: 0.0

--- a/configs/train-ecsi-stage3-soar-x0.yaml
+++ b/configs/train-ecsi-stage3-soar-x0.yaml
@@ -8,14 +8,12 @@ model:
   trunk:
     blocks_per_ckpt: 4
   diffusion_head:
-    train_x_0_perturb_time_min: 0.4
-    train_x_0_perturb_time_max: 0.8
-    train_x_0_perturb_prob: 0.5
-    train_x_0_perturb_rotation_deg: 8.0
-    train_x_0_perturb_translation_distance: 1.2
+    train_x_0_perturb_time_min: 0.7
+    train_x_0_perturb_prob: 0.2
+    train_x_0_perturb_translation_std: 4.0
 
 train:
-  name: ecsi-stage3-exact-markov-mid-soar-x0
+  name: ecsi-stage3-exact-markov-mid-soar-high-x0
   seed: 3
   load_opt_state: false
   load_global_step: true

--- a/configs/train-ecsi-stage3-soar-x0.yaml
+++ b/configs/train-ecsi-stage3-soar-x0.yaml
@@ -23,7 +23,6 @@ train:
 
   global_hparams:
     diffusion_batch_size: 32
-    global_batch_size: 160
 
   training:
     train_trunk: false

--- a/configs/train-ecsi-stage3-soar-x0.yaml
+++ b/configs/train-ecsi-stage3-soar-x0.yaml
@@ -22,7 +22,7 @@ train:
   init_from_ema: [trunk]
 
   global_hparams:
-    diffusion_batch_size: 16
+    diffusion_batch_size: 32
     global_batch_size: 160
 
   training:

--- a/configs/train-ecsi-stage3-soar-x0.yaml
+++ b/configs/train-ecsi-stage3-soar-x0.yaml
@@ -1,0 +1,54 @@
+_yaml_: "train-ecsi-stage3.yaml"
+
+model:
+  # The 80k source checkpoint contains this head. It remains part of the
+  # strict-load structure but is frozen with the trunk and has zero loss.
+  patch_pair_geometry:
+    enabled: true
+  trunk:
+    blocks_per_ckpt: 4
+  diffusion_head:
+    train_x_0_perturb_time_min: 0.4
+    train_x_0_perturb_time_max: 0.8
+    train_x_0_perturb_prob: 0.5
+    train_x_0_perturb_rotation_deg: 8.0
+    train_x_0_perturb_translation_distance: 1.2
+
+train:
+  name: ecsi-stage3-exact-markov-mid-soar-x0
+  seed: 3
+  load_opt_state: false
+  load_global_step: true
+  init_from_ema: [trunk]
+
+  global_hparams:
+    diffusion_batch_size: 16
+    global_batch_size: 160
+
+  training:
+    train_trunk: false
+    train_diffusion_head: true
+    train_confidence_head: true
+    log_time_binned_losses: true
+    time_bin_width: 0.1
+    soar:
+      mode: model_sampler
+      root_time_policy: mid_high_schedule_stratified
+      auxiliary_transition: exact_markov
+      apply_rollout_churn: false
+      rollout_schedule_num_steps: 100
+      rollout_schedule_step_count: 1.0
+      auxiliary_samples_per_root: 4
+      forward_retention_min: 0.5
+      lambda_aux: 1.0
+      mid_time_lower: 0.2
+      high_time_split: 0.8
+      mid_time_probability: 1.0
+
+  optimizer:
+    max_lr: 0.001
+    lr_decay_factor: 1.0
+
+  loss:
+    weights:
+      patch_geometry: 0.0

--- a/src/kfold/model/model_train.py
+++ b/src/kfold/model/model_train.py
@@ -189,6 +189,7 @@ class KFoldForTrain(KFold):
         f_input: FoldingInput,
         num_recycles: int = 3,
         diffusion_batch_size: int = 48,
+        soar_config: dict[str, object] | None = None,
         num_mini_rollout_steps: int = 20,
         num_mini_rollout_samples: int = 1,
         train_trunk: bool = True,
@@ -214,6 +215,8 @@ class KFoldForTrain(KFold):
         # For structure module training:
         diffusion_batch_size : int
             Batch size for diffusion training step.
+        soar_config : dict[str, object] | None
+            Optional sampler-matched Exact-Markov ECSI SOAR configuration.
 
         # For confidence module training with diffusion mini-rollout:
         num_mini_rollout_steps : int
@@ -299,9 +302,19 @@ class KFoldForTrain(KFold):
                 _z = z * mask[:, None, None, None]
 
             # Forward pass through diffusion head for training.
+            training_kwargs: dict[str, object] = {}
+            if (
+                soar_config is not None
+                and soar_config.get("mode", "disabled") != "disabled"
+            ):
+                training_kwargs["soar_config"] = soar_config
             with torch.autocast(device.type, enabled=False):
                 dict_out["diffusion"] = self.diffusion_head.training_step(
-                    f_input, s_inputs, _z, diffusion_batch_size
+                    f_input,
+                    s_inputs,
+                    _z,
+                    diffusion_batch_size,
+                    **training_kwargs,
                 )
 
         if train_confidence_module:

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -20,7 +20,11 @@ import torch
 
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.primitives.utils import expand_dim
-from kfold.utils.geometry.random_augment import CenterRandomAugmentation, do_centering
+from kfold.utils.geometry.random_augment import (
+    CenterRandomAugmentation,
+    do_centering,
+    quaternion_to_matrix,
+)
 from kfold.utils.geometry.rigid_align import get_rigid_transform_torch
 from kfold.utils.registry import STRUCTURE_MODULE
 
@@ -354,6 +358,13 @@ class KFoldECSI(BaseStructureModule):
         train_time_schedule: str = "logistic"
         train_time_schedule_params: tuple[float, float] = (-2.15, 2.25)
 
+        # Optional bounded chain-wise x0 perturbation for base bridge samples.
+        train_x_0_perturb_time_min: float = 0.4
+        train_x_0_perturb_time_max: float = 0.8
+        train_x_0_perturb_prob: float = 0.0
+        train_x_0_perturb_rotation_deg: float = 0.0
+        train_x_0_perturb_translation_distance: float = 0.0
+
     def __init__(self, cfg: Config, score_model: DiffusionModule):
         """Initialize the ECSI module.
 
@@ -385,6 +396,31 @@ class KFoldECSI(BaseStructureModule):
         self.train_time_schedule: str = cfg.train_time_schedule
         self.train_time_schedule_params: tuple[float, float] = (
             cfg.train_time_schedule_params
+        )
+        if not (
+            self.time_min
+            <= cfg.train_x_0_perturb_time_min
+            <= cfg.train_x_0_perturb_time_max
+            <= self.time_max
+        ):
+            raise ValueError(
+                "ECSI x0 perturb times must lie in the trained time support "
+                "and satisfy time_min <= time_max."
+            )
+        if not 0.0 <= cfg.train_x_0_perturb_prob <= 1.0:
+            raise ValueError("ECSI train_x_0_perturb_prob must lie in [0, 1].")
+        if cfg.train_x_0_perturb_rotation_deg < 0.0:
+            raise ValueError("ECSI train_x_0_perturb_rotation_deg must be non-negative.")
+        if cfg.train_x_0_perturb_translation_distance < 0.0:
+            raise ValueError(
+                "ECSI train_x_0_perturb_translation_distance must be non-negative."
+            )
+        self.train_x_0_perturb_time_min = cfg.train_x_0_perturb_time_min
+        self.train_x_0_perturb_time_max = cfg.train_x_0_perturb_time_max
+        self.train_x_0_perturb_prob = cfg.train_x_0_perturb_prob
+        self.train_x_0_perturb_rotation_deg = cfg.train_x_0_perturb_rotation_deg
+        self.train_x_0_perturb_translation_distance = (
+            cfg.train_x_0_perturb_translation_distance
         )
 
         # Inference time sampling
@@ -588,6 +624,16 @@ class KFoldECSI(BaseStructureModule):
             "x_gt": x_0,
             "loss_weights": loss_weights,
         }
+        for name in (
+            "time_eligible_mask",
+            "eligible_mask",
+            "requested_mask",
+            "applied_mask",
+            "x_0_rmsd",
+            "x_t_rmsd",
+            "resolved_chain_count",
+        ):
+            output[f"x_0_perturb_{name}"] = train_input[f"x_0_perturb_{name}"]
         if soar.mode == "disabled":
             return output
 
@@ -725,6 +771,179 @@ class KFoldECSI(BaseStructureModule):
         t = self.time_min + (self.time_max - self.time_min) * t
         return t
 
+    def _sample_x_0_perturb_masks(
+        self,
+        *,
+        t: torch.Tensor,
+        resolved_chain_count: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Select bounded mid-time perturbations without touching disabled RNG."""
+        time_eligible = (t >= self.train_x_0_perturb_time_min) & (
+            t < self.train_x_0_perturb_time_max
+        )
+        multichain = resolved_chain_count[:, None] > 1
+        eligible = time_eligible & multichain
+        if self.train_x_0_perturb_prob == 0.0:
+            requested = torch.zeros_like(time_eligible)
+        else:
+            requested = time_eligible & (torch.rand_like(t) < self.train_x_0_perturb_prob)
+        has_strength = (
+            self.train_x_0_perturb_rotation_deg > 0.0
+            or self.train_x_0_perturb_translation_distance > 0.0
+        )
+        applied = requested & multichain & has_strength
+        return {
+            "time_eligible": time_eligible,
+            "eligible": eligible,
+            "requested": requested,
+            "applied": applied,
+        }
+
+    @staticmethod
+    def _fixed_axis_angle_rotations(
+        shape: tuple[int, ...],
+        *,
+        angle_degrees: float,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Sample random axes with one fixed non-negative rotation magnitude."""
+        if angle_degrees == 0.0:
+            identity = torch.eye(3, dtype=dtype, device=device)
+            return identity.expand(*shape, 3, 3)
+        axes = torch.randn(*shape, 3, dtype=dtype, device=device)
+        axes = axes / axes.norm(dim=-1, keepdim=True).clamp_min(torch.finfo(dtype).eps)
+        half_angle = torch.full(
+            (*shape, 1),
+            math.radians(angle_degrees) / 2.0,
+            dtype=dtype,
+            device=device,
+        )
+        quaternion = torch.cat(
+            (torch.cos(half_angle), axes * torch.sin(half_angle)), dim=-1
+        )
+        return quaternion_to_matrix(quaternion)
+
+    @staticmethod
+    def _fixed_direction_translations(
+        shape: tuple[int, ...],
+        *,
+        distance: float,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Sample random directions with one fixed translation magnitude."""
+        if distance == 0.0:
+            return torch.zeros(*shape, 3, dtype=dtype, device=device)
+        directions = torch.randn(*shape, 3, dtype=dtype, device=device)
+        directions = directions / directions.norm(dim=-1, keepdim=True).clamp_min(
+            torch.finfo(dtype).eps
+        )
+        return directions * distance
+
+    def _perturb_x_0(
+        self,
+        *,
+        x_0: torch.Tensor,
+        t: torch.Tensor,
+        f_input: FoldingInput,
+        x_0_mask: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Perturb base-bridge x0 chain poses while retaining clean supervision."""
+        batch_size, num_samples, num_atoms, _ = x_0.shape
+        if self.train_x_0_perturb_prob == 0.0 or (
+            self.train_x_0_perturb_rotation_deg == 0.0
+            and self.train_x_0_perturb_translation_distance == 0.0
+        ):
+            time_eligible = (t >= self.train_x_0_perturb_time_min) & (
+                t < self.train_x_0_perturb_time_max
+            )
+            false_mask = torch.zeros_like(time_eligible)
+            zero = torch.zeros_like(t)
+            return {
+                "x_0_bridge": x_0,
+                "time_eligible_mask": time_eligible,
+                "eligible_mask": false_mask,
+                "requested_mask": false_mask,
+                "applied_mask": false_mask,
+                "x_0_rmsd": zero,
+                "resolved_chain_count": torch.zeros_like(t, dtype=torch.long),
+            }
+        num_chains = f_input.chain.asym_id.shape[1]
+        token_index = f_input.atom.token_index.clamp(
+            min=0, max=f_input.token.asym_id.shape[-1] - 1
+        )
+        atom_asym_id = torch.gather(f_input.token.asym_id, 1, token_index)
+        resolved_mask = x_0_mask[:, 0].bool()
+        atom_in_chain = atom_asym_id[:, :, None] == f_input.chain.asym_id[:, None, :]
+        atom_in_chain &= f_input.chain.pad_mask[:, None, :]
+        atom_chain_index = atom_in_chain.to(torch.int64).argmax(dim=-1)
+        atom_is_valid = resolved_mask & atom_in_chain.any(dim=-1)
+        chain_has_atoms = (atom_in_chain & resolved_mask[:, :, None]).any(dim=1)
+        resolved_chain_count = chain_has_atoms.sum(dim=-1)
+        selection = self._sample_x_0_perturb_masks(
+            t=t, resolved_chain_count=resolved_chain_count
+        )
+        applied = selection["applied"]
+        chain_index_xyz = atom_chain_index[:, None, :, None].expand(
+            batch_size, num_samples, num_atoms, 3
+        )
+        chain_sums = torch.zeros(
+            (batch_size, num_samples, num_chains, 3),
+            dtype=x_0.dtype,
+            device=x_0.device,
+        )
+        chain_sums.scatter_add_(
+            dim=2,
+            index=chain_index_xyz,
+            src=x_0 * atom_is_valid[:, None, :, None],
+        )
+        chain_counts = (atom_in_chain & resolved_mask[:, :, None]).sum(dim=1)
+        chain_centers = chain_sums / chain_counts[:, None, :, None].clamp_min(1)
+        chain_rotations = self._fixed_axis_angle_rotations(
+            (batch_size, num_samples, num_chains),
+            angle_degrees=self.train_x_0_perturb_rotation_deg,
+            dtype=x_0.dtype,
+            device=x_0.device,
+        )
+        chain_translations = self._fixed_direction_translations(
+            (batch_size, num_samples, num_chains),
+            distance=self.train_x_0_perturb_translation_distance,
+            dtype=x_0.dtype,
+            device=x_0.device,
+        )
+        atom_centers = torch.gather(chain_centers, dim=2, index=chain_index_xyz)
+        atom_translations = torch.gather(chain_translations, dim=2, index=chain_index_xyz)
+        rotation_index = atom_chain_index[:, None, :, None, None].expand(
+            batch_size, num_samples, num_atoms, 3, 3
+        )
+        atom_rotations = torch.gather(chain_rotations, dim=2, index=rotation_index)
+        transformed = (
+            torch.einsum("bnad,bnads->bnas", x_0 - atom_centers, atom_rotations)
+            + atom_centers
+            + atom_translations
+        )
+        expanded_mask = x_0_mask.expand(-1, num_samples, -1)
+        transformed = transformed.masked_fill(~expanded_mask[..., None], 0.0)
+        aligned = custom_rigid_align(
+            transformed,
+            x_0,
+            expanded_mask,
+            output_mask=expanded_mask,
+        )
+        apply_mask = applied[..., None, None] & expanded_mask[..., None]
+        x_0_bridge = torch.where(apply_mask, aligned, x_0)
+        x_0_rmsd = self._masked_coordinate_rmsd(x_0_bridge - x_0, expanded_mask)
+        return {
+            "x_0_bridge": x_0_bridge,
+            "time_eligible_mask": selection["time_eligible"],
+            "eligible_mask": selection["eligible"],
+            "requested_mask": selection["requested"],
+            "applied_mask": applied,
+            "x_0_rmsd": x_0_rmsd,
+            "resolved_chain_count": resolved_chain_count[:, None].expand_as(t),
+        }
+
     def sample_train_input(
         self,
         f_input: FoldingInput,
@@ -756,7 +975,7 @@ class KFoldECSI(BaseStructureModule):
         apo_mask = f_input.atom.pad_mask  # [B, Natom]
 
         # Repeat holo coords
-        x_0 = expand_dim(x_holo, num_samples, dim=-3)  # [B, N, Natom, 3]
+        x_0 = expand_dim(x_holo, num_samples, dim=-3).clone()  # [B, N, Natom, 3]
         x_0_mask = holo_mask.unsqueeze(-2)  # [B, 1, Natom]
 
         # Sample from prior coordinates
@@ -781,9 +1000,21 @@ class KFoldECSI(BaseStructureModule):
             x_T, x_0, x_0_mask, rotation_only=True, output_mask=x_T_mask
         )
 
+        # Perturb only the endpoint used by the base bridge. SOAR reconstructs
+        # its roots from the clean x_0 returned below.
+        perturb = self._perturb_x_0(
+            x_0=x_0,
+            t=t,
+            f_input=f_input,
+            x_0_mask=x_0_mask,
+        )
+
         # ECSI interpolation with atom-wise shared bridge noise.
         noise = torch.randn_like(x_0).masked_fill_(~x_T_mask[..., None], 0.0)
-        x_t = self._interpolate_bridge(x_0, x_T, noise, t)
+        x_t_clean = self._interpolate_bridge(x_0, x_T, noise, t)
+        x_t = self._interpolate_bridge(perturb["x_0_bridge"], x_T, noise, t)
+        expanded_mask = x_T_mask.expand(-1, num_samples, -1)
+        x_t_rmsd = self._masked_coordinate_rmsd(x_t - x_t_clean, expanded_mask)
 
         # Zero the hidden atoms as well as the padding, so that a code path which
         # forgets `train_mask` sees the origin rather than a prior-scale offset.
@@ -798,6 +1029,13 @@ class KFoldECSI(BaseStructureModule):
             "x_T": x_T,
             "atom_mask": train_mask,
             "noise": noise,
+            "x_0_perturb_time_eligible_mask": perturb["time_eligible_mask"],
+            "x_0_perturb_eligible_mask": perturb["eligible_mask"],
+            "x_0_perturb_requested_mask": perturb["requested_mask"],
+            "x_0_perturb_applied_mask": perturb["applied_mask"],
+            "x_0_perturb_x_0_rmsd": perturb["x_0_rmsd"],
+            "x_0_perturb_x_t_rmsd": x_t_rmsd,
+            "x_0_perturb_resolved_chain_count": perturb["resolved_chain_count"],
         }
 
     def _interpolate_bridge(

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -23,7 +23,7 @@ from kfold.model.primitives.utils import expand_dim
 from kfold.utils.geometry.random_augment import (
     CenterRandomAugmentation,
     do_centering,
-    quaternion_to_matrix,
+    random_rotations_torch,
 )
 from kfold.utils.geometry.rigid_align import get_rigid_transform_torch
 from kfold.utils.registry import STRUCTURE_MODULE
@@ -325,6 +325,13 @@ class KFoldECSI(BaseStructureModule):
             A tuple of (mu, std) for the logistic time sampling schedule.
             Time values are sampled from sigmoid(N(mu, std)), then scaled to
             [time_min, time_max].
+        train_x_0_perturb_time_min : float
+            Apply chain-rigid x0 perturbation only strictly above this time.
+        train_x_0_perturb_prob : float
+            Probability of perturbing an eligible high-time training sample.
+        train_x_0_perturb_translation_std : float
+            Per-axis standard deviation of each chain's Gaussian translation,
+            in Angstrom. Applied chains also receive a random SO(3) rotation.
         """
 
         sigma_data: float = 16.0
@@ -357,12 +364,10 @@ class KFoldECSI(BaseStructureModule):
         train_time_schedule: str = "logistic"
         train_time_schedule_params: tuple[float, float] = (-2.15, 2.25)
 
-        # Optional bounded chain-wise x0 perturbation for base bridge samples.
-        train_x_0_perturb_time_min: float = 0.4
-        train_x_0_perturb_time_max: float = 0.8
+        # Optional high-time chain-wise x0 perturbation for base bridge samples.
+        train_x_0_perturb_time_min: float = 0.7
         train_x_0_perturb_prob: float = 0.0
-        train_x_0_perturb_rotation_deg: float = 0.0
-        train_x_0_perturb_translation_distance: float = 0.0
+        train_x_0_perturb_translation_std: float = 0.0
 
     def __init__(self, cfg: Config, score_model: DiffusionModule):
         """Initialize the ECSI module.
@@ -396,31 +401,19 @@ class KFoldECSI(BaseStructureModule):
         self.train_time_schedule_params: tuple[float, float] = (
             cfg.train_time_schedule_params
         )
-        if not (
-            self.time_min
-            <= cfg.train_x_0_perturb_time_min
-            <= cfg.train_x_0_perturb_time_max
-            <= self.time_max
-        ):
+        if not self.time_min <= cfg.train_x_0_perturb_time_min <= self.time_max:
             raise ValueError(
-                "ECSI x0 perturb times must lie in the trained time support "
-                "and satisfy time_min <= time_max."
+                "ECSI train_x_0_perturb_time_min must lie in the trained time support."
             )
         if not 0.0 <= cfg.train_x_0_perturb_prob <= 1.0:
             raise ValueError("ECSI train_x_0_perturb_prob must lie in [0, 1].")
-        if cfg.train_x_0_perturb_rotation_deg < 0.0:
-            raise ValueError("ECSI train_x_0_perturb_rotation_deg must be non-negative.")
-        if cfg.train_x_0_perturb_translation_distance < 0.0:
+        if cfg.train_x_0_perturb_translation_std < 0.0:
             raise ValueError(
-                "ECSI train_x_0_perturb_translation_distance must be non-negative."
+                "ECSI train_x_0_perturb_translation_std must be non-negative."
             )
         self.train_x_0_perturb_time_min = cfg.train_x_0_perturb_time_min
-        self.train_x_0_perturb_time_max = cfg.train_x_0_perturb_time_max
         self.train_x_0_perturb_prob = cfg.train_x_0_perturb_prob
-        self.train_x_0_perturb_rotation_deg = cfg.train_x_0_perturb_rotation_deg
-        self.train_x_0_perturb_translation_distance = (
-            cfg.train_x_0_perturb_translation_distance
-        )
+        self.train_x_0_perturb_translation_std = cfg.train_x_0_perturb_translation_std
 
         # Inference time sampling
         self.align_x_0_hat_to_x_t: bool = cfg.align_x_0_hat_to_x_t
@@ -776,21 +769,15 @@ class KFoldECSI(BaseStructureModule):
         t: torch.Tensor,
         resolved_chain_count: torch.Tensor,
     ) -> dict[str, torch.Tensor]:
-        """Select bounded mid-time perturbations without touching disabled RNG."""
-        time_eligible = (t >= self.train_x_0_perturb_time_min) & (
-            t < self.train_x_0_perturb_time_max
-        )
+        """Select high-time perturbations without touching disabled RNG."""
+        time_eligible = t > self.train_x_0_perturb_time_min
         multichain = resolved_chain_count[:, None] > 1
         eligible = time_eligible & multichain
         if self.train_x_0_perturb_prob == 0.0:
             requested = torch.zeros_like(time_eligible)
         else:
             requested = time_eligible & (torch.rand_like(t) < self.train_x_0_perturb_prob)
-        has_strength = (
-            self.train_x_0_perturb_rotation_deg > 0.0
-            or self.train_x_0_perturb_translation_distance > 0.0
-        )
-        applied = requested & multichain & has_strength
+        applied = requested & multichain
         return {
             "time_eligible": time_eligible,
             "eligible": eligible,
@@ -798,65 +785,19 @@ class KFoldECSI(BaseStructureModule):
             "applied": applied,
         }
 
-    @staticmethod
-    def _fixed_axis_angle_rotations(
-        shape: tuple[int, ...],
-        *,
-        angle_degrees: float,
-        dtype: torch.dtype,
-        device: torch.device,
-    ) -> torch.Tensor:
-        """Sample random axes with one fixed non-negative rotation magnitude."""
-        if angle_degrees == 0.0:
-            identity = torch.eye(3, dtype=dtype, device=device)
-            return identity.expand(*shape, 3, 3)
-        axes = torch.randn(*shape, 3, dtype=dtype, device=device)
-        axes = axes / axes.norm(dim=-1, keepdim=True).clamp_min(torch.finfo(dtype).eps)
-        half_angle = torch.full(
-            (*shape, 1),
-            math.radians(angle_degrees) / 2.0,
-            dtype=dtype,
-            device=device,
-        )
-        quaternion = torch.cat(
-            (torch.cos(half_angle), axes * torch.sin(half_angle)), dim=-1
-        )
-        return quaternion_to_matrix(quaternion)
-
-    @staticmethod
-    def _fixed_direction_translations(
-        shape: tuple[int, ...],
-        *,
-        distance: float,
-        dtype: torch.dtype,
-        device: torch.device,
-    ) -> torch.Tensor:
-        """Sample random directions with one fixed translation magnitude."""
-        if distance == 0.0:
-            return torch.zeros(*shape, 3, dtype=dtype, device=device)
-        directions = torch.randn(*shape, 3, dtype=dtype, device=device)
-        directions = directions / directions.norm(dim=-1, keepdim=True).clamp_min(
-            torch.finfo(dtype).eps
-        )
-        return directions * distance
-
     def _perturb_x_0(
         self,
         *,
         x_0: torch.Tensor,
+        x_T: torch.Tensor,
         t: torch.Tensor,
         f_input: FoldingInput,
         x_0_mask: torch.Tensor,
     ) -> dict[str, torch.Tensor]:
-        """Perturb base-bridge x0 chain poses while retaining clean supervision."""
+        """Apply the original high-time chain-rigid x0 corruption contract."""
         batch_size, num_samples, num_atoms, _ = x_0.shape
-        if self.train_x_0_perturb_prob == 0.0 or (
-            self.train_x_0_perturb_rotation_deg == 0.0
-            and self.train_x_0_perturb_translation_distance == 0.0
-        ):
-            time_eligible = (t >= self.train_x_0_perturb_time_min) & (
-                t < self.train_x_0_perturb_time_max
-            )
+        if self.train_x_0_perturb_prob == 0.0:
+            time_eligible = t > self.train_x_0_perturb_time_min
             false_mask = torch.zeros_like(time_eligible)
             zero = torch.zeros_like(t)
             return {
@@ -899,18 +840,13 @@ class KFoldECSI(BaseStructureModule):
         )
         chain_counts = (atom_in_chain & resolved_mask[:, :, None]).sum(dim=1)
         chain_centers = chain_sums / chain_counts[:, None, :, None].clamp_min(1)
-        chain_rotations = self._fixed_axis_angle_rotations(
+        chain_rotations = random_rotations_torch(
             (batch_size, num_samples, num_chains),
-            angle_degrees=self.train_x_0_perturb_rotation_deg,
             dtype=x_0.dtype,
             device=x_0.device,
         )
-        chain_translations = self._fixed_direction_translations(
-            (batch_size, num_samples, num_chains),
-            distance=self.train_x_0_perturb_translation_distance,
-            dtype=x_0.dtype,
-            device=x_0.device,
-        )
+        chain_translations = torch.randn_like(chain_centers)
+        chain_translations *= self.train_x_0_perturb_translation_std
         atom_centers = torch.gather(chain_centers, dim=2, index=chain_index_xyz)
         atom_translations = torch.gather(chain_translations, dim=2, index=chain_index_xyz)
         rotation_index = atom_chain_index[:, None, :, None, None].expand(
@@ -922,14 +858,16 @@ class KFoldECSI(BaseStructureModule):
             + atom_centers
             + atom_translations
         )
+        apply_atom_mask = applied[..., None, None] & atom_is_valid[:, None, :, None]
+        x_0_perturbed = torch.where(apply_atom_mask, transformed, x_0)
         expanded_mask = x_0_mask.expand(-1, num_samples, -1)
-        transformed = transformed.masked_fill(~expanded_mask[..., None], 0.0)
         aligned = custom_rigid_align(
-            transformed,
-            x_0,
+            x_0_perturbed,
+            x_T,
             expanded_mask,
-            output_mask=expanded_mask,
+            rotation_only=True,
         )
+        aligned = do_centering(aligned, mask=expanded_mask)
         apply_mask = applied[..., None, None] & expanded_mask[..., None]
         x_0_bridge = torch.where(apply_mask, aligned, x_0)
         x_0_rmsd = self._masked_coordinate_rmsd(x_0_bridge - x_0, expanded_mask)
@@ -1003,6 +941,7 @@ class KFoldECSI(BaseStructureModule):
         # its roots from the clean x_0 returned below.
         perturb = self._perturb_x_0(
             x_0=x_0,
+            x_T=x_T,
             t=t,
             f_input=f_input,
             x_0_mask=x_0_mask,

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -32,11 +32,6 @@ from .sample_diffusion import BaseStructureModule
 from .score_model import DiffusionModule
 
 _T = TypeVar("_T", float, torch.Tensor)
-ECSI_SOAR_MODES = frozenset({"disabled", "model_sampler"})
-ECSI_SOAR_ROOT_TIME_POLICIES = frozenset(
-    {"mirror_base_training_time", "mid_high_schedule_stratified"}
-)
-ECSI_SOAR_AUXILIARY_TRANSITIONS = frozenset({"exact_markov"})
 
 
 # === Utility functions with type flexibility and numerical stability handling === #
@@ -167,17 +162,21 @@ class ECSISOARConfig:
     mid_time_probability: float = 1.0
 
     def __post_init__(self) -> None:
-        if self.mode not in ECSI_SOAR_MODES:
+        if self.mode not in ("disabled", "model_sampler"):
             raise ValueError(
                 f"Unknown ECSI SOAR mode {self.mode!r}; "
-                f"expected one of {sorted(ECSI_SOAR_MODES)}."
+                "expected 'disabled' or 'model_sampler'."
             )
-        if self.root_time_policy not in ECSI_SOAR_ROOT_TIME_POLICIES:
+        if self.root_time_policy not in (
+            "mirror_base_training_time",
+            "mid_high_schedule_stratified",
+        ):
             raise ValueError(
                 f"Unknown ECSI SOAR root-time policy {self.root_time_policy!r}; "
-                f"expected one of {sorted(ECSI_SOAR_ROOT_TIME_POLICIES)}."
+                "expected 'mirror_base_training_time' or "
+                "'mid_high_schedule_stratified'."
             )
-        if self.auxiliary_transition not in ECSI_SOAR_AUXILIARY_TRANSITIONS:
+        if self.auxiliary_transition != "exact_markov":
             raise ValueError(
                 f"Unknown ECSI SOAR auxiliary transition "
                 f"{self.auxiliary_transition!r}; expected exact_markov."

--- a/src/kfold/model/modules/structure/ecsi.py
+++ b/src/kfold/model/modules/structure/ecsi.py
@@ -12,6 +12,7 @@ Models the transition from source (apo) to target (holo) conformations.
 
 import dataclasses
 import math
+from collections.abc import Mapping
 from typing import TypeVar
 
 import numpy as np
@@ -27,6 +28,11 @@ from .sample_diffusion import BaseStructureModule
 from .score_model import DiffusionModule
 
 _T = TypeVar("_T", float, torch.Tensor)
+ECSI_SOAR_MODES = frozenset({"disabled", "model_sampler"})
+ECSI_SOAR_ROOT_TIME_POLICIES = frozenset(
+    {"mirror_base_training_time", "mid_high_schedule_stratified"}
+)
+ECSI_SOAR_AUXILIARY_TRANSITIONS = frozenset({"exact_markov"})
 
 
 # === Utility functions with type flexibility and numerical stability handling === #
@@ -137,6 +143,89 @@ class SICoeffs:
         return self.eta * (  # type: ignore
             gamma * gamma_dot - alpha_dot / _clip(alpha) * gamma**2
         )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ECSISOARConfig:
+    """Configuration for sampler-matched Exact-Markov ECSI SOAR training."""
+
+    mode: str = "disabled"
+    root_time_policy: str = "mirror_base_training_time"
+    auxiliary_transition: str = "exact_markov"
+    apply_rollout_churn: bool = False
+    rollout_schedule_num_steps: int = 100
+    rollout_schedule_step_count: float = 1.0
+    auxiliary_samples_per_root: int = 4
+    forward_retention_min: float = 0.5
+    lambda_aux: float = 1.0
+    mid_time_lower: float = 0.2
+    high_time_split: float = 0.8
+    mid_time_probability: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.mode not in ECSI_SOAR_MODES:
+            raise ValueError(
+                f"Unknown ECSI SOAR mode {self.mode!r}; "
+                f"expected one of {sorted(ECSI_SOAR_MODES)}."
+            )
+        if self.root_time_policy not in ECSI_SOAR_ROOT_TIME_POLICIES:
+            raise ValueError(
+                f"Unknown ECSI SOAR root-time policy {self.root_time_policy!r}; "
+                f"expected one of {sorted(ECSI_SOAR_ROOT_TIME_POLICIES)}."
+            )
+        if self.auxiliary_transition not in ECSI_SOAR_AUXILIARY_TRANSITIONS:
+            raise ValueError(
+                f"Unknown ECSI SOAR auxiliary transition "
+                f"{self.auxiliary_transition!r}; expected exact_markov."
+            )
+        if self.rollout_schedule_num_steps <= 0:
+            raise ValueError("ECSI SOAR rollout_schedule_num_steps must be positive.")
+        if not 0.0 < self.rollout_schedule_step_count <= self.rollout_schedule_num_steps:
+            raise ValueError(
+                "ECSI SOAR rollout_schedule_step_count must be in "
+                "(0, rollout_schedule_num_steps]."
+            )
+        if self.auxiliary_samples_per_root < 0:
+            raise ValueError("ECSI SOAR auxiliary_samples_per_root must be non-negative.")
+        if not 0.0 <= self.forward_retention_min <= 1.0:
+            raise ValueError("ECSI SOAR forward_retention_min must lie in [0, 1].")
+        if self.lambda_aux < 0.0:
+            raise ValueError("ECSI SOAR lambda_aux must be non-negative.")
+        if not 0.0 <= self.mid_time_lower < self.high_time_split <= 1.0:
+            raise ValueError(
+                "ECSI SOAR times must satisfy 0 <= mid_time_lower < high_time_split <= 1."
+            )
+        if not 0.0 <= self.mid_time_probability <= 1.0:
+            raise ValueError("ECSI SOAR mid_time_probability must lie in [0, 1].")
+        if self.mode != "disabled":
+            if self.auxiliary_samples_per_root == 0:
+                raise ValueError(
+                    "Active ECSI SOAR requires auxiliary_samples_per_root > 0."
+                )
+            if self.lambda_aux == 0.0:
+                raise ValueError("Active ECSI SOAR requires lambda_aux > 0.")
+
+    @classmethod
+    def from_mapping(
+        cls,
+        config: "Mapping[str, object] | ECSISOARConfig | None",
+    ) -> "ECSISOARConfig":
+        if config is None:
+            return cls()
+        if isinstance(config, cls):
+            return config
+        known_fields = {field.name for field in dataclasses.fields(cls)}
+        unknown_fields = set(config) - known_fields
+        if unknown_fields:
+            raise ValueError(
+                f"Unknown ECSI SOAR config fields: {sorted(unknown_fields)}."
+            )
+        return cls(**dict(config))  # type: ignore[arg-type]
+
+    def num_auxiliary_samples(self, num_roots: int) -> int:
+        if num_roots < 0:
+            raise ValueError("ECSI SOAR num_roots must be non-negative.")
+        return num_roots * self.auxiliary_samples_per_root
 
 
 @STRUCTURE_MODULE.register()
@@ -466,11 +555,10 @@ class KFoldECSI(BaseStructureModule):
         s_inputs: torch.Tensor,
         z: torch.Tensor,
         diffusion_batch_size: int,
+        soar_config: Mapping[str, object] | ECSISOARConfig | None = None,
     ) -> dict[str, torch.Tensor]:
-        """Perform a single training step for the structure module.
-        See Section 5 of EDM paper.
-        """
-        # Sample x
+        """Perform base ECSI training plus optional Exact-Markov SOAR."""
+        soar = ECSISOARConfig.from_mapping(soar_config)
         with torch.autocast(f_input.device.type, enabled=False):
             train_input = self.sample_train_input(f_input, diffusion_batch_size)
 
@@ -478,6 +566,7 @@ class KFoldECSI(BaseStructureModule):
         x_0 = train_input["x_0"]  # [B, N, Natom, 3]
         x_t = train_input["x_t"]  # [B, N, Natom, 3]
         x_T = train_input["x_T"]  # [B, N, Natom, 3]
+        atom_mask = train_input["atom_mask"]
 
         x_0_hat = self._forward_train(
             x_t=x_t,  # [B, N, Natom, 3]
@@ -486,12 +575,12 @@ class KFoldECSI(BaseStructureModule):
             s_inputs=s_inputs,  # [B, Lt, c_s]
             z=z,  # [B, Lt, Lt, c_z]
             x_T=x_T,  # [B, N, Natom, 3]
-            atom_mask=train_input["atom_mask"],  # [B, Natom]
+            atom_mask=atom_mask,  # [B, Natom]
         )  # [B, N, Natom, 3]
 
         loss_weights = self.loss_weights(t)  # [B, N]
 
-        return {
+        output = {
             "t": t,
             "x_t": x_t,
             "x_T": x_T,
@@ -499,6 +588,57 @@ class KFoldECSI(BaseStructureModule):
             "x_gt": x_0,
             "loss_weights": loss_weights,
         }
+        if soar.mode == "disabled":
+            return output
+
+        auxiliary = self._build_soar_training_batch(
+            f_input=f_input,
+            s_inputs=s_inputs,
+            z=z,
+            config=soar,
+            x_0=x_0,
+            x_T=x_T,
+            atom_mask=atom_mask,
+            bridge_noise=train_input["noise"],
+            base_t0=t,
+        )
+        output["t"] = torch.cat((t, auxiliary["t_aux"]), dim=1)
+        output["x_t"] = torch.cat((x_t, auxiliary["x_aux"]), dim=1)
+        output["x_T"] = torch.cat((x_T, auxiliary["x_T"]), dim=1)
+        output["x_0_hat"] = torch.cat((x_0_hat, auxiliary["x_0_hat_aux"]), dim=1)
+        output["x_gt"] = torch.cat((x_0, auxiliary["x_0"]), dim=1)
+        output["loss_weights"] = torch.cat(
+            (loss_weights, self.loss_weights(auxiliary["t_aux"])), dim=1
+        )
+
+        batch_size = t.shape[0]
+        auxiliary_mask = torch.ones(
+            (batch_size, auxiliary["t_aux"].shape[1]),
+            dtype=torch.bool,
+            device=t.device,
+        )
+        output["soar_auxiliary_mask"] = torch.cat(
+            (torch.zeros_like(t, dtype=torch.bool), auxiliary_mask), dim=1
+        )
+        output["soar_supervision_weights"] = torch.cat(
+            (torch.ones_like(t), auxiliary["supervision_weights"]), dim=1
+        )
+        for name in (
+            "base_t0",
+            "t0",
+            "t_call",
+            "t1",
+            "t2",
+            "root_branch_count",
+            "forward_retention",
+            "forward_variance",
+            "endpoint_error_rmsd",
+            "model_to_oracle_sampler_rmsd",
+            "oracle_sampler_to_exact_ecsi_rmsd",
+            "model_sampler_to_exact_ecsi_rmsd",
+        ):
+            output[f"soar_{name}"] = auxiliary[name]
+        return output
 
     def _forward_train(
         self,
@@ -641,16 +781,9 @@ class KFoldECSI(BaseStructureModule):
             x_T, x_0, x_0_mask, rotation_only=True, output_mask=x_T_mask
         )
 
-        # === Interpolate to get x_t === #
-        C = self.coeff
-        _t = t[:, :, None, None]
-        alpha_t, beta_t, gamma_t = C.alpha(_t), C.beta(_t), C.gamma(_t)
-
-        # Sample noise
-        noise = torch.randn_like(x_0)
-
-        # ECSI interpolation with atom-wise noise.
-        x_t = alpha_t * x_0 + beta_t * x_T + gamma_t * noise
+        # ECSI interpolation with atom-wise shared bridge noise.
+        noise = torch.randn_like(x_0).masked_fill_(~x_T_mask[..., None], 0.0)
+        x_t = self._interpolate_bridge(x_0, x_T, noise, t)
 
         # Zero the hidden atoms as well as the padding, so that a code path which
         # forgets `train_mask` sees the origin rather than a prior-scale offset.
@@ -664,7 +797,438 @@ class KFoldECSI(BaseStructureModule):
             "x_t": x_t,
             "x_T": x_T,
             "atom_mask": train_mask,
+            "noise": noise,
         }
+
+    def _interpolate_bridge(
+        self,
+        x_0: torch.Tensor,
+        x_T: torch.Tensor,
+        noise: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        """Evaluate the ECSI bridge with caller-supplied shared noise."""
+        expanded_t = t[..., None, None]
+        return (
+            self.coeff.alpha(expanded_t) * x_0
+            + self.coeff.beta(expanded_t) * x_T
+            + self.coeff.gamma(expanded_t) * noise
+        )
+
+    def _build_soar_training_batch(
+        self,
+        *,
+        f_input: FoldingInput,
+        s_inputs: torch.Tensor,
+        z: torch.Tensor,
+        config: ECSISOARConfig,
+        x_0: torch.Tensor,
+        x_T: torch.Tensor,
+        atom_mask: torch.Tensor,
+        bridge_noise: torch.Tensor,
+        base_t0: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        """Build detached Exact-Markov auxiliaries from model-generated states."""
+        if x_0.shape != x_T.shape or x_0.shape != bridge_noise.shape:
+            raise ValueError("SOAR endpoint and bridge-noise shapes must match.")
+        if base_t0.shape != x_0.shape[:2]:
+            raise ValueError("SOAR base times must match the base sample dimensions.")
+        if atom_mask.shape != (x_0.shape[0], x_0.shape[-2]):
+            raise ValueError("SOAR atom_mask must have shape [B, Natom].")
+
+        batch_size, num_roots = base_t0.shape
+        if num_roots == 0:
+            raise ValueError("Active ECSI SOAR requires at least one base root.")
+        num_auxiliary = config.num_auxiliary_samples(num_roots)
+        root_mask = atom_mask.unsqueeze(1).expand(-1, num_roots, -1)
+
+        with torch.no_grad(), torch.autocast(f_input.device.type, enabled=False):
+            t0 = self.construct_soar_root_times(base_t0=base_t0, config=config)
+            t1, t2 = self.sample_soar_auxiliary_times(t0=t0, config=config)
+            x_t0 = self._interpolate_bridge(x_0, x_T, bridge_noise, t0)
+            x_t0 = x_t0.masked_fill(~root_mask[..., None], 0.0)
+            x_t1_exact = self._interpolate_bridge(x_0, x_T, bridge_noise, t1)
+            x_t1_exact = x_t1_exact.masked_fill(~root_mask[..., None], 0.0)
+            x_call, t_call = self._prepare_soar_rollout_call(
+                config=config,
+                x_t=x_t0,
+                x_T=x_T,
+                mask=root_mask,
+                t=t0,
+            )
+
+        with torch.no_grad():
+            x_0_hat_t0 = self._forward_train(
+                x_t=x_call,
+                t=t_call,
+                f_input=f_input,
+                s_inputs=s_inputs,
+                z=z,
+                x_T=x_T,
+                atom_mask=atom_mask,
+            ).detach()
+
+        with torch.no_grad(), torch.autocast(f_input.device.type, enabled=False):
+            model_endpoint = self._postprocess_soar_endpoint(
+                endpoint=x_0_hat_t0,
+                x_t=x_call,
+                mask=root_mask,
+            )
+            oracle_endpoint = self._postprocess_soar_endpoint(
+                endpoint=x_0,
+                x_t=x_call,
+                mask=root_mask,
+            )
+            shared_update_noise = torch.randn_like(x_call).masked_fill_(
+                ~root_mask[..., None], 0.0
+            )
+            x_t1_model = self._apply_soar_sampler_update(
+                f_input=f_input,
+                x_t=x_call,
+                x_0_hat=model_endpoint,
+                x_T=x_T,
+                mask=root_mask,
+                t=t_call,
+                t_next=t1,
+                noise=shared_update_noise,
+            )
+            x_t1_oracle = self._apply_soar_sampler_update(
+                f_input=f_input,
+                x_t=x_call,
+                x_0_hat=oracle_endpoint,
+                x_T=x_T,
+                mask=root_mask,
+                t=t_call,
+                t_next=t1,
+                noise=shared_update_noise,
+            )
+            model_transition = self._exact_ecsi_forward_transition(
+                x_t1=x_t1_model,
+                x_T=x_T,
+                mask=root_mask,
+                t1=t1,
+                t2=t2,
+            )
+            x_aux_branched = model_transition["x_t2"]
+            x_aux = x_aux_branched.reshape(
+                batch_size, num_auxiliary, *x_0.shape[-2:]
+            ).detach()
+            x_T_aux = (
+                x_T.unsqueeze(2)
+                .expand(-1, -1, config.auxiliary_samples_per_root, -1, -1)
+                .reshape_as(x_aux)
+            )
+            x_0_aux = (
+                x_0.unsqueeze(2)
+                .expand(-1, -1, config.auxiliary_samples_per_root, -1, -1)
+                .reshape_as(x_aux)
+            )
+            t_aux = t2.reshape(batch_size, num_auxiliary)
+
+        x_0_hat_aux = self._forward_train(
+            x_t=x_aux,
+            t=t_aux,
+            f_input=f_input,
+            s_inputs=s_inputs,
+            z=z,
+            x_T=x_T_aux,
+            atom_mask=atom_mask,
+        )
+
+        endpoint_error_rmsd = self._masked_coordinate_rmsd(
+            model_endpoint - oracle_endpoint, root_mask
+        )
+        model_to_oracle_rmsd = self._masked_coordinate_rmsd(
+            x_t1_model - x_t1_oracle, root_mask
+        )
+        oracle_to_exact_rmsd = self._masked_coordinate_rmsd(
+            x_t1_oracle - x_t1_exact, root_mask
+        )
+        model_to_exact_rmsd = self._masked_coordinate_rmsd(
+            x_t1_model - x_t1_exact, root_mask
+        )
+        supervision_weights = torch.full(
+            (batch_size, num_auxiliary),
+            config.lambda_aux,
+            dtype=t_aux.dtype,
+            device=t_aux.device,
+        )
+        root_branch_count = torch.full(
+            (batch_size, num_roots),
+            config.auxiliary_samples_per_root,
+            dtype=torch.long,
+            device=t_aux.device,
+        )
+        return {
+            "base_t0": base_t0.detach(),
+            "t0": t0.detach(),
+            "t_call": t_call.detach(),
+            "t1": t1.detach(),
+            "t2": t2.detach(),
+            "root_branch_count": root_branch_count,
+            "supervision_weights": supervision_weights,
+            "t_aux": t_aux,
+            "x_0": x_0_aux,
+            "x_T": x_T_aux,
+            "x_aux": x_aux,
+            "x_0_hat_aux": x_0_hat_aux,
+            "forward_retention": model_transition["retention"].detach(),
+            "forward_variance": model_transition["variance"].detach(),
+            "endpoint_error_rmsd": endpoint_error_rmsd.detach(),
+            "model_to_oracle_sampler_rmsd": model_to_oracle_rmsd.detach(),
+            "oracle_sampler_to_exact_ecsi_rmsd": oracle_to_exact_rmsd.detach(),
+            "model_sampler_to_exact_ecsi_rmsd": model_to_exact_rmsd.detach(),
+        }
+
+    def construct_soar_root_times(
+        self, *, base_t0: torch.Tensor, config: ECSISOARConfig
+    ) -> torch.Tensor:
+        """Construct independently controlled SOAR rollout root times."""
+        if base_t0.ndim != 2:
+            raise ValueError("SOAR base time must have shape [B, Nroot].")
+        if config.root_time_policy == "mirror_base_training_time":
+            return (self.time_min + self.time_max - base_t0).clamp(
+                min=self.time_min, max=self.time_max
+            )
+
+        schedule = torch.tensor(
+            self.get_effective_sampling_schedule(config.rollout_schedule_num_steps),
+            dtype=base_t0.dtype,
+            device=base_t0.device,
+        )
+        mid_roots = self._sample_soar_schedule_cell_band(
+            shape=base_t0.shape,
+            schedule=schedule,
+            lower=max(self.time_min, config.mid_time_lower),
+            upper=min(self.time_max, config.high_time_split),
+        )
+        high_roots = self._sample_soar_schedule_cell_band(
+            shape=base_t0.shape,
+            schedule=schedule,
+            lower=max(self.time_min, config.high_time_split),
+            upper=self.time_max,
+        )
+        choose_mid = torch.rand_like(base_t0) < config.mid_time_probability
+        return torch.where(choose_mid, mid_roots, high_roots)
+
+    @staticmethod
+    def _sample_soar_schedule_cell_band(
+        *,
+        shape: torch.Size | tuple[int, ...],
+        schedule: torch.Tensor,
+        lower: float,
+        upper: float,
+    ) -> torch.Tensor:
+        """Sample uniformly over schedule cells intersecting one time band."""
+        cell_high = torch.minimum(schedule[:-1], torch.full_like(schedule[:-1], upper))
+        cell_low = torch.maximum(schedule[1:], torch.full_like(schedule[1:], lower))
+        valid_indices = torch.nonzero(cell_high > cell_low, as_tuple=False).flatten()
+        if valid_indices.numel() == 0:
+            raise ValueError(
+                f"No production-schedule cell intersects SOAR band [{lower}, {upper}]."
+            )
+        sampled_offset = torch.randint(
+            valid_indices.numel(), shape, device=schedule.device
+        )
+        sampled_index = valid_indices[sampled_offset]
+        sampled_low = cell_low[sampled_index]
+        sampled_high = cell_high[sampled_index]
+        return sampled_low + (sampled_high - sampled_low) * torch.rand(
+            shape, dtype=schedule.dtype, device=schedule.device
+        )
+
+    def sample_soar_auxiliary_times(
+        self, *, t0: torch.Tensor, config: ECSISOARConfig
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Move one production-schedule step, then sample later forward times."""
+        schedule_values = self.get_effective_sampling_schedule(
+            config.rollout_schedule_num_steps
+        )
+        work_dtype = torch.float64 if t0.dtype == torch.float64 else torch.float32
+        schedule = torch.tensor(schedule_values, dtype=work_dtype, device=t0.device)
+        t0_work = t0.to(dtype=work_dtype)
+        cell_index = ((schedule[:-1] >= t0_work.unsqueeze(-1)).sum(dim=-1) - 1).clamp(
+            min=0, max=config.rollout_schedule_num_steps - 1
+        )
+        cell_start = schedule[cell_index]
+        cell_end = schedule[cell_index + 1]
+        cell_fraction = ((cell_start - t0_work) / (cell_start - cell_end)).clamp(0, 1)
+        u0 = cell_index.to(dtype=work_dtype) + cell_fraction
+        u1 = (u0 + config.rollout_schedule_step_count).clamp_max(
+            config.rollout_schedule_num_steps
+        )
+        next_index = (
+            torch.floor(u1)
+            .to(dtype=torch.long)
+            .clamp_max(config.rollout_schedule_num_steps - 1)
+        )
+        next_fraction = u1 - next_index.to(dtype=work_dtype)
+        t1 = torch.lerp(
+            schedule[next_index], schedule[next_index + 1], next_fraction
+        ).clamp_min(self.time_min)
+        t1 = t1.to(dtype=t0.dtype)
+
+        uniform = torch.rand(
+            (*t1.shape, config.auxiliary_samples_per_root),
+            dtype=t1.dtype,
+            device=t1.device,
+        )
+        alpha_t1 = self.coeff.alpha(t1)
+        feasible_min = self.coeff.alpha(torch.full_like(t1, self.time_max)) / (
+            alpha_t1.clamp_min(torch.finfo(alpha_t1.dtype).eps)
+        )
+        retention_min = torch.maximum(
+            torch.full_like(t1, config.forward_retention_min), feasible_min
+        ).clamp_max(1.0)
+        retention = (
+            retention_min.unsqueeze(-1) + (1.0 - retention_min.unsqueeze(-1)) * uniform
+        )
+        t2 = 1.0 - retention * alpha_t1.unsqueeze(-1)
+        t2 = torch.maximum(t2, t1.unsqueeze(-1))
+        t2 = torch.minimum(t2, torch.full_like(t2, self.time_max))
+        return t1, t2
+
+    def _prepare_soar_rollout_call(
+        self,
+        *,
+        config: ECSISOARConfig,
+        x_t: torch.Tensor,
+        x_T: torch.Tensor,
+        mask: torch.Tensor,
+        t: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Optionally apply production churn before the detached rollout call."""
+        if not config.apply_rollout_churn:
+            return x_t, t
+        output = torch.empty_like(x_t)
+        call_times = torch.empty_like(t)
+        for batch_index in range(t.shape[0]):
+            for root_index in range(t.shape[1]):
+                state, call_time = self._apply_forward_pinned_churn(
+                    x_t[batch_index : batch_index + 1, root_index : root_index + 1],
+                    x_T[batch_index : batch_index + 1, root_index : root_index + 1],
+                    mask[batch_index : batch_index + 1, root_index : root_index + 1],
+                    float(t[batch_index, root_index]),
+                )
+                output[batch_index, root_index] = state[0, 0]
+                call_times[batch_index, root_index] = call_time
+        return output, call_times
+
+    def _apply_soar_sampler_update(
+        self,
+        *,
+        f_input: FoldingInput,
+        x_t: torch.Tensor,
+        x_0_hat: torch.Tensor,
+        x_T: torch.Tensor,
+        mask: torch.Tensor,
+        t: torch.Tensor,
+        t_next: torch.Tensor,
+        noise: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the class-routed production update to independently timed roots."""
+        output = torch.empty_like(x_t)
+        sde_atom_mask = self._get_sde_atom_mask(f_input)
+        for batch_index in range(t.shape[0]):
+            selected_atoms = sde_atom_mask[batch_index : batch_index + 1]
+            has_sde_atoms = self.sampler_sde_atom_classes == ("all",) or bool(
+                selected_atoms.any()
+            )
+            for root_index in range(t.shape[1]):
+                state = self._apply_class_selective_update(
+                    x_t[batch_index : batch_index + 1, root_index : root_index + 1],
+                    x_0_hat[batch_index : batch_index + 1, root_index : root_index + 1],
+                    x_T[batch_index : batch_index + 1, root_index : root_index + 1],
+                    mask[batch_index : batch_index + 1, root_index : root_index + 1],
+                    selected_atoms,
+                    has_sde_atoms,
+                    float(t[batch_index, root_index]),
+                    float(t_next[batch_index, root_index]),
+                    noise=noise[
+                        batch_index : batch_index + 1, root_index : root_index + 1
+                    ],
+                )
+                output[batch_index, root_index] = state[0, 0]
+        return output.detach()
+
+    @staticmethod
+    def _masked_coordinate_rmsd(
+        displacement: torch.Tensor, mask: torch.Tensor
+    ) -> torch.Tensor:
+        if displacement.shape[:-1] != mask.shape:
+            raise ValueError("Coordinate displacement and atom-mask shapes must match.")
+        weights = mask.to(displacement.dtype)
+        squared = displacement.square().sum(dim=-1)
+        return torch.sqrt(
+            (squared * weights).sum(dim=-1) / weights.sum(dim=-1).clamp(min=1.0)
+        )
+
+    def _exact_ecsi_forward_transition(
+        self,
+        *,
+        x_t1: torch.Tensor,
+        x_T: torch.Tensor,
+        mask: torch.Tensor,
+        t1: torch.Tensor,
+        t2: torch.Tensor,
+        noise: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        """Sample the exact ECSI bridge transition from t1 to later t2."""
+        alpha_t1 = self.coeff.alpha(t1).unsqueeze(-1)
+        retention = self.coeff.alpha(t2) / alpha_t1.clamp_min(torch.finfo(t1.dtype).eps)
+        gamma_t1 = self.coeff.gamma(t1).unsqueeze(-1)
+        gamma_t2 = self.coeff.gamma(t2)
+        variance = self.coeff.eta * (
+            gamma_t2.square() - retention.square() * gamma_t1.square()
+        )
+        tolerance = (
+            32.0
+            * torch.finfo(variance.dtype).eps
+            * (gamma_t2.square() + retention.square() * gamma_t1.square())
+            .abs()
+            .clamp_min(1.0)
+        )
+        if torch.any(variance < -tolerance):
+            raise RuntimeError("Exact ECSI forward-transition variance is negative.")
+        variance = variance.clamp_min(0.0)
+        branch_shape = (*t2.shape, *x_t1.shape[-2:])
+        x_t1_branches = x_t1.unsqueeze(-3).expand(branch_shape)
+        x_T_branches = x_T.unsqueeze(-3).expand(branch_shape)
+        branch_mask = mask.unsqueeze(-2).expand(*t2.shape, mask.shape[-1])
+        mean = (
+            retention[..., None, None] * x_t1_branches
+            + (self.coeff.beta(t2) - retention * self.coeff.beta(t1).unsqueeze(-1))[
+                ..., None, None
+            ]
+            * x_T_branches
+        )
+        if noise is None:
+            noise = torch.randn_like(mean)
+        elif noise.shape != mean.shape:
+            raise ValueError("ECSI forward-transition noise shape is incompatible.")
+        noise = noise.masked_fill(~branch_mask[..., None], 0.0)
+        x_t2 = mean + torch.sqrt(variance)[..., None, None] * noise
+        x_t2 = x_t2.masked_fill(~branch_mask[..., None], 0.0)
+        return {
+            "x_t2": x_t2,
+            "variance": variance,
+            "retention": retention,
+            "noise": noise,
+        }
+
+    def _postprocess_soar_endpoint(
+        self,
+        *,
+        endpoint: torch.Tensor,
+        x_t: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the endpoint transform used by production ECSI sampling."""
+        if self.align_x_0_hat_to_x_t:
+            endpoint = custom_rigid_align(
+                endpoint, x_t, mask, rotation_only=True, output_mask=mask
+            )
+        return do_centering(endpoint, mask=mask)
 
     def _get_sde_atom_mask(self, f_input: FoldingInput) -> torch.Tensor:
         """Return selected atoms for class-routed SDE updates.
@@ -704,6 +1268,31 @@ class KFoldECSI(BaseStructureModule):
     # ============================================================
     # For inference
     # ============================================================
+    def get_effective_sampling_schedule(self, num_steps: int) -> list[float]:
+        """Return the production schedule after high-churn knot warping."""
+        times = list(self.get_sampling_schedule(num_steps))
+        t_hi = float(times[0])
+        t_lo = self.churn_end_time
+        band = [
+            index
+            for index, time_value in enumerate(times)
+            if t_lo < float(time_value) < t_hi
+        ]
+        if band and self.stepwarp_power != 1.0:
+            lo_index, hi_index = band[0], band[-1]
+            count = hi_index - lo_index + 1
+            for offset, index in enumerate(range(lo_index, hi_index + 1)):
+                fraction = (offset + 1) / (count + 1)
+                warped_fraction = 1.0 - (1.0 - fraction) ** self.stepwarp_power
+                times[index] = t_hi - (t_hi - t_lo) * warped_fraction
+        if len(times) != num_steps + 1:
+            raise RuntimeError(
+                f"Expected {num_steps + 1} ECSI time points, got {len(times)}."
+            )
+        if any(left <= right for left, right in zip(times[:-1], times[1:], strict=True)):
+            raise RuntimeError("Effective ECSI sampling schedule must decrease.")
+        return [float(time_value) for time_value in times]
+
     def sample_structure(
         self,
         f_input: FoldingInput,
@@ -730,21 +1319,8 @@ class KFoldECSI(BaseStructureModule):
         """
         model = self.score_model
 
-        # Get time schedule (from t_max toward t_min)
-        times = self.get_sampling_schedule(num_steps)
-
-        # Concentrate knots in the early high-churn band without changing NFE.
-        t_hi = float(times[0])
-        t_lo = self.churn_end_time
-        times = list(times)
-        band = [i for i, time in enumerate(times) if t_lo < float(time) < t_hi]
-        if band and self.stepwarp_power != 1.0:
-            lo_i, hi_i = band[0], band[-1]
-            n = hi_i - lo_i + 1
-            for k, i in enumerate(range(lo_i, hi_i + 1)):
-                fraction = (k + 1) / (n + 1)
-                warped_fraction = 1.0 - (1.0 - fraction) ** self.stepwarp_power
-                times[i] = t_hi - (t_hi - t_lo) * warped_fraction
+        # Get the exact production schedule (from t_max toward t_min).
+        times = self.get_effective_sampling_schedule(num_steps)
 
         # Sample x_T from prior (apo structures)
         x_T = self.sample_prior(f_input, num_samples)  # (B, N, Natom, 3)
@@ -1005,6 +1581,7 @@ class KFoldECSI(BaseStructureModule):
         t: float,
         *,
         chi: float,
+        noise: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, float]:
         r"""Apply a bridge conditional with ``sigma_eff`` inflated by ``chi``.
 
@@ -1028,7 +1605,11 @@ class KFoldECSI(BaseStructureModule):
         if variance <= 0.0:
             return x_t, t
 
-        noise = torch.randn_like(x_t).masked_fill_(~mask[..., None], 0.0)
+        if noise is None:
+            noise = torch.randn_like(x_t)
+        elif noise.shape != x_t.shape:
+            raise ValueError("Sigma-matched churn noise must match x_t shape.")
+        noise = noise.masked_fill(~mask[..., None], 0.0)
         x_hat = (
             alpha_ratio * x_t
             + (float(coeff.beta(t_hat)) - alpha_ratio * float(coeff.beta(t))) * x_T
@@ -1048,6 +1629,7 @@ class KFoldECSI(BaseStructureModule):
         x_T: torch.Tensor,
         mask: torch.Tensor,
         t: float,
+        noise: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, float]:
         # The schedule starts at ``time_max``. Keep both churn bounds open so
         # that the initial state is never perturbed or consumes RNG.
@@ -1060,6 +1642,7 @@ class KFoldECSI(BaseStructureModule):
             mask,
             t,
             chi=self._churn_factor_at_time(t),
+            noise=noise,
         )
 
     def _apply_class_selective_update(
@@ -1072,6 +1655,7 @@ class KFoldECSI(BaseStructureModule):
         has_sde_atoms: bool,
         t: float,
         t_next: float,
+        noise: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Preserve [all] or overlay selected updates on an SI-ODE base."""
         selected_mode, selected_ode_type = self._select_update_method(t)
@@ -1086,6 +1670,7 @@ class KFoldECSI(BaseStructureModule):
                 mode=selected_mode,
                 ode_type=selected_ode_type,
                 step_scale=self.sampler_step_scale,
+                noise=noise,
             )
 
         x_ode = self._update_step(
@@ -1098,6 +1683,7 @@ class KFoldECSI(BaseStructureModule):
             mode="ode",
             ode_type="si",
             step_scale=self.sampler_step_scale,
+            noise=noise,
         )
         if not has_sde_atoms:
             return x_ode
@@ -1116,6 +1702,7 @@ class KFoldECSI(BaseStructureModule):
             mode=selected_mode,
             ode_type=selected_ode_type,
             step_scale=self.sampler_step_scale,
+            noise=noise,
         )
         return torch.where(sde_atom_mask[:, None, :, None], x_sde, x_ode)
 
@@ -1136,6 +1723,7 @@ class KFoldECSI(BaseStructureModule):
         mode: str = "ode",  # 'ode' or 'sde'
         ode_type: str = "si",  # 'si' or 'ecsi'
         step_scale: float = 1.0,
+        noise: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """SDE step for ECSI sampling.
         See Algorithm 1 of ECSI paper.
@@ -1169,7 +1757,11 @@ class KFoldECSI(BaseStructureModule):
             # SDE update
             gamma_t = C.gamma(t)
             eps: float = C.eps(t)
-            noise = torch.randn_like(x_t).masked_fill_(~mask[..., None], 0.0)
+            if noise is None:
+                noise = torch.randn_like(x_t)
+            elif noise.shape != x_t.shape:
+                raise ValueError("Sampler update noise must match x_t shape.")
+            noise = noise.masked_fill(~mask[..., None], 0.0)
 
             if ode_type == "si":
                 # SI SDE drift pinned to the denoised endpoint:

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -737,7 +737,7 @@ class KFoldTrainingModule(pl.LightningModule):
         diffusion_metrics: dict[str, torch.Tensor],
         diffusion_out: dict[str, torch.Tensor],
     ) -> None:
-        """Add actual bounded x0-perturb exposure and displacement telemetry."""
+        """Add actual high-time x0-perturb exposure and displacement telemetry."""
         t = diffusion_out["t"][:, : diffusion_out["x_0_perturb_applied_mask"].shape[1]]
         time_eligible = diffusion_out["x_0_perturb_time_eligible_mask"].bool()
         eligible = diffusion_out["x_0_perturb_eligible_mask"].bool()

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -171,6 +171,8 @@ def _get_diffusion_time_for_binning(
 def _training_metric_log_name(metric_name: str) -> str:
     if metric_name.startswith("soar_"):
         return f"soar/{metric_name.removeprefix('soar_')}"
+    if metric_name.startswith("x_0_perturb_"):
+        return f"x_0_perturb/{metric_name.removeprefix('x_0_perturb_')}"
     return f"train/{metric_name}"
 
 
@@ -667,6 +669,11 @@ class KFoldTrainingModule(pl.LightningModule):
                 diffusion_metrics["soar_total_objective_mass"] = (
                     base_mass + auxiliary_mass
                 )
+            if "x_0_perturb_applied_mask" in diffusion_out:
+                self._add_x_0_perturb_metrics(
+                    diffusion_metrics=diffusion_metrics,
+                    diffusion_out=diffusion_out,
+                )
 
         else:
             diffusion_loss, diffusion_metrics = 0.0, {}
@@ -723,6 +730,54 @@ class KFoldTrainingModule(pl.LightningModule):
         all_metrics["loss"] = loss.detach()
 
         return loss, all_metrics
+
+    @staticmethod
+    def _add_x_0_perturb_metrics(
+        *,
+        diffusion_metrics: dict[str, torch.Tensor],
+        diffusion_out: dict[str, torch.Tensor],
+    ) -> None:
+        """Add actual bounded x0-perturb exposure and displacement telemetry."""
+        t = diffusion_out["t"][:, : diffusion_out["x_0_perturb_applied_mask"].shape[1]]
+        time_eligible = diffusion_out["x_0_perturb_time_eligible_mask"].bool()
+        eligible = diffusion_out["x_0_perturb_eligible_mask"].bool()
+        requested = diffusion_out["x_0_perturb_requested_mask"].bool()
+        applied = diffusion_out["x_0_perturb_applied_mask"].bool()
+        x_0_rmsd = diffusion_out["x_0_perturb_x_0_rmsd"].detach().float()
+        x_t_rmsd = diffusion_out["x_0_perturb_x_t_rmsd"].detach().float()
+        chain_count = diffusion_out["x_0_perturb_resolved_chain_count"].detach().float()
+
+        def masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+            weights = mask.to(values.dtype)
+            return (values * weights).sum() / weights.sum().clamp(min=1.0)
+
+        prefix = "x_0_perturb_"
+        diffusion_metrics[f"{prefix}time_eligible_fraction"] = (
+            time_eligible.float().mean()
+        )
+        diffusion_metrics[f"{prefix}eligible_fraction"] = eligible.float().mean()
+        diffusion_metrics[f"{prefix}requested_fraction"] = requested.float().mean()
+        diffusion_metrics[f"{prefix}applied_fraction"] = applied.float().mean()
+        diffusion_metrics[f"{prefix}applied_given_eligible"] = (
+            applied.float().sum() / eligible.float().sum().clamp(min=1.0)
+        )
+        diffusion_metrics[f"{prefix}applied_t_mean"] = masked_mean(t.float(), applied)
+        diffusion_metrics[f"{prefix}x_0_rmsd_mean"] = masked_mean(x_0_rmsd, applied)
+        diffusion_metrics[f"{prefix}x_t_rmsd_mean"] = masked_mean(x_t_rmsd, applied)
+        diffusion_metrics[f"{prefix}x_t_rmsd_max"] = x_t_rmsd.max()
+        diffusion_metrics[f"{prefix}resolved_chain_count_mean"] = chain_count.mean()
+
+        for bin_index in range(10):
+            lower = bin_index / 10.0
+            upper = (bin_index + 1) / 10.0
+            in_bin = (t >= lower) & (t < upper)
+            bin_name = f"t{bin_index:02d}_{bin_index + 1:02d}"
+            diffusion_metrics[f"{prefix}{bin_name}_applied_fraction"] = (
+                applied & in_bin
+            ).float().sum() / in_bin.float().sum().clamp(min=1.0)
+            diffusion_metrics[f"{prefix}{bin_name}_x_t_rmsd_mean"] = masked_mean(
+                x_t_rmsd, applied & in_bin
+            )
 
     def validation_step(
         self,

--- a/src/kfold/training/training_module.py
+++ b/src/kfold/training/training_module.py
@@ -17,6 +17,7 @@ from kfold.data.types.model_input import FoldingInput
 from kfold.data.types.structure import RefStructure
 from kfold.data.utils.writer import KFoldWriter
 from kfold.model.model_train import KFoldConfig, KFoldForTrain
+from kfold.model.modules.structure.ecsi import ECSISOARConfig
 from kfold.training.utils.binned_loss_logging import (
     EntityBinConfig,
     EntityBinnedLossLogger,
@@ -134,6 +135,9 @@ class TrainingConfig(_Config):
     parcae: ParcaeTrainConfig = dataclasses.field(default_factory=ParcaeTrainConfig)
     # for structure model training
     diffusion_batch_size: int = 48
+    soar: dict[str, Any] = dataclasses.field(
+        default_factory=lambda: dataclasses.asdict(ECSISOARConfig())
+    )
     # for confidence module training
     num_mini_rollout_steps: int = 20
     num_mini_rollout_samples: int = 1
@@ -162,6 +166,12 @@ def _get_diffusion_time_for_binning(
     if torch.is_tensor(t):
         return t
     return None
+
+
+def _training_metric_log_name(metric_name: str) -> str:
+    if metric_name.startswith("soar_"):
+        return f"soar/{metric_name.removeprefix('soar_')}"
+    return f"train/{metric_name}"
 
 
 def _get_structure_module_for_binning(model: Any) -> Any:
@@ -237,6 +247,7 @@ class KFoldTrainingModule(pl.LightningModule):
         self.training_config: TrainingConfig = TrainingConfig.from_dict(
             self.config.training
         )
+        self.soar_config = ECSISOARConfig.from_mapping(self.training_config.soar)
         self.parcae_train_config: ParcaeTrainConfig = ParcaeTrainConfig.from_dict(
             self.training_config.parcae
         )
@@ -506,6 +517,7 @@ class KFoldTrainingModule(pl.LightningModule):
                 num_mini_rollout_steps=training_config.num_mini_rollout_steps,
                 num_mini_rollout_samples=training_config.num_mini_rollout_samples,
                 diffusion_batch_size=training_config.diffusion_batch_size,
+                soar_config=dataclasses.asdict(self.soar_config),
                 train_trunk=self.train_trunk,
                 train_diffusion_head=self.train_diffusion_head,
                 train_confidence_module=self.train_confidence_head,
@@ -561,7 +573,12 @@ class KFoldTrainingModule(pl.LightningModule):
                     )
 
         for k, v in metrics.items():
-            self.log(f"train/{k}", v, prog_bar=(k == "loss"), sync_dist=False)
+            self.log(
+                _training_metric_log_name(k),
+                v,
+                prog_bar=(k == "loss"),
+                sync_dist=False,
+            )
 
         return loss
 
@@ -607,7 +624,49 @@ class KFoldTrainingModule(pl.LightningModule):
                 x_true=diffusion_out["x_gt"],
                 f_input=f_input,
                 per_sample_weights=model_output["diffusion"]["loss_weights"],
+                supervision_weights=diffusion_out.get("soar_supervision_weights"),
+                auxiliary_mask=diffusion_out.get("soar_auxiliary_mask"),
             )
+            if "soar_t0" in diffusion_out:
+
+                def add_tensor_stats(name: str, values: torch.Tensor) -> None:
+                    values = values.detach().float()
+                    diffusion_metrics[f"soar_{name}_mean"] = values.mean()
+                    diffusion_metrics[f"soar_{name}_std"] = values.std(unbiased=False)
+                    diffusion_metrics[f"soar_{name}_median"] = values.median()
+                    diffusion_metrics[f"soar_{name}_min"] = values.min()
+                    diffusion_metrics[f"soar_{name}_max"] = values.max()
+
+                for time_name in ("base_t0", "t0", "t_call", "t1", "t2"):
+                    add_tensor_stats(time_name, diffusion_out[f"soar_{time_name}"])
+                for name in (
+                    "forward_retention",
+                    "forward_variance",
+                    "endpoint_error_rmsd",
+                    "model_to_oracle_sampler_rmsd",
+                    "oracle_sampler_to_exact_ecsi_rmsd",
+                    "model_sampler_to_exact_ecsi_rmsd",
+                ):
+                    add_tensor_stats(name, diffusion_out[f"soar_{name}"])
+                root_branch_count = diffusion_out["soar_root_branch_count"].detach()
+                diffusion_metrics["soar_auxiliary_samples_per_root"] = (
+                    root_branch_count.float().mean()
+                )
+                supervision_weights = diffusion_out["soar_supervision_weights"].detach()
+                auxiliary_mask = diffusion_out["soar_auxiliary_mask"].detach()
+                base_mass = (
+                    supervision_weights.masked_fill(auxiliary_mask, 0.0).sum(dim=1).mean()
+                )
+                auxiliary_mass = (
+                    supervision_weights.masked_fill(~auxiliary_mask, 0.0)
+                    .sum(dim=1)
+                    .mean()
+                )
+                diffusion_metrics["soar_base_objective_mass"] = base_mass
+                diffusion_metrics["soar_aux_objective_mass"] = auxiliary_mass
+                diffusion_metrics["soar_total_objective_mass"] = (
+                    base_mass + auxiliary_mass
+                )
 
         else:
             diffusion_loss, diffusion_metrics = 0.0, {}
@@ -944,6 +1003,8 @@ class KFoldTrainingModule(pl.LightningModule):
         x_true: torch.Tensor,
         f_input: FoldingInput,
         per_sample_weights: torch.Tensor,
+        supervision_weights: torch.Tensor | None = None,
+        auxiliary_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
         """Compute diffusion structure loss.
         See Section 3.7.1 Diffusion Training.
@@ -971,18 +1032,35 @@ class KFoldTrainingModule(pl.LightningModule):
         alpha_chain_com = self.loss_weights["chain_com"]
         alpha_bond = self.loss_weights["bond"]
         alpha_smooth_lddt = self.loss_weights["smooth_lddt"]
+        if supervision_weights is None:
+            supervision_weights = torch.ones_like(per_sample_weights)
+        if supervision_weights.shape != per_sample_weights.shape:
+            raise ValueError(
+                "supervision_weights and per_sample_weights must have the same shape."
+            )
+        if auxiliary_mask is not None:
+            if auxiliary_mask.shape != per_sample_weights.shape:
+                raise ValueError(
+                    "auxiliary_mask and per_sample_weights must have the same shape."
+                )
+            auxiliary_mask = auxiliary_mask.bool()
+
+        def weighted_mean(values: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
+            return (values * weights).sum() / weights.sum().clamp(min=1.0)
 
         # Equations 3-4
         L_mse, L_chain_com = self.weighted_mse_loss(
             x_pred, x_true, f_input, compute_chain_com_loss=alpha_chain_com > 0
         )
         L_mse_weighted = L_mse * per_sample_weights  # [B, Nsample]
-        metrics["mse_loss"] = L_mse_weighted.detach().mean()
+        metrics["mse_loss"] = weighted_mean(L_mse_weighted.detach(), supervision_weights)
 
         if alpha_chain_com > 0:
             assert L_chain_com is not None
             L_chain_com_weighted = L_chain_com * per_sample_weights  # [B, Nsample]
-            metrics["chain_com_loss"] = L_chain_com_weighted.detach().mean()
+            metrics["chain_com_loss"] = weighted_mean(
+                L_chain_com_weighted.detach(), supervision_weights
+            )
         else:
             L_chain_com_weighted = None
 
@@ -990,14 +1068,18 @@ class KFoldTrainingModule(pl.LightningModule):
         if alpha_bond > 0:
             L_bond = self.bond_loss(x_pred, x_true, f_input)
             L_bond_weighted = L_bond * per_sample_weights  # [B, Nsample]
-            metrics["bond_loss"] = L_bond_weighted.detach().mean()
+            metrics["bond_loss"] = weighted_mean(
+                L_bond_weighted.detach(), supervision_weights
+            )
         else:
             L_bond_weighted = None
 
         # Algorithm 27
         if alpha_smooth_lddt > 0:
             L_smooth_lddt = self.smooth_lddt_loss(x_pred, x_true, f_input)  # [B, Nsample]
-            metrics["smooth_lddt_loss"] = L_smooth_lddt.detach().mean()
+            metrics["smooth_lddt_loss"] = weighted_mean(
+                L_smooth_lddt.detach(), supervision_weights
+            )
         else:
             L_smooth_lddt = None
 
@@ -1016,9 +1098,18 @@ class KFoldTrainingModule(pl.LightningModule):
                 L_diffusion_per_sample + alpha_smooth_lddt * L_smooth_lddt
             )
 
-        # Mean over diffusion samples
-        L_diffusion = L_diffusion_per_sample.mean()
+        # Normalize once over base and auxiliary objective mass.
+        L_diffusion = weighted_mean(L_diffusion_per_sample, supervision_weights)
         metrics["diffusion_loss"] = L_diffusion.detach()
+        if auxiliary_mask is not None:
+            base_weights = (~auxiliary_mask).to(L_diffusion_per_sample.dtype)
+            auxiliary_weights = auxiliary_mask.to(L_diffusion_per_sample.dtype)
+            metrics["soar_base_diffusion_loss"] = weighted_mean(
+                L_diffusion_per_sample.detach(), base_weights
+            )
+            metrics["soar_aux_diffusion_loss"] = weighted_mean(
+                L_diffusion_per_sample.detach(), auxiliary_weights
+            )
 
         if self._binned_cache_enabled and self.train_diffusion_head:
             payload: dict[str, torch.Tensor] = {

--- a/tests/unit_tests/test_ecsi_soar_0811.py
+++ b/tests/unit_tests/test_ecsi_soar_0811.py
@@ -1,0 +1,230 @@
+import pytest
+import torch
+
+from kfold.model.modules.structure.ecsi import ECSISOARConfig, KFoldECSI, SICoeffs
+from kfold.training.training_module import _training_metric_log_name
+
+
+def make_math_only_ecsi() -> KFoldECSI:
+    ecsi = object.__new__(KFoldECSI)
+    ecsi.coeff = SICoeffs(gamma_max=24.0, gamma_power=1.0, eta=1.0)
+    ecsi.time_min = 1e-8
+    ecsi.time_max = 0.9999
+    ecsi.churn_end_time = 0.5
+    ecsi.churn_max_time = ecsi.time_max
+    ecsi.churn_factor = 0.1
+    ecsi.churn_max_multiplier = 4.0
+    ecsi.churn_step_fraction = 0.4
+    ecsi.churn_step_power = 1.0
+    ecsi.ode_step_power = 2.0
+    ecsi.stepwarp_power = 0.5
+    return ecsi
+
+
+def test_soar_config_accepts_exact_markov_model_sampler_only() -> None:
+    config = ECSISOARConfig(mode="model_sampler")
+    assert config.num_auxiliary_samples(16) == 64
+    with pytest.raises(ValueError, match="Unknown ECSI SOAR mode"):
+        ECSISOARConfig(mode="model_si")
+    with pytest.raises(ValueError, match="Unknown ECSI SOAR config fields"):
+        ECSISOARConfig.from_mapping({"mode": "model_sampler", "extra": 1})
+    with pytest.raises(ValueError, match="auxiliary transition"):
+        ECSISOARConfig(auxiliary_transition="coupled_transport")
+
+
+def test_soar_metrics_use_top_level_namespace() -> None:
+    assert _training_metric_log_name("soar_t_call_mean") == "soar/t_call_mean"
+    assert _training_metric_log_name("loss") == "train/loss"
+
+
+def test_soar_times_follow_effective_0811_schedule() -> None:
+    ecsi = make_math_only_ecsi()
+    config = ECSISOARConfig(mode="model_sampler", auxiliary_samples_per_root=2)
+    schedule = torch.tensor(
+        ecsi.get_effective_sampling_schedule(config.rollout_schedule_num_steps),
+        dtype=torch.float64,
+    )
+    indices = torch.tensor([0, 7, 25, 72, 98, 99])
+    t0 = schedule[indices].view(1, -1)
+    torch.manual_seed(11)
+    t1, t2 = ecsi.sample_soar_auxiliary_times(t0=t0, config=config)
+    torch.testing.assert_close(
+        t1,
+        schedule[indices + 1].clamp_min(ecsi.time_min).view(1, -1),
+        rtol=0.0,
+        atol=1e-15,
+    )
+    assert t2.shape == (1, len(indices), 2)
+    assert torch.all(t2 >= t1.unsqueeze(-1))
+    assert torch.all(t2 <= ecsi.time_max)
+
+
+def test_shared_noise_pairs_model_and_oracle_ecsi_sde_updates() -> None:
+    ecsi = make_math_only_ecsi()
+    x_t = torch.randn(1, 1, 5, 3, dtype=torch.float64)
+    x_T = torch.randn_like(x_t)
+    model_endpoint = torch.randn_like(x_t)
+    oracle_endpoint = torch.randn_like(x_t)
+    mask = torch.ones(1, 1, 5, dtype=torch.bool)
+    noise = torch.randn_like(x_t)
+    model = ecsi._update_step(
+        x_t,
+        model_endpoint,
+        x_T,
+        mask,
+        0.8,
+        0.75,
+        mode="sde",
+        ode_type="ecsi",
+        noise=noise,
+    )
+    oracle = ecsi._update_step(
+        x_t,
+        oracle_endpoint,
+        x_T,
+        mask,
+        0.8,
+        0.75,
+        mode="sde",
+        ode_type="ecsi",
+        noise=noise,
+    )
+    zero_noise_model = ecsi._update_step(
+        x_t,
+        model_endpoint,
+        x_T,
+        mask,
+        0.8,
+        0.75,
+        mode="sde",
+        ode_type="ecsi",
+        noise=torch.zeros_like(noise),
+    )
+    zero_noise_oracle = ecsi._update_step(
+        x_t,
+        oracle_endpoint,
+        x_T,
+        mask,
+        0.8,
+        0.75,
+        mode="sde",
+        ode_type="ecsi",
+        noise=torch.zeros_like(noise),
+    )
+    torch.testing.assert_close(
+        model - oracle,
+        zero_noise_model - zero_noise_oracle,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_soar_rollout_bypasses_churn_exactly() -> None:
+    ecsi = make_math_only_ecsi()
+    config = ECSISOARConfig(mode="model_sampler", apply_rollout_churn=False)
+    x_t = torch.randn(1, 2, 4, 3)
+    x_T = torch.randn_like(x_t)
+    mask = torch.ones(1, 2, 4, dtype=torch.bool)
+    t = torch.tensor([[0.7, 0.9]])
+    x_call, t_call = ecsi._prepare_soar_rollout_call(
+        config=config, x_t=x_t, x_T=x_T, mask=mask, t=t
+    )
+    assert x_call is x_t
+    assert t_call is t
+
+
+def test_exact_forward_transition_matches_formula_and_seeded_noise() -> None:
+    ecsi = make_math_only_ecsi()
+    x_t1 = torch.randn(1, 2, 4, 3, dtype=torch.float64)
+    x_T = torch.randn_like(x_t1)
+    mask = torch.ones(1, 2, 4, dtype=torch.bool)
+    t1 = torch.tensor([[0.4, 0.7]], dtype=torch.float64)
+    t2 = torch.tensor([[[0.5, 0.8], [0.75, 0.9]]], dtype=torch.float64)
+    noise = torch.randn(1, 2, 2, 4, 3, dtype=torch.float64)
+    transition = ecsi._exact_ecsi_forward_transition(
+        x_t1=x_t1,
+        x_T=x_T,
+        mask=mask,
+        t1=t1,
+        t2=t2,
+        noise=noise,
+    )
+    retention = (1.0 - t2) / (1.0 - t1).unsqueeze(-1)
+    expected_variance = ecsi.coeff.eta * (
+        ecsi.coeff.gamma(t2).square()
+        - retention.square() * ecsi.coeff.gamma(t1).unsqueeze(-1).square()
+    )
+    expected_mean = retention[..., None, None] * x_t1.unsqueeze(2) + (
+        t2 - retention * t1.unsqueeze(-1)
+    )[..., None, None] * x_T.unsqueeze(2)
+    torch.testing.assert_close(transition["variance"], expected_variance)
+    torch.testing.assert_close(
+        transition["x_t2"],
+        expected_mean + expected_variance.sqrt()[..., None, None] * noise,
+    )
+
+
+def test_mid_only_root_policy_is_uniform_over_intersecting_schedule_cells() -> None:
+    ecsi = make_math_only_ecsi()
+    config = ECSISOARConfig(
+        mode="model_sampler",
+        root_time_policy="mid_high_schedule_stratified",
+        mid_time_lower=0.2,
+        high_time_split=0.8,
+        mid_time_probability=1.0,
+    )
+    base_t0 = torch.zeros(1, 20000)
+    torch.manual_seed(23)
+    roots = ecsi.construct_soar_root_times(base_t0=base_t0, config=config)
+    assert torch.all((roots >= 0.2) & (roots < 0.8))
+
+    schedule = torch.tensor(
+        ecsi.get_effective_sampling_schedule(config.rollout_schedule_num_steps),
+        dtype=roots.dtype,
+    )
+    cell_high = torch.minimum(schedule[:-1], torch.full_like(schedule[:-1], 0.8))
+    cell_low = torch.maximum(schedule[1:], torch.full_like(schedule[1:], 0.2))
+    valid_indices = torch.nonzero(cell_high > cell_low, as_tuple=False).flatten()
+    sampled_indices = ((schedule[:-1] >= roots.unsqueeze(-1)).sum(dim=-1) - 1).clamp(
+        min=0, max=config.rollout_schedule_num_steps - 1
+    )
+    counts = torch.stack([(sampled_indices == index).sum() for index in valid_indices])
+    expected = roots.numel() / valid_indices.numel()
+    assert torch.all((counts.float() - expected).abs() < 0.2 * expected)
+
+
+def test_mid_only_root_policy_preserves_recent_rng_consumption() -> None:
+    ecsi = make_math_only_ecsi()
+    config = ECSISOARConfig(
+        mode="model_sampler",
+        root_time_policy="mid_high_schedule_stratified",
+        mid_time_lower=0.2,
+        high_time_split=0.8,
+        mid_time_probability=1.0,
+    )
+    base_t0 = torch.zeros(1, 32)
+    schedule = torch.tensor(
+        ecsi.get_effective_sampling_schedule(config.rollout_schedule_num_steps),
+        dtype=base_t0.dtype,
+    )
+    torch.manual_seed(31)
+    observed = ecsi.construct_soar_root_times(base_t0=base_t0, config=config)
+    observed_next_random = torch.rand_like(base_t0)
+
+    torch.manual_seed(31)
+    expected = ecsi._sample_soar_schedule_cell_band(
+        shape=base_t0.shape,
+        schedule=schedule,
+        lower=0.2,
+        upper=0.8,
+    )
+    ecsi._sample_soar_schedule_cell_band(
+        shape=base_t0.shape,
+        schedule=schedule,
+        lower=0.8,
+        upper=ecsi.time_max,
+    )
+    torch.rand_like(base_t0)
+    expected_next_random = torch.rand_like(base_t0)
+    torch.testing.assert_close(observed, expected)
+    torch.testing.assert_close(observed_next_random, expected_next_random)

--- a/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
+++ b/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+from kfold.config import load_config, to_dict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_soar_x0_preset_inherits_latest_stage3_data_contract() -> None:
+    base = load_config(REPO_ROOT / "configs/train-ecsi-stage3.yaml")
+    candidate = load_config(REPO_ROOT / "configs/train-ecsi-stage3-soar-x0.yaml")
+    assert to_dict(candidate.train.data) == to_dict(base.train.data)
+    assert candidate.train.data.max_tokens == 768
+    assert candidate.train.data.max_atoms == 9216
+    assert candidate.train.data.max_sequence_tokens == 1536
+    names = [dataset.name for dataset in candidate.train.data.train_datasets]
+    weights = [float(dataset.weight) for dataset in candidate.train.data.train_datasets]
+    assert names == [
+        "rcsb-train-upd",
+        "AF2-MGnify-long",
+        "Rfam",
+        "AFDB-homodimer",
+        "AFDB-heterodimer",
+        "JASPAR",
+        "ENCORE",
+        "TPD",
+    ]
+    assert weights == [0.75, 0.05, 0.05, 0.1, 0.02, 0.01, 0.01, 0.01]
+
+
+def test_soar_x0_preset_changes_only_declared_training_surfaces() -> None:
+    config = load_config(REPO_ROOT / "configs/train-ecsi-stage3-soar-x0.yaml")
+    assert config.model.patch_pair_geometry.enabled is True
+    assert config.model.diffusion_head.train_x_0_perturb_time_min == 0.4
+    assert config.model.diffusion_head.train_x_0_perturb_time_max == 0.8
+    assert config.model.diffusion_head.train_x_0_perturb_prob == 0.5
+    assert config.model.diffusion_head.train_x_0_perturb_rotation_deg == 8.0
+    assert config.model.diffusion_head.train_x_0_perturb_translation_distance == 1.2
+    assert config.train.global_hparams.diffusion_batch_size == 16
+    assert config.train.global_hparams.global_batch_size == 160
+    assert config.train.load_opt_state is False
+    assert config.train.load_global_step is True
+    assert list(config.train.init_from_ema) == ["trunk"]
+    assert config.train.loss.weights.patch_geometry == 0.0
+
+    soar = config.train.training.soar
+    assert soar.mode == "model_sampler"
+    assert soar.root_time_policy == "mid_high_schedule_stratified"
+    assert soar.auxiliary_transition == "exact_markov"
+    assert soar.apply_rollout_churn is False
+    assert soar.auxiliary_samples_per_root == 4
+    assert soar.forward_retention_min == 0.5
+    assert soar.lambda_aux == 1.0
+    assert soar.mid_time_lower == 0.2
+    assert soar.high_time_split == 0.8
+    assert soar.mid_time_probability == 1.0

--- a/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
+++ b/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
@@ -34,11 +34,9 @@ def test_soar_x0_preset_inherits_latest_stage3_data_contract() -> None:
 def test_soar_x0_preset_changes_only_declared_training_surfaces() -> None:
     config = load_config(REPO_ROOT / "configs/train-ecsi-stage3-soar-x0.yaml")
     assert config.model.patch_pair_geometry.enabled is True
-    assert config.model.diffusion_head.train_x_0_perturb_time_min == 0.4
-    assert config.model.diffusion_head.train_x_0_perturb_time_max == 0.8
-    assert config.model.diffusion_head.train_x_0_perturb_prob == 0.5
-    assert config.model.diffusion_head.train_x_0_perturb_rotation_deg == 8.0
-    assert config.model.diffusion_head.train_x_0_perturb_translation_distance == 1.2
+    assert config.model.diffusion_head.train_x_0_perturb_time_min == 0.7
+    assert config.model.diffusion_head.train_x_0_perturb_prob == 0.2
+    assert config.model.diffusion_head.train_x_0_perturb_translation_std == 4.0
     assert config.train.global_hparams.diffusion_batch_size == 32
     assert config.train.load_opt_state is False
     assert config.train.load_global_step is True

--- a/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
+++ b/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
@@ -35,7 +35,7 @@ def test_soar_x0_preset_changes_only_declared_training_surfaces() -> None:
     assert config.model.diffusion_head.train_x_0_perturb_prob == 0.5
     assert config.model.diffusion_head.train_x_0_perturb_rotation_deg == 8.0
     assert config.model.diffusion_head.train_x_0_perturb_translation_distance == 1.2
-    assert config.train.global_hparams.diffusion_batch_size == 16
+    assert config.train.global_hparams.diffusion_batch_size == 32
     assert config.train.global_hparams.global_batch_size == 160
     assert config.train.load_opt_state is False
     assert config.train.load_global_step is True

--- a/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
+++ b/tests/unit_tests/test_ecsi_stage3_soar_x0_config.py
@@ -9,6 +9,10 @@ def test_soar_x0_preset_inherits_latest_stage3_data_contract() -> None:
     base = load_config(REPO_ROOT / "configs/train-ecsi-stage3.yaml")
     candidate = load_config(REPO_ROOT / "configs/train-ecsi-stage3-soar-x0.yaml")
     assert to_dict(candidate.train.data) == to_dict(base.train.data)
+    assert (
+        candidate.train.global_hparams.global_batch_size
+        == base.train.global_hparams.global_batch_size
+    )
     assert candidate.train.data.max_tokens == 768
     assert candidate.train.data.max_atoms == 9216
     assert candidate.train.data.max_sequence_tokens == 1536
@@ -36,7 +40,6 @@ def test_soar_x0_preset_changes_only_declared_training_surfaces() -> None:
     assert config.model.diffusion_head.train_x_0_perturb_rotation_deg == 8.0
     assert config.model.diffusion_head.train_x_0_perturb_translation_distance == 1.2
     assert config.train.global_hparams.diffusion_batch_size == 32
-    assert config.train.global_hparams.global_batch_size == 160
     assert config.train.load_opt_state is False
     assert config.train.load_global_step is True
     assert list(config.train.init_from_ema) == ["trunk"]

--- a/tests/unit_tests/test_ecsi_x_0_perturb.py
+++ b/tests/unit_tests/test_ecsi_x_0_perturb.py
@@ -3,17 +3,16 @@ from types import MethodType, SimpleNamespace
 import pytest
 import torch
 
+import kfold.model.modules.structure.ecsi as ecsi_module
 from kfold.model.modules.structure.ecsi import KFoldECSI
 from kfold.training.training_module import KFoldTrainingModule
 
 
 def make_module(**overrides: object) -> KFoldECSI:
     values: dict[str, object] = {
-        "train_x_0_perturb_time_min": 0.4,
-        "train_x_0_perturb_time_max": 0.8,
+        "train_x_0_perturb_time_min": 0.7,
         "train_x_0_perturb_prob": 1.0,
-        "train_x_0_perturb_rotation_deg": 8.0,
-        "train_x_0_perturb_translation_distance": 1.2,
+        "train_x_0_perturb_translation_std": 4.0,
     }
     values.update(overrides)
     return KFoldECSI(KFoldECSI.Config(**values), score_model=object())  # type: ignore[arg-type]
@@ -30,7 +29,7 @@ def make_endpoint_input() -> SimpleNamespace:
     )
 
 
-def make_x_0() -> tuple[torch.Tensor, torch.Tensor]:
+def make_endpoints() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     x_0 = torch.tensor(
         [
             [
@@ -53,12 +52,13 @@ def make_x_0() -> tuple[torch.Tensor, torch.Tensor]:
             ]
         ]
     )
-    return x_0, torch.ones((1, 1, 6), dtype=torch.bool)
+    x_T = x_0 + torch.tensor([5.0, -3.0, 2.0])
+    return x_0, x_T, torch.ones((1, 1, 6), dtype=torch.bool)
 
 
 def test_disabled_selection_does_not_consume_rng() -> None:
     module = make_module(train_x_0_perturb_prob=0.0)
-    t = torch.tensor([[0.5, 0.6]])
+    t = torch.tensor([[0.8, 0.9]])
     chain_count = torch.tensor([2])
     torch.manual_seed(3)
     module._sample_x_0_perturb_masks(t=t, resolved_chain_count=chain_count)
@@ -68,42 +68,23 @@ def test_disabled_selection_does_not_consume_rng() -> None:
     torch.testing.assert_close(observed, expected)
 
 
-def test_time_bounds_are_lower_closed_and_upper_open() -> None:
+def test_time_threshold_is_strictly_above_point_seven() -> None:
     module = make_module()
-    t = torch.tensor([[0.3999, 0.4, 0.7999, 0.8]])
+    t = torch.tensor([[0.6999, 0.7, 0.7001, 0.9999]])
     masks = module._sample_x_0_perturb_masks(t=t, resolved_chain_count=torch.tensor([2]))
-    assert masks["applied"].tolist() == [[False, True, True, False]]
+    assert masks["applied"].tolist() == [[False, False, True, True]]
 
 
-def test_rotation_and_translation_have_fixed_magnitudes() -> None:
+def test_chain_internal_distances_and_legacy_centered_frame_are_preserved() -> None:
     module = make_module()
-    torch.manual_seed(5)
-    rotations = module._fixed_axis_angle_rotations(
-        (128,), angle_degrees=8.0, dtype=torch.float64, device=torch.device("cpu")
-    )
-    traces = rotations.diagonal(dim1=-2, dim2=-1).sum(dim=-1)
-    angles = torch.acos(((traces - 1.0) / 2.0).clamp(-1.0, 1.0))
-    torch.testing.assert_close(
-        angles,
-        torch.full_like(angles, torch.deg2rad(torch.tensor(8.0)).item()),
-        rtol=1e-10,
-        atol=2e-9,
-    )
-    translations = module._fixed_direction_translations(
-        (128,), distance=1.2, dtype=torch.float64, device=torch.device("cpu")
-    )
-    torch.testing.assert_close(
-        translations.norm(dim=-1), torch.full((128,), 1.2, dtype=torch.float64)
-    )
-
-
-def test_chain_internal_distances_and_clean_frame_are_preserved() -> None:
-    module = make_module()
-    x_0, mask = make_x_0()
+    x_0, x_T, mask = make_endpoints()
+    clean_x_0 = x_0.clone()
+    clean_x_T = x_T.clone()
     torch.manual_seed(7)
     out = module._perturb_x_0(
         x_0=x_0,
-        t=torch.tensor([[0.5, 0.9]]),
+        x_T=x_T,
+        t=torch.tensor([[0.8, 0.5]]),
         f_input=make_endpoint_input(),
         x_0_mask=mask,
     )
@@ -115,12 +96,49 @@ def test_chain_internal_distances_and_clean_frame_are_preserved() -> None:
         actual = torch.cdist(perturbed[0, 0, chain_atoms], perturbed[0, 0, chain_atoms])
         torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
     torch.testing.assert_close(
-        perturbed[0, 0].mean(dim=0), x_0[0, 0].mean(dim=0), atol=1e-5, rtol=0
+        perturbed[0, 0].mean(dim=0), torch.zeros(3), atol=1e-5, rtol=0
+    )
+    assert torch.equal(x_0, clean_x_0)
+    assert torch.equal(x_T, clean_x_T)
+
+
+def test_legacy_random_so3_and_axiswise_gaussian_translation_are_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = make_module()
+    x_0, x_T, mask = make_endpoints()
+    captured: dict[str, torch.Tensor | tuple[int, ...]] = {}
+
+    def identity_rotations(
+        shape: tuple[int, ...], *, dtype: torch.dtype, device: torch.device
+    ) -> torch.Tensor:
+        captured["rotation_shape"] = shape
+        return torch.eye(3, dtype=dtype, device=device).expand(*shape, 3, 3)
+
+    def unit_gaussian(values: torch.Tensor) -> torch.Tensor:
+        translations = torch.ones_like(values)
+        captured["translations"] = translations
+        return translations
+
+    monkeypatch.setattr(ecsi_module, "random_rotations_torch", identity_rotations)
+    monkeypatch.setattr(torch, "randn_like", unit_gaussian)
+    module._perturb_x_0(
+        x_0=x_0,
+        x_T=x_T,
+        t=torch.tensor([[0.8, 0.9]]),
+        f_input=make_endpoint_input(),
+        x_0_mask=mask,
+    )
+
+    assert captured["rotation_shape"] == (1, 2, 2)
+    torch.testing.assert_close(
+        captured["translations"],  # type: ignore[arg-type]
+        torch.full((1, 2, 2, 3), 4.0),
     )
 
 
-def test_monomer_and_zero_strength_are_exact_noops() -> None:
-    x_0, mask = make_x_0()
+def test_monomer_is_an_exact_noop() -> None:
+    x_0, x_T, mask = make_endpoints()
     monomer_input = make_endpoint_input()
     monomer_input.chain.pad_mask = torch.tensor([[True, False]])
     monomer_input.atom.token_index = torch.tensor([[0, 0, 0, 0, 0, 0]])
@@ -128,25 +146,13 @@ def test_monomer_and_zero_strength_are_exact_noops() -> None:
     module = make_module()
     monomer = module._perturb_x_0(
         x_0=x_0,
-        t=torch.tensor([[0.5, 0.6]]),
+        x_T=x_T,
+        t=torch.tensor([[0.8, 0.9]]),
         f_input=monomer_input,
         x_0_mask=mask,
     )
     assert torch.equal(monomer["x_0_bridge"], x_0)
     assert not monomer["applied_mask"].any()
-
-    zero_module = make_module(
-        train_x_0_perturb_rotation_deg=0.0,
-        train_x_0_perturb_translation_distance=0.0,
-    )
-    zero = zero_module._perturb_x_0(
-        x_0=x_0,
-        t=torch.tensor([[0.5, 0.6]]),
-        f_input=make_endpoint_input(),
-        x_0_mask=mask,
-    )
-    assert torch.equal(zero["x_0_bridge"], x_0)
-    assert not zero["applied_mask"].any()
 
 
 def test_bridge_delta_is_alpha_scaled_endpoint_delta() -> None:
@@ -167,6 +173,7 @@ def test_bridge_delta_is_alpha_scaled_endpoint_delta() -> None:
         self: KFoldECSI,
         *,
         x_0: torch.Tensor,
+        x_T: torch.Tensor,
         t: torch.Tensor,
         f_input: SimpleNamespace,
         x_0_mask: torch.Tensor,
@@ -195,24 +202,24 @@ def test_bridge_delta_is_alpha_scaled_endpoint_delta() -> None:
     assert torch.equal(out["x_0"], seen["x_0"])
 
 
-def test_logistic_schedule_requests_about_eight_percent() -> None:
-    module = make_module(train_x_0_perturb_prob=0.5)
+def test_logistic_schedule_requests_about_two_percent() -> None:
+    module = make_module(train_x_0_perturb_prob=0.2)
     torch.manual_seed(19)
     t = module.sample_noise_level((1, 200000), torch.device("cpu"))
     masks = module._sample_x_0_perturb_masks(t=t, resolved_chain_count=torch.tensor([2]))
-    assert abs(masks["requested"].float().mean().item() - 0.0805) < 0.003
+    assert abs(masks["requested"].float().mean().item() - 0.0183) < 0.002
 
 
 def test_telemetry_reports_actual_and_time_binned_dose() -> None:
     metrics: dict[str, torch.Tensor] = {}
     out = {
-        "t": torch.tensor([[0.45, 0.55, 0.75, 0.85]]),
-        "x_0_perturb_time_eligible_mask": torch.tensor([[True, True, True, False]]),
-        "x_0_perturb_eligible_mask": torch.tensor([[True, True, True, False]]),
-        "x_0_perturb_requested_mask": torch.tensor([[True, False, True, False]]),
-        "x_0_perturb_applied_mask": torch.tensor([[True, False, True, False]]),
-        "x_0_perturb_x_0_rmsd": torch.tensor([[1.0, 0.0, 3.0, 0.0]]),
-        "x_0_perturb_x_t_rmsd": torch.tensor([[0.55, 0.0, 0.75, 0.0]]),
+        "t": torch.tensor([[0.65, 0.75, 0.85, 0.95]]),
+        "x_0_perturb_time_eligible_mask": torch.tensor([[False, True, True, True]]),
+        "x_0_perturb_eligible_mask": torch.tensor([[False, True, True, True]]),
+        "x_0_perturb_requested_mask": torch.tensor([[False, True, False, True]]),
+        "x_0_perturb_applied_mask": torch.tensor([[False, True, False, True]]),
+        "x_0_perturb_x_0_rmsd": torch.tensor([[0.0, 1.0, 0.0, 3.0]]),
+        "x_0_perturb_x_t_rmsd": torch.tensor([[0.0, 0.55, 0.0, 0.75]]),
         "x_0_perturb_resolved_chain_count": torch.tensor([[2, 2, 2, 2]]),
     }
     KFoldTrainingModule._add_x_0_perturb_metrics(
@@ -225,7 +232,7 @@ def test_telemetry_reports_actual_and_time_binned_dose() -> None:
     )
     torch.testing.assert_close(metrics["x_0_perturb_x_t_rmsd_mean"], torch.tensor(0.65))
     torch.testing.assert_close(
-        metrics["x_0_perturb_t04_05_applied_fraction"], torch.tensor(1.0)
+        metrics["x_0_perturb_t07_08_applied_fraction"], torch.tensor(1.0)
     )
 
 
@@ -234,9 +241,8 @@ def test_telemetry_reports_actual_and_time_binned_dose() -> None:
     [
         ({"train_x_0_perturb_prob": -0.1}, "must lie in"),
         ({"train_x_0_perturb_prob": 1.1}, "must lie in"),
-        ({"train_x_0_perturb_rotation_deg": -1.0}, "non-negative"),
-        ({"train_x_0_perturb_translation_distance": -1.0}, "non-negative"),
-        ({"train_x_0_perturb_time_min": 0.9}, "times must lie"),
+        ({"train_x_0_perturb_translation_std": -1.0}, "non-negative"),
+        ({"train_x_0_perturb_time_min": 1.0}, "time support"),
     ],
 )
 def test_invalid_x_0_perturbation_config_is_rejected(

--- a/tests/unit_tests/test_ecsi_x_0_perturb.py
+++ b/tests/unit_tests/test_ecsi_x_0_perturb.py
@@ -1,0 +1,246 @@
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+from kfold.model.modules.structure.ecsi import KFoldECSI
+from kfold.training.training_module import KFoldTrainingModule
+
+
+def make_module(**overrides: object) -> KFoldECSI:
+    values: dict[str, object] = {
+        "train_x_0_perturb_time_min": 0.4,
+        "train_x_0_perturb_time_max": 0.8,
+        "train_x_0_perturb_prob": 1.0,
+        "train_x_0_perturb_rotation_deg": 8.0,
+        "train_x_0_perturb_translation_distance": 1.2,
+    }
+    values.update(overrides)
+    return KFoldECSI(KFoldECSI.Config(**values), score_model=object())  # type: ignore[arg-type]
+
+
+def make_endpoint_input() -> SimpleNamespace:
+    return SimpleNamespace(
+        chain=SimpleNamespace(
+            asym_id=torch.tensor([[10, 20]]),
+            pad_mask=torch.tensor([[True, True]]),
+        ),
+        token=SimpleNamespace(asym_id=torch.tensor([[10, 20]])),
+        atom=SimpleNamespace(token_index=torch.tensor([[0, 0, 0, 1, 1, 1]])),
+    )
+
+
+def make_x_0() -> tuple[torch.Tensor, torch.Tensor]:
+    x_0 = torch.tensor(
+        [
+            [
+                [
+                    [-2.0, 0.0, 0.0],
+                    [-1.0, 1.0, 0.0],
+                    [-1.0, 0.0, 1.0],
+                    [1.0, 0.0, 0.0],
+                    [2.0, 1.0, 0.0],
+                    [2.0, 0.0, 1.0],
+                ],
+                [
+                    [-2.0, 0.0, 0.0],
+                    [-1.0, 1.0, 0.0],
+                    [-1.0, 0.0, 1.0],
+                    [1.0, 0.0, 0.0],
+                    [2.0, 1.0, 0.0],
+                    [2.0, 0.0, 1.0],
+                ],
+            ]
+        ]
+    )
+    return x_0, torch.ones((1, 1, 6), dtype=torch.bool)
+
+
+def test_disabled_selection_does_not_consume_rng() -> None:
+    module = make_module(train_x_0_perturb_prob=0.0)
+    t = torch.tensor([[0.5, 0.6]])
+    chain_count = torch.tensor([2])
+    torch.manual_seed(3)
+    module._sample_x_0_perturb_masks(t=t, resolved_chain_count=chain_count)
+    observed = torch.rand(4)
+    torch.manual_seed(3)
+    expected = torch.rand(4)
+    torch.testing.assert_close(observed, expected)
+
+
+def test_time_bounds_are_lower_closed_and_upper_open() -> None:
+    module = make_module()
+    t = torch.tensor([[0.3999, 0.4, 0.7999, 0.8]])
+    masks = module._sample_x_0_perturb_masks(t=t, resolved_chain_count=torch.tensor([2]))
+    assert masks["applied"].tolist() == [[False, True, True, False]]
+
+
+def test_rotation_and_translation_have_fixed_magnitudes() -> None:
+    module = make_module()
+    torch.manual_seed(5)
+    rotations = module._fixed_axis_angle_rotations(
+        (128,), angle_degrees=8.0, dtype=torch.float64, device=torch.device("cpu")
+    )
+    traces = rotations.diagonal(dim1=-2, dim2=-1).sum(dim=-1)
+    angles = torch.acos(((traces - 1.0) / 2.0).clamp(-1.0, 1.0))
+    torch.testing.assert_close(
+        angles,
+        torch.full_like(angles, torch.deg2rad(torch.tensor(8.0)).item()),
+        rtol=1e-10,
+        atol=2e-9,
+    )
+    translations = module._fixed_direction_translations(
+        (128,), distance=1.2, dtype=torch.float64, device=torch.device("cpu")
+    )
+    torch.testing.assert_close(
+        translations.norm(dim=-1), torch.full((128,), 1.2, dtype=torch.float64)
+    )
+
+
+def test_chain_internal_distances_and_clean_frame_are_preserved() -> None:
+    module = make_module()
+    x_0, mask = make_x_0()
+    torch.manual_seed(7)
+    out = module._perturb_x_0(
+        x_0=x_0,
+        t=torch.tensor([[0.5, 0.9]]),
+        f_input=make_endpoint_input(),
+        x_0_mask=mask,
+    )
+    perturbed = out["x_0_bridge"]
+    assert not torch.allclose(perturbed[:, 0], x_0[:, 0])
+    assert torch.equal(perturbed[:, 1], x_0[:, 1])
+    for chain_atoms in (slice(0, 3), slice(3, 6)):
+        expected = torch.cdist(x_0[0, 0, chain_atoms], x_0[0, 0, chain_atoms])
+        actual = torch.cdist(perturbed[0, 0, chain_atoms], perturbed[0, 0, chain_atoms])
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(
+        perturbed[0, 0].mean(dim=0), x_0[0, 0].mean(dim=0), atol=1e-5, rtol=0
+    )
+
+
+def test_monomer_and_zero_strength_are_exact_noops() -> None:
+    x_0, mask = make_x_0()
+    monomer_input = make_endpoint_input()
+    monomer_input.chain.pad_mask = torch.tensor([[True, False]])
+    monomer_input.atom.token_index = torch.tensor([[0, 0, 0, 0, 0, 0]])
+    monomer_input.token.asym_id = torch.tensor([[10]])
+    module = make_module()
+    monomer = module._perturb_x_0(
+        x_0=x_0,
+        t=torch.tensor([[0.5, 0.6]]),
+        f_input=monomer_input,
+        x_0_mask=mask,
+    )
+    assert torch.equal(monomer["x_0_bridge"], x_0)
+    assert not monomer["applied_mask"].any()
+
+    zero_module = make_module(
+        train_x_0_perturb_rotation_deg=0.0,
+        train_x_0_perturb_translation_distance=0.0,
+    )
+    zero = zero_module._perturb_x_0(
+        x_0=x_0,
+        t=torch.tensor([[0.5, 0.6]]),
+        f_input=make_endpoint_input(),
+        x_0_mask=mask,
+    )
+    assert torch.equal(zero["x_0_bridge"], x_0)
+    assert not zero["applied_mask"].any()
+
+
+def test_bridge_delta_is_alpha_scaled_endpoint_delta() -> None:
+    module = make_module(gamma_max=0.0)
+    label_coords = torch.randn((1, 6, 3))
+    seen: dict[str, torch.Tensor] = {}
+    f_input = make_endpoint_input()
+    f_input.batch_size = 1
+    f_input.device = torch.device("cpu")
+    f_input.atom.label_coords = label_coords
+    f_input.atom.prior_coords = torch.randn((1, 6, 1, 3))
+    f_input.atom.resolved_mask = torch.ones((1, 6), dtype=torch.bool)
+    f_input.atom.pad_mask = torch.ones((1, 6), dtype=torch.bool)
+    module.random_augmentation = lambda x, mask: x
+    module.sample_noise_level = lambda shape, device: torch.tensor([[0.5, 0.7]])
+
+    def add_offset(
+        self: KFoldECSI,
+        *,
+        x_0: torch.Tensor,
+        t: torch.Tensor,
+        f_input: SimpleNamespace,
+        x_0_mask: torch.Tensor,
+    ) -> dict[str, torch.Tensor]:
+        seen["x_0"] = x_0.clone()
+        sample_mask = torch.ones_like(t, dtype=torch.bool)
+        return {
+            "x_0_bridge": x_0 + 2.0,
+            "time_eligible_mask": sample_mask,
+            "eligible_mask": sample_mask,
+            "requested_mask": sample_mask,
+            "applied_mask": sample_mask,
+            "x_0_rmsd": torch.full_like(t, 2.0 * 3**0.5),
+            "resolved_chain_count": torch.full_like(t, 2, dtype=torch.long),
+        }
+
+    module._perturb_x_0 = MethodType(add_offset, module)  # type: ignore[method-assign]
+    out = module.sample_train_input(f_input, diffusion_batch_size=2)
+    clean = module._interpolate_bridge(out["x_0"], out["x_T"], out["noise"], out["t"])
+    expected_delta = (1.0 - out["t"])[..., None, None] * 2.0
+    torch.testing.assert_close(out["x_t"] - clean, expected_delta.expand_as(out["x_t"]))
+    torch.testing.assert_close(
+        out["x_0_perturb_x_t_rmsd"],
+        (1.0 - out["t"]) * (2.0 * 3**0.5),
+    )
+    assert torch.equal(out["x_0"], seen["x_0"])
+
+
+def test_logistic_schedule_requests_about_eight_percent() -> None:
+    module = make_module(train_x_0_perturb_prob=0.5)
+    torch.manual_seed(19)
+    t = module.sample_noise_level((1, 200000), torch.device("cpu"))
+    masks = module._sample_x_0_perturb_masks(t=t, resolved_chain_count=torch.tensor([2]))
+    assert abs(masks["requested"].float().mean().item() - 0.0805) < 0.003
+
+
+def test_telemetry_reports_actual_and_time_binned_dose() -> None:
+    metrics: dict[str, torch.Tensor] = {}
+    out = {
+        "t": torch.tensor([[0.45, 0.55, 0.75, 0.85]]),
+        "x_0_perturb_time_eligible_mask": torch.tensor([[True, True, True, False]]),
+        "x_0_perturb_eligible_mask": torch.tensor([[True, True, True, False]]),
+        "x_0_perturb_requested_mask": torch.tensor([[True, False, True, False]]),
+        "x_0_perturb_applied_mask": torch.tensor([[True, False, True, False]]),
+        "x_0_perturb_x_0_rmsd": torch.tensor([[1.0, 0.0, 3.0, 0.0]]),
+        "x_0_perturb_x_t_rmsd": torch.tensor([[0.55, 0.0, 0.75, 0.0]]),
+        "x_0_perturb_resolved_chain_count": torch.tensor([[2, 2, 2, 2]]),
+    }
+    KFoldTrainingModule._add_x_0_perturb_metrics(
+        diffusion_metrics=metrics,
+        diffusion_out=out,
+    )
+    torch.testing.assert_close(metrics["x_0_perturb_applied_fraction"], torch.tensor(0.5))
+    torch.testing.assert_close(
+        metrics["x_0_perturb_applied_given_eligible"], torch.tensor(2.0 / 3.0)
+    )
+    torch.testing.assert_close(metrics["x_0_perturb_x_t_rmsd_mean"], torch.tensor(0.65))
+    torch.testing.assert_close(
+        metrics["x_0_perturb_t04_05_applied_fraction"], torch.tensor(1.0)
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"train_x_0_perturb_prob": -0.1}, "must lie in"),
+        ({"train_x_0_perturb_prob": 1.1}, "must lie in"),
+        ({"train_x_0_perturb_rotation_deg": -1.0}, "non-negative"),
+        ({"train_x_0_perturb_translation_distance": -1.0}, "non-negative"),
+        ({"train_x_0_perturb_time_min": 0.9}, "times must lie"),
+    ],
+)
+def test_invalid_x_0_perturbation_config_is_rejected(
+    overrides: dict[str, float], message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        make_module(**overrides)


### PR DESCRIPTION
## Summary
- port the recent Exact-Markov ECSI-SDE SOAR path onto the latest `train/0811` Stage-3 data/crop contract
- sample SOAR roots continuously inside production schedule cells intersecting `t in [0.2, 0.8)`, with four Exact-Markov auxiliaries per root and no rollout churn
- restore the previously exercised high-time x0 perturbation contract from `train/0811-x0-perturb@638c07c1`
- keep pair gating out of scope and keep SOAR roots clean; x0 perturbation affects base bridges only
- retain actual exposure and x0/xt displacement telemetry

## High-time x0 perturbation
- eligible only for resolved multimers at `t > 0.7`
- Bernoulli probability `0.2` for high-time samples
- independent unrestricted random SO(3) rotation per chain
- independent per-axis Gaussian translation `N(0, 4^2)` Angstrom per chain
- rotation-only alignment of perturbed x0 to xT followed by centering, matching the prior implementation
- clean x0 remains the supervision target; xT, conditioning, masks, bridge noise, and SOAR states are unchanged

With the current logistic training-time distribution, the requested fraction before the multichain filter is about 1.83%. The applied fraction is logged directly and is expected to be around the previously observed 1% scale after data eligibility.

## Intended differences from `b6330274 / 86gto9fn`
- inherit `origin/train/0811@91cea6fc`, including the 8-dataset mixture and modality cropper settings
- pair bias remains linear; no gate code
- SOAR uses Exact-Markov, mid-only roots, four auxiliaries, retention minimum 0.5, and no rollout churn
- x0 perturbation now matches the earlier high-time random-SO(3)/Gaussian-translation implementation instead of the bounded mid-time 8-degree/1.2-Angstrom variant
- base ECSI config keeps perturbation disabled; the Stage-3 derived preset enables it
- no cluster-specific launcher or checkpoint path is included

## Validation
- 54 focused ECSI tests passed, including SOAR schedule-cell sampling, retention, Exact-Markov transition variance/noise, disabled perturb RNG no-op, strict `t > 0.7` boundary, random SO(3)/Gaussian translation routing, intrachain-distance preservation, legacy alignment/centering, alpha-scaled xt displacement, requested exposure, telemetry, and latest Stage-3 config parity
- `ruff check` and `ruff format --check` passed for all changed Python files
- `git diff --check` passed

The earlier PR head was exercised in full training through 83k. This follow-up high-time perturbation restoration is unit/config tested but has not yet been retrained.
