### PR TITLE
feat: add configurable Triton kernels for K-Fold inference

### DIFF
--- a/configs/model/kfold-ecsi.yaml
+++ b/configs/model/kfold-ecsi.yaml
@@ -1,6 +1,7 @@
 # === Model Configuration === #
 # kernel settings
 kernel_cuequivariance: true
+kernel_backend: null  # torch, cuequivariance, triton; null keeps legacy behavior
 
 # Module configurations
 channel_s: 384

--- a/configs/model/kfold-edm.yaml
+++ b/configs/model/kfold-edm.yaml
@@ -1,6 +1,7 @@
 # === Model Configuration === #
 # kernel settings
 kernel_cuequivariance: true
+kernel_backend: null  # torch, cuequivariance, triton; null keeps legacy behavior
 
 # Module configurations
 channel_s: 384

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
 [project.optional-dependencies]
 cuequiv = [
   "torch>=2.7.0",
-  "cuequivariance_torch>=0.6.0",
-  "cuequivariance_ops_cu12>=0.6.0",
-  "cuequivariance_ops_torch_cu12>=0.6.0",
+  "cuequivariance_torch~=0.10.0",
+  "cuequivariance_ops_cu12~=0.10.0",
+  "cuequivariance_ops_torch_cu12~=0.10.0",
 ]
 dev = ["pre-commit", "pytest"]
 train = [

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -44,6 +44,12 @@ def parse_args():
         help="Path to the model configuration file.",
     )
     parser.add_argument(
+        "--kernel-backend",
+        choices=("torch", "cuequivariance", "triton"),
+        default=None,
+        help="Override the kernel backend for this inference run.",
+    )
+    parser.add_argument(
         "--ccd",
         type=pathlib.Path,
         required=True,
@@ -120,6 +126,11 @@ def parse_args():
         "--overwrite",
         action="store_true",
         help="Whether to overwrite existing inference results.",
+    )
+    parser.add_argument(
+        "--non-strict",
+        action="store_true",
+        help="Allow checkpoint keys to differ from the current model.",
     )
     parser.add_argument(
         "--dry-run",
@@ -230,7 +241,16 @@ def main():
 
     # Load model
     logger.info(f"Loading model from weight: {args.weight}")
-    model: KFold = KFold.from_checkpoint(args.config, args.weight)
+    model: KFold = KFold.from_checkpoint(
+        args.config,
+        args.weight,
+        override_args=(
+            [f"kernel_backend={args.kernel_backend}"]
+            if args.kernel_backend is not None
+            else None
+        ),
+        strict=not args.non_strict,
+    )
     model = model.eval().cuda()
     logger.info("Model loaded successfully.")
 

--- a/src/kfold/model/layers/folding/atom_transformer.py
+++ b/src/kfold/model/layers/folding/atom_transformer.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.primitives import LayerNorm, LinearNoBias
 from kfold.utils.checkpointing import checkpoint_fn
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 from .diffusion_transformer import LocalTransformerStack
 from .utils import (
@@ -253,6 +254,7 @@ class AtomAttentionEncoder(nn.Module):
         num_heads=4,
         use_structure: bool = False,
         ckpt_atom_stack: bool = False,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the atom attention encoder.
 
@@ -286,6 +288,7 @@ class AtomAttentionEncoder(nn.Module):
             channel_z=channel_atompair,
             num_blocks=num_blocks,
             num_heads=num_heads,
+            kernel_policy=kernel_policy,
         )
         self.linear_q_to_a = LinearNoBias(channel_atom, channel_token, init="default")
         self.relu = nn.ReLU()
@@ -376,6 +379,7 @@ class AtomAttentionDecoder(nn.Module):
         num_blocks: int = 3,
         num_heads: int = 4,
         ckpt_atom_stack: bool = False,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the atom attention decoder.
 
@@ -404,6 +408,7 @@ class AtomAttentionDecoder(nn.Module):
             channel_z=channel_atompair,
             num_blocks=num_blocks,
             num_heads=num_heads,
+            kernel_policy=kernel_policy,
         )
         self.layernorm_q = LayerNorm(channel_atom, create_offset=False)
         self.linear_q_to_r = LinearNoBias(channel_atom, 3, init="final", precision=32)

--- a/src/kfold/model/layers/folding/attention_pair_bias.py
+++ b/src/kfold/model/layers/folding/attention_pair_bias.py
@@ -81,8 +81,12 @@ class AttentionPairBias(nn.Module):
         v: torch.Tensor,
         pair_bias: torch.Tensor,
         mask: torch.Tensor,
+        *,
+        use_kernels: bool | None = None,
     ) -> torch.Tensor:
-        # Dispatch is fixed when this module is constructed.
+        if use_kernels is None:
+            use_kernels = self.backend is KernelBackend.CUEQUIVARIANCE
+
         return attention_pair_bias(
             s=a,
             q=q,
@@ -96,7 +100,7 @@ class AttentionPairBias(nn.Module):
             b_proj_o=self.linear_out.bias,
             num_heads=self.num_heads,
             inf=self.inf,
-            use_kernels=self.backend is KernelBackend.CUEQUIVARIANCE,
+            use_kernels=use_kernels,
         )
 
 
@@ -305,6 +309,7 @@ class CrossAttentionPairBias(AttentionPairBias):
                 v,
                 pair_bias,
                 mask,
+                use_kernels=False,
             )
             a_q = rearrange(a, "... (w l) d -> ... w l d", w=a_q.shape[-3])
 

--- a/src/kfold/model/layers/folding/attention_pair_bias.py
+++ b/src/kfold/model/layers/folding/attention_pair_bias.py
@@ -11,7 +11,11 @@ import torch.nn as nn
 from einops import rearrange
 
 from kfold.model.primitives import AdaLN, LayerNorm, Linear, LinearNoBias
-from kfold.model.primitives.attention import attention_pair_bias
+from kfold.model.primitives.attention import (
+    attention_pair_bias,
+    triton_attention_pair_bias,
+)
+from kfold.utils.kernels import KernelBackend
 
 
 class AttentionPairBias(nn.Module):
@@ -22,6 +26,7 @@ class AttentionPairBias(nn.Module):
         *,
         zero_init_out: bool = False,
         inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
     ) -> None:
         """Initialize the attention pair bias layer.
 
@@ -40,6 +45,7 @@ class AttentionPairBias(nn.Module):
         self.num_heads: int = num_heads
         self.head_dim: int = channel_a // num_heads
         self.inf: float = inf
+        self.backend = backend
 
         self.linear_q = Linear(channel_a, channel_a, init="default")
         self.linear_k = LinearNoBias(channel_a, channel_a, init="default")
@@ -61,7 +67,10 @@ class AttentionPairBias(nn.Module):
         v = self.linear_v(a_k)
         # [*, L, c] -> [*, H, L, c_h]
         H = self.num_heads
-        q, k, v = map(lambda t: rearrange(t, "... l (h d) -> ... h l d", h=H), (q, k, v))
+        q, k, v = map(
+            lambda t: rearrange(t, "... l (h d) -> ... h l d", h=H),
+            (q, k, v),
+        )
         return q, k, v
 
     def _attention(
@@ -72,9 +81,8 @@ class AttentionPairBias(nn.Module):
         v: torch.Tensor,
         pair_bias: torch.Tensor,
         mask: torch.Tensor,
-        use_kernels: bool,
     ) -> torch.Tensor:
-        # Attention Pair Bias with cuequivariance kernels
+        # Dispatch is fixed when this module is constructed.
         return attention_pair_bias(
             s=a,
             q=q,
@@ -88,7 +96,7 @@ class AttentionPairBias(nn.Module):
             b_proj_o=self.linear_out.bias,
             num_heads=self.num_heads,
             inf=self.inf,
-            use_kernels=use_kernels,
+            use_kernels=self.backend is KernelBackend.CUEQUIVARIANCE,
         )
 
 
@@ -98,7 +106,9 @@ class SelfAttentionPairBias(AttentionPairBias):
         channel_a: int,
         num_heads: int,
         channel_s: int | None,
+        call_site: str,
         inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
     ) -> None:
         """Initialize the attention pair bias layer.
 
@@ -114,12 +124,16 @@ class SelfAttentionPairBias(AttentionPairBias):
             The inf value, by default 1e9
         """
         self.use_single_conditioning: bool = channel_s is not None
+        if call_site not in {"diffusion_global", "confidence"}:
+            raise ValueError(f"Unsupported self APB call site: {call_site!r}")
+        self.call_site = call_site
 
         super().__init__(
             channel_a,
             num_heads,
             zero_init_out=(not self.use_single_conditioning),
             inf=inf,
+            backend=backend,
         )
 
         if self.use_single_conditioning:
@@ -136,7 +150,6 @@ class SelfAttentionPairBias(AttentionPairBias):
         s: torch.Tensor | None,
         pair_bias: torch.Tensor,
         mask: torch.Tensor,
-        use_kernels: bool = False,
     ) -> torch.Tensor:
         """Forward pass.
 
@@ -150,9 +163,6 @@ class SelfAttentionPairBias(AttentionPairBias):
             The pair representation tensor (..., H, L, L)
         mask : torch.Tensor
             The attention mask tensor (..., L)
-        use_kernels : bool, optional
-            Whether to use custom kernel for attention, by default False
-
         Returns
         -------
         a : torch.Tensor
@@ -165,8 +175,25 @@ class SelfAttentionPairBias(AttentionPairBias):
             assert s is None
             a = self.layernorm_a(a)
 
-        q, k, v = self._prev_qkv(a, a)
-        a = self._attention(a, q, k, v, pair_bias, mask, use_kernels)
+        if self.backend is KernelBackend.TRITON:
+            a = triton_attention_pair_bias(
+                self,
+                a,
+                a,
+                pair_bias,
+                mask,
+                call_site=self.call_site,
+            )
+        else:
+            q, k, v = self._prev_qkv(a, a)
+            a = self._attention(
+                a,
+                q,
+                k,
+                v,
+                pair_bias,
+                mask,
+            )
 
         if self.use_single_conditioning:
             assert s is not None
@@ -181,6 +208,7 @@ class CrossAttentionPairBias(AttentionPairBias):
         num_heads: int,
         channel_s: int | None,
         inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
     ) -> None:
         """Initialize the attention pair bias layer.
 
@@ -204,6 +232,7 @@ class CrossAttentionPairBias(AttentionPairBias):
             num_heads,
             zero_init_out=(not self.use_single_conditioning),
             inf=inf,
+            backend=backend,
         )
 
         if self.use_single_conditioning:
@@ -257,16 +286,27 @@ class CrossAttentionPairBias(AttentionPairBias):
             a_q = self.layernorm_a_q(a_q)
             a_k = self.layernorm_a_k(a_k)
 
-        # Prepare attention pair bias input
-        a = rearrange(a_q, "... w l d -> ... (w l) d")  # flatten for compatibility
-
-        # [*, W, Lq/k, c] -> [*, W, H, Lq/k, c_h]
-        q, k, v = self._prev_qkv(a_q, a_k)
-
-        a = self._attention(a, q, k, v, pair_bias, mask, use_kernels=False)
-
-        # Reshape back to original shape
-        a_q = rearrange(a, "... (w l) d -> ... w l d", w=a_q.shape[-3])
+        if self.backend is KernelBackend.TRITON:
+            a_q = triton_attention_pair_bias(
+                self,
+                a_q,
+                a_k,
+                pair_bias,
+                mask,
+                call_site="diffusion_local",
+            )
+        else:
+            a = rearrange(a_q, "... w l d -> ... (w l) d")
+            q, k, v = self._prev_qkv(a_q, a_k)
+            a = self._attention(
+                a,
+                q,
+                k,
+                v,
+                pair_bias,
+                mask,
+            )
+            a_q = rearrange(a, "... (w l) d -> ... w l d", w=a_q.shape[-3])
 
         if self.use_single_conditioning:
             assert s_q is not None

--- a/src/kfold/model/layers/folding/diffusion.py
+++ b/src/kfold/model/layers/folding/diffusion.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.primitives import LayerNorm, LinearNoBias
 from kfold.model.primitives.utils import add
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 from .atom_transformer import AtomAttentionDecoder, AtomAttentionEncoder, AtomEmbedder
 from .diffusion_transformer import CachedGlobalTransformerStack
@@ -163,6 +164,7 @@ class DiffusionStack(nn.Module):
         atom_decoder_heads: int = 4,
         blocks_per_ckpt: int | None = None,
         ckpt_atom_stack: bool = False,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ) -> None:
         """Initialize the diffusion module.
 
@@ -250,6 +252,7 @@ class DiffusionStack(nn.Module):
             num_heads=atom_encoder_heads,
             use_structure=True,
             ckpt_atom_stack=ckpt_atom_stack,
+            kernel_policy=kernel_policy,
         )
         if separate_endpoint_atom_encoder:
             self.endpoint_atom_attention_encoder = AtomAttentionEncoder(
@@ -261,6 +264,7 @@ class DiffusionStack(nn.Module):
                 num_heads=atom_encoder_heads,
                 use_structure=True,
                 ckpt_atom_stack=ckpt_atom_stack,
+                kernel_policy=kernel_policy,
             )
             self.layernorm_a_t = LayerNorm(channel_a, create_offset=False)
             self.layernorm_a_endpoint = LayerNorm(channel_a, create_offset=False)
@@ -287,6 +291,7 @@ class DiffusionStack(nn.Module):
             num_blocks=token_transformer_blocks,
             num_heads=token_transformer_heads,
             blocks_per_ckpt=blocks_per_ckpt,
+            kernel_policy=kernel_policy,
         )
 
         self.layernorm_a = LayerNorm(channel_a, create_offset=False)
@@ -299,6 +304,7 @@ class DiffusionStack(nn.Module):
             num_blocks=atom_decoder_blocks,
             num_heads=atom_decoder_heads,
             ckpt_atom_stack=ckpt_atom_stack,
+            kernel_policy=kernel_policy,
         )
 
     # === Main forward function for training === #

--- a/src/kfold/model/layers/folding/diffusion_transformer.py
+++ b/src/kfold/model/layers/folding/diffusion_transformer.py
@@ -19,13 +19,63 @@ from functools import partial
 import einops
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from kfold.model.primitives import AdaLN, LayerNorm, Linear, LinearNoBias, SwiGLU
 from kfold.model.primitives.utils import add, permute_final_dims
 from kfold.utils.checkpointing import checkpoint_blocks
 
 from .attention_pair_bias import CrossAttentionPairBias, SelfAttentionPairBias
+from .transition import use_compiled_transition
 from .utils import build_atom_to_qk_fn
+
+
+def _conditioned_transition_forward(
+    a: torch.Tensor,
+    s: torch.Tensor,
+    adaln_s_norm_weight: torch.Tensor,
+    adaln_gate_weight: torch.Tensor,
+    adaln_gate_bias: torch.Tensor,
+    adaln_bias_weight: torch.Tensor,
+    swiglu_weight: torch.Tensor,
+    output_gate_weight: torch.Tensor,
+    output_gate_bias: torch.Tensor,
+    output_weight: torch.Tensor,
+    a_eps: float,
+    s_eps: float,
+) -> torch.Tensor:
+    """ConditionedTransitionBlock math for max-autotune inference."""
+    normalized_a = F.layer_norm(
+        a.float(),
+        (a.shape[-1],),
+        None,
+        None,
+        a_eps,
+    ).to(a.dtype)
+    normalized_s = F.layer_norm(
+        s.float(),
+        (s.shape[-1],),
+        adaln_s_norm_weight,
+        None,
+        s_eps,
+    ).to(s.dtype)
+    a = torch.sigmoid(
+        F.linear(normalized_s, adaln_gate_weight, adaln_gate_bias)
+    ) * normalized_a + F.linear(normalized_s, adaln_bias_weight)
+    swiglu_a, swiglu_b = F.linear(a, swiglu_weight).chunk(2, dim=-1)
+    hidden = F.silu(swiglu_a) * swiglu_b
+    return torch.sigmoid(F.linear(s, output_gate_weight, output_gate_bias)) * F.linear(
+        hidden,
+        output_weight,
+    )
+
+
+_compiled_conditioned_transition_forward = torch.compile(
+    _conditioned_transition_forward,
+    mode="max-autotune-no-cudagraphs",
+    fullgraph=True,
+    dynamic=True,
+)
 
 
 class ConditionedTransitionBlock(nn.Module):
@@ -58,6 +108,22 @@ class ConditionedTransitionBlock(nn.Module):
 
     def forward(self, a: torch.Tensor, s: torch.Tensor) -> torch.Tensor:
         """See Section 3.7 Algorithm 25 Conditioned Transition Block"""
+        if use_compiled_transition(self, a):
+            return _compiled_conditioned_transition_forward(
+                a,
+                s,
+                self.adaln.layernorm_s.weight,
+                self.adaln.linear_g.weight,
+                self.adaln.linear_g.bias,
+                self.adaln.linear_bias.weight,
+                self.swiglu.linear.weight,
+                self.linear_g.weight,
+                self.linear_g.bias,
+                self.linear_out.weight,
+                self.adaln.layernorm_a.eps,
+                self.adaln.layernorm_s.eps,
+            )
+
         # Line 1
         a = self.adaln(a, s)
         # Line 2

--- a/src/kfold/model/layers/folding/diffusion_transformer.py
+++ b/src/kfold/model/layers/folding/diffusion_transformer.py
@@ -24,6 +24,7 @@ import torch.nn.functional as F
 from kfold.model.primitives import AdaLN, LayerNorm, Linear, LinearNoBias, SwiGLU
 from kfold.model.primitives.utils import add, permute_final_dims
 from kfold.utils.checkpointing import checkpoint_blocks
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 from .attention_pair_bias import CrossAttentionPairBias, SelfAttentionPairBias
 from .transition import use_compiled_transition
@@ -149,6 +150,7 @@ class GlobalTransformerStack(torch.nn.Module):
         num_heads: int,
         num_blocks: int,
         blocks_per_ckpt: int | None = None,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer.
 
@@ -171,7 +173,13 @@ class GlobalTransformerStack(torch.nn.Module):
         self.layernorm_z = LayerNorm(channel_z, create_offset=False)
         self.blocks = nn.ModuleList(
             [
-                GlobalTransformerBlock(channel_a, channel_s, channel_z, num_heads)
+                GlobalTransformerBlock(
+                    channel_a,
+                    channel_s,
+                    channel_z,
+                    num_heads,
+                    kernel_policy=kernel_policy,
+                )
                 for _ in range(num_blocks)
             ]
         )
@@ -229,6 +237,7 @@ class GlobalTransformerBlock(nn.Module):
         channel_s: int,
         channel_z: int,
         num_heads: int,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer block.
 
@@ -245,7 +254,13 @@ class GlobalTransformerBlock(nn.Module):
         """
         super().__init__()
         self.linear_z_to_bias = LinearNoBias(channel_z, num_heads, init="default")
-        self.attention = SelfAttentionPairBias(channel_a, num_heads, channel_s)
+        self.attention = SelfAttentionPairBias(
+            channel_a,
+            num_heads,
+            channel_s,
+            call_site="diffusion_global",
+            backend=kernel_policy.attention_pair_bias,
+        )
         self.transition = ConditionedTransitionBlock(channel_a, channel_s)
 
     def forward(
@@ -278,7 +293,15 @@ class GlobalTransformerBlock(nn.Module):
         # Line 2
         pair_bias = self.linear_z_to_bias(z)  # [*, L, L, H]
         pair_bias = permute_final_dims(pair_bias, (0, 3, 1, 2))  # [*, H, L, L]
-        a = _add(a, self.attention(a, s, pair_bias, mask))
+        a = _add(
+            a,
+            self.attention(
+                a,
+                s,
+                pair_bias,
+                mask,
+            ),
+        )
         # Line 3
         a = _add(a, self.transition(a, s))
         return a
@@ -295,6 +318,7 @@ class CachedGlobalTransformerStack(nn.Module):
         num_heads: int,
         num_blocks: int,
         blocks_per_ckpt: int | None = None,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer.
 
@@ -314,7 +338,12 @@ class CachedGlobalTransformerStack(nn.Module):
         super().__init__()
         self.blocks = nn.ModuleList(
             [
-                CachedGlobalTransformerBlock(channel_a, channel_s, num_heads)
+                CachedGlobalTransformerBlock(
+                    channel_a,
+                    channel_s,
+                    num_heads,
+                    kernel_policy=kernel_policy,
+                )
                 for _ in range(num_blocks)
             ]
         )
@@ -368,6 +397,7 @@ class CachedGlobalTransformerBlock(nn.Module):
         channel_a: int,
         channel_s: int,
         num_heads: int,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer block.
 
@@ -383,7 +413,13 @@ class CachedGlobalTransformerBlock(nn.Module):
             The number of heads.
         """
         super().__init__()
-        self.attention = SelfAttentionPairBias(channel_a, num_heads, channel_s)
+        self.attention = SelfAttentionPairBias(
+            channel_a,
+            num_heads,
+            channel_s,
+            call_site="diffusion_global",
+            backend=kernel_policy.attention_pair_bias,
+        )
         self.transition = ConditionedTransitionBlock(channel_a, channel_s)
 
     def forward(
@@ -414,7 +450,13 @@ class CachedGlobalTransformerBlock(nn.Module):
         _add = partial(add, inplace=not self.training)
 
         # Line 2
-        a = _add(a, self.attention(a, s, pair_bias, mask))
+        a_update = self.attention(
+            a,
+            s,
+            pair_bias,
+            mask,
+        )
+        a = _add(a, a_update)
         # Line 3
         a = _add(a, self.transition(a, s))
         return a
@@ -436,6 +478,7 @@ class LocalTransformerStack(nn.Module):
         channel_z: int,
         num_heads: int,
         num_blocks: int,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer.
 
@@ -456,7 +499,13 @@ class LocalTransformerStack(nn.Module):
         self.layernorm_z = LayerNorm(channel_z, create_offset=False)
         self.blocks = nn.ModuleList(
             [
-                LocalTransformerBlock(channel_a, channel_s, channel_z, num_heads)
+                LocalTransformerBlock(
+                    channel_a,
+                    channel_s,
+                    channel_z,
+                    num_heads,
+                    kernel_policy=kernel_policy,
+                )
                 for _ in range(num_blocks)
             ]
         )
@@ -496,7 +545,14 @@ class LocalTransformerStack(nn.Module):
 
         for block in self.blocks:
             a_q, a_k = to_qk(a, -2)  # [*, W, Lq/Lk, c_a]
-            a_q = block(a_q, a_k, s_q, s_k, z, mask_k)  # [*, W, Lq, c_a]
+            a_q = block(
+                a_q,
+                a_k,
+                s_q,
+                s_k,
+                z,
+                mask_k,
+            )  # [*, W, Lq, c_a]
             a = a_q.flatten(-3, -2)  # [*, L, c_a]
         return a
 
@@ -513,6 +569,7 @@ class LocalTransformerBlock(nn.Module):
         channel_s: int,
         channel_z: int,
         num_heads: int,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the diffusion transformer block.
 
@@ -529,7 +586,12 @@ class LocalTransformerBlock(nn.Module):
         """
         super().__init__()
         self.linear_z_to_bias = LinearNoBias(channel_z, num_heads, init="default")
-        self.attention = CrossAttentionPairBias(channel_a, num_heads, channel_s)
+        self.attention = CrossAttentionPairBias(
+            channel_a,
+            num_heads,
+            channel_s,
+            backend=kernel_policy.attention_pair_bias,
+        )
         self.transition = ConditionedTransitionBlock(channel_a, channel_s)
 
     def forward(
@@ -566,11 +628,17 @@ class LocalTransformerBlock(nn.Module):
         _add = partial(add, inplace=not self.training)
 
         # Line 2
-        # Create pair bias for local attention
         pair_bias = self.linear_z_to_bias(z)  # [*, Lq, Lk, H]
-        pair_bias = permute_final_dims(pair_bias, (0, 3, 1, 2))  # [*, W, H, Lq, Lk]
-        # Apply attention with pair bias
-        a_q = _add(a_q, self.attention(a_q, a_k, s_q, s_k, pair_bias, mask))
+        pair_bias = permute_final_dims(pair_bias, (0, 3, 1, 2))
+        attention_update = self.attention(
+            a_q,
+            a_k,
+            s_q,
+            s_k,
+            pair_bias,
+            mask,
+        )
+        a_q = _add(a_q, attention_update)
         # Line 3
         a_q = _add(a_q, self.transition(a_q, s_q))
         return a_q

--- a/src/kfold/model/layers/folding/input_encoder.py
+++ b/src/kfold/model/layers/folding/input_encoder.py
@@ -3,6 +3,7 @@ import torch
 import kfold.constants as C
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.primitives import LinearNoBias
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 from .atom_transformer import AtomAttentionEncoder, AtomEmbedder
 
@@ -20,6 +21,7 @@ class InputFeatureEmbedder(torch.nn.Module):
         atom_encoder_blocks: int = 3,
         atom_encoder_heads: int = 4,
         ckpt_atom_stack: bool = False,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ) -> None:
         """Initialize the Input feature embedding module.
 
@@ -54,6 +56,7 @@ class InputFeatureEmbedder(torch.nn.Module):
             num_heads=atom_encoder_heads,
             use_structure=False,
             ckpt_atom_stack=ckpt_atom_stack,
+            kernel_policy=kernel_policy,
         )
 
         # residue info

--- a/src/kfold/model/layers/folding/transition.py
+++ b/src/kfold/model/layers/folding/transition.py
@@ -1,6 +1,44 @@
+import torch
+import torch.nn.functional as F
 from torch import Tensor, nn
 
 from kfold.model.primitives import LayerNorm, LinearNoBias, SwiGLU
+
+# This shared function sees several valid channel/expansion signatures in K-Fold.
+torch._dynamo.config.recompile_limit = max(torch._dynamo.config.recompile_limit, 32)
+
+
+def _transition_forward(
+    x: Tensor,
+    norm_weight: Tensor,
+    norm_bias: Tensor,
+    swiglu_weight: Tensor,
+    output_weight: Tensor,
+    eps: float,
+) -> Tensor:
+    """Transition math shared by eager and compiled inference paths."""
+    normalized = F.layer_norm(
+        x.float(),
+        (x.shape[-1],),
+        norm_weight,
+        norm_bias,
+        eps,
+    ).to(x.dtype)
+    a, b = F.linear(normalized, swiglu_weight).chunk(2, dim=-1)
+    return F.linear(F.silu(a) * b, output_weight)
+
+
+_compiled_transition_forward = torch.compile(
+    _transition_forward,
+    mode="max-autotune-no-cudagraphs",
+    fullgraph=True,
+    dynamic=True,
+)
+
+
+def use_compiled_transition(module: nn.Module, x: Tensor) -> bool:
+    """Use the measured max-autotune path only for standalone CUDA inference."""
+    return x.is_cuda and not module.training and not torch.compiler.is_compiling()
 
 
 class Transition(nn.Module):
@@ -45,6 +83,16 @@ class Transition(nn.Module):
             The output data of shape (..., D)
 
         """
+        if use_compiled_transition(self, x):
+            return _compiled_transition_forward(
+                x,
+                self.layernorm.weight,
+                self.layernorm.bias,
+                self.swiglu.linear.weight,
+                self.linear_out.weight,
+                self.layernorm.eps,
+            )
+
         # Line 1
         x = self.layernorm(x)
 

--- a/src/kfold/model/layers/folding/transition.py
+++ b/src/kfold/model/layers/folding/transition.py
@@ -38,7 +38,12 @@ _compiled_transition_forward = torch.compile(
 
 def use_compiled_transition(module: nn.Module, x: Tensor) -> bool:
     """Use the measured max-autotune path only for standalone CUDA inference."""
-    return x.is_cuda and not module.training and not torch.compiler.is_compiling()
+    return (
+        x.is_cuda
+        and not module.training
+        and not torch.is_grad_enabled()
+        and not torch.compiler.is_compiling()
+    )
 
 
 class Transition(nn.Module):

--- a/src/kfold/model/model.py
+++ b/src/kfold/model/model.py
@@ -23,6 +23,7 @@ from kfold.model.modules import (
 from kfold.model.modules.structure import sample_diffusion, score_model
 from kfold.model.primitives import LayerNorm, Linear, LinearNoBias
 from kfold.utils.config import resolve_config
+from kfold.utils.kernels import KernelPolicy
 from kfold.utils.registry import Registry
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class KFoldConfig:
 
     # Kernel configurations
     kernel_cuequivariance: bool = True
+    kernel_backend: str | None = None
 
     # For training
     diffusion_conditioning_drop_rate: float = 0.0
@@ -129,10 +131,10 @@ class KFold(torch.nn.Module):
         self.trunk_config = resolve_config(TrunkConfig, config.trunk)
         self.parcae_config = resolve_config(ParcaeConfig, config.parcae)
 
-        kernel_config = {
+        self.kernel_config = {
             "cuequivariance": config.kernel_cuequivariance,
         }
-        self.kernel_config = kernel_config
+        self.kernel_policy = KernelPolicy.from_config(config)
 
         # Initialize pre-trained sequence and structure encoders.
         self.prot_seq_encoder = sequence_encoder.SequenceEncoder(
@@ -146,7 +148,9 @@ class KFold(torch.nn.Module):
         )
 
         # Initialize input featurizer.
-        self.input_embedder = input_embedder.InputEmbedder(config.input_embedder)
+        self.input_embedder = input_embedder.InputEmbedder(
+            config.input_embedder, kernel_policy=self.kernel_policy
+        )
 
         # Initialize LM single and pairwise feature projection modules.
         self.prot_seq_to_s_lm = LMEncoder(
@@ -162,7 +166,9 @@ class KFold(torch.nn.Module):
         self.lm_to_pair = LMToPair(self.channel_s, self.channel_z)
 
         # Initialize trunk
-        self.apo_module = apo_module.ApoModule(config.apo_module)
+        self.apo_module = apo_module.ApoModule(
+            config.apo_module, kernel_policy=self.kernel_policy
+        )
         self.layernorm_z = LayerNorm(self.channel_z)
 
         # Parcae theory: learn a continuous negative-diagonal state transition
@@ -185,12 +191,14 @@ class KFold(torch.nn.Module):
             self.channel_z,
             self.trunk_config.num_lm_blocks,
             self.trunk_config.dropout,
+            kernel_policy=self.kernel_policy,
         )
         self.main_stack = tri_stack.TrianglularStack(
             self.channel_z,
             self.trunk_config.num_main_blocks,
             self.trunk_config.dropout,
             blocks_per_ckpt=self.trunk_config.blocks_per_ckpt,
+            kernel_policy=self.kernel_policy,
         )
         # Recyling
         self.linear_refine = LinearNoBias(self.channel_z, self.channel_z, init="identity")
@@ -198,11 +206,12 @@ class KFold(torch.nn.Module):
             self.channel_z,
             self.trunk_config.num_refine_blocks,
             self.trunk_config.dropout,
+            kernel_policy=self.kernel_policy,
         )
 
         # Initialize prediction heads
         self.score_model = score_model.DiffusionModule(
-            config.score_model, kernel_config=kernel_config
+            config.score_model, kernel_policy=self.kernel_policy
         )
         # NOTE: diffusion_head is not a torch.nn.Module
         # TODO: After we fix the diffusion algorith, remove Registry.instantiate
@@ -215,7 +224,7 @@ class KFold(torch.nn.Module):
             channel_z=self.channel_z,
         )
         self.confidence_head = confidence_head.ConfidenceHead(
-            config.confidence_head, kernel_config=kernel_config
+            config.confidence_head, kernel_policy=self.kernel_policy
         )
 
     def _parcae_discretized_dynamics(self) -> tuple[torch.Tensor, torch.Tensor]:
@@ -431,7 +440,6 @@ class KFold(torch.nn.Module):
         z: torch.Tensor
             The updated tensor of shape (B, L, L, c_z).
         """
-        use_cuequiv_kernels = self.kernel_config.get("cuequivariance", False)
         dtype = torch.get_autocast_dtype(f_input.device.type)
 
         # Parcae theory: stable channel-wise state decay (a) and
@@ -443,7 +451,7 @@ class KFold(torch.nn.Module):
         s_inputs, z_inputs = self.input_embedder(f_input)
 
         # Embedding of the apo state into the pair representation.
-        z_inputs = z_inputs + self.apo_module(f_input, use_cuequiv_kernels)
+        z_inputs = z_inputs + self.apo_module(f_input)
 
         # Initialize an independent pair-state z_0 instead of recycling from zeros.
         z = self._init_parcae_pair_state(z_inputs)
@@ -458,13 +466,13 @@ class KFold(torch.nn.Module):
         for _ in range(0, num_recycles + 1):
             # Intentional dropout during inference.
             _z_lm = F.dropout(z_lm, p=self.dropout, training=True)
-            u_t = z_inputs + self.lm_stack(_z_lm, pair_mask, use_cuequiv_kernels)
+            u_t = z_inputs + self.lm_stack(_z_lm, pair_mask)
             # Parcae recurrence: z_in = a * z_t + B_bar LN(u_t)
             z = a * z + F.linear(self.layernorm_z(u_t), b)
-            z = self.main_stack(z, pair_mask, use_cuequiv_kernels)
+            z = self.main_stack(z, pair_mask)
 
         # Refinement iteration
-        z = self.refine_stack(self.linear_refine(z), pair_mask, use_cuequiv_kernels)
+        z = self.refine_stack(self.linear_refine(z), pair_mask)
 
         return s_inputs, s_lm, z
 

--- a/src/kfold/model/modules/apo_module.py
+++ b/src/kfold/model/modules/apo_module.py
@@ -21,6 +21,7 @@ from kfold.model.primitives import (
 from kfold.model.primitives.utils import add
 from kfold.utils.checkpointing import checkpoint_blocks
 from kfold.utils.config import configurable
+from kfold.utils.kernels import TORCH_POLICY, KernelBackend, KernelPolicy
 
 
 class PairformerStack(torch.nn.Module):
@@ -33,26 +34,33 @@ class PairformerStack(torch.nn.Module):
         num_blocks: int = 48,
         dropout: float = 0.1,
         blocks_per_ckpt: int | None = None,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the Pairformer module."""
         super().__init__()
         self.channel_z: int = channel_z
         self.num_blocks: int = num_blocks
         self.dropout: float = dropout
+        self.kernel_policy = kernel_policy
 
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
 
         self.blocks = torch.nn.ModuleList()
         for _ in range(num_blocks):
             self.blocks.append(
-                PairformerBlock(self.channel_z, num_tri_heads, self.dropout)
+                PairformerBlock(
+                    self.channel_z,
+                    num_tri_heads,
+                    self.dropout,
+                    kernel_policy=kernel_policy,
+                )
             )
 
     def forward(
         self,
         z: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_kernels: bool = False,
+        use_cuequiv_kernels: bool | None = None,
     ) -> torch.Tensor:
         """Perform the forward pass.
 
@@ -62,19 +70,34 @@ class PairformerStack(torch.nn.Module):
             The pairwise embeddings
         pair mask : torch.Tensor
             The pair token mask
-        use_cuequiv_kernels : bool, optional
-            Whether to use CuEQuiv kernels, by default False
-
+        use_cuequiv_kernels : bool | None, optional
+            Legacy training argument. The backend is selected when the stack is
+            constructed.
         Returns
         -------
         torch.Tensor
             The updated sequence embeddings.
         """
+        if use_cuequiv_kernels is not None:
+            expected = (
+                KernelBackend.CUEQUIVARIANCE
+                if use_cuequiv_kernels
+                else KernelBackend.TORCH
+            )
+            selected = (
+                self.kernel_policy.triangle_attention,
+                self.kernel_policy.triangle_multiplication,
+            )
+            if any(backend is not expected for backend in selected):
+                raise ValueError(
+                    "The legacy training kernel flag does not match the "
+                    "stack backend selected at construction."
+                )
+
         blocks = [
             partial(
                 b,
                 pair_mask=pair_mask,
-                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -96,6 +119,7 @@ class PairformerBlock(torch.nn.Module):
         channel_z: int = 64,
         num_tri_heads: int = 4,
         dropout: float = 0.1,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the Pairformer module.
 
@@ -108,10 +132,18 @@ class PairformerBlock(torch.nn.Module):
         """
         super().__init__()
         self.channel_z: int = channel_z
-        self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
-        self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
-        self.tri_att_start = TriangleAttentionStartingNode(channel_z, num_tri_heads)
-        self.tri_att_end = TriangleAttentionEndingNode(channel_z, num_tri_heads)
+        self.tri_mul_out = TriangleMultiplicationOutgoing(
+            channel_z, backend=kernel_policy.triangle_multiplication
+        )
+        self.tri_mul_in = TriangleMultiplicationIncoming(
+            channel_z, backend=kernel_policy.triangle_multiplication
+        )
+        self.tri_att_start = TriangleAttentionStartingNode(
+            channel_z, num_tri_heads, backend=kernel_policy.triangle_attention
+        )
+        self.tri_att_end = TriangleAttentionEndingNode(
+            channel_z, num_tri_heads, backend=kernel_policy.triangle_attention
+        )
         self.transition_z = Transition(channel_z, expansion_factor=2)
         self.dropout_rowwise_z = DropoutRowwise(dropout)
         self.dropout_columnwise_z = DropoutColumnwise(dropout)
@@ -120,7 +152,6 @@ class PairformerBlock(torch.nn.Module):
         self,
         z: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the forward pass.
         See Section 3.6 Algorithm 20 Pairformer Stack
@@ -129,27 +160,19 @@ class PairformerBlock(torch.nn.Module):
 
         z = _add(
             z,
-            self.dropout_rowwise_z(
-                self.tri_mul_out(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_rowwise_z(self.tri_mul_out(z, pair_mask)),
         )
         z = _add(
             z,
-            self.dropout_rowwise_z(
-                self.tri_mul_in(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_rowwise_z(self.tri_mul_in(z, pair_mask)),
         )
         z = _add(
             z,
-            self.dropout_rowwise_z(
-                self.tri_att_start(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_rowwise_z(self.tri_att_start(z, pair_mask)),
         )
         z = _add(
             z,
-            self.dropout_columnwise_z(
-                self.tri_att_end(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_columnwise_z(self.tri_att_end(z, pair_mask)),
         )
         z = _add(z, self.transition_z(z))
         return z * pair_mask[..., None]
@@ -252,7 +275,11 @@ class ApoModule(torch.nn.Module):
         max_dist: float = 50.75
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config) -> None:
+    def __init__(
+        self,
+        cfg: Config,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
+    ) -> None:
         super().__init__()
         self.channel_z = cfg.channel_z
         self.channel_apo = cfg.channel_apo
@@ -275,6 +302,7 @@ class ApoModule(torch.nn.Module):
             num_blocks=cfg.num_blocks,
             dropout=cfg.dropout,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
+            kernel_policy=kernel_policy,
         )
         self.layernorm_out = LayerNorm(self.channel_apo)
         self.linear_out = LinearNoBias(self.channel_apo, self.channel_z, init="relu")
@@ -282,7 +310,7 @@ class ApoModule(torch.nn.Module):
     def forward(
         self,
         f_input: FoldingInput,
-        use_cuequiv_kernels: bool = False,
+        use_cuequiv_kernels: bool | None = None,
     ) -> torch.Tensor:
         """Return an apo pair update of shape ``[B, L, L, C_z]``."""
         pseudo_beta = f_input.token.apo_repr_coords.transpose(1, 2)

--- a/src/kfold/model/modules/confidence_head.py
+++ b/src/kfold/model/modules/confidence_head.py
@@ -12,6 +12,7 @@ from kfold.model.primitives import LayerNorm, LinearNoBias
 from kfold.model.primitives.utils import add, gather_dim, get_context_dtype
 from kfold.utils.checkpointing import checkpoint_blocks
 from kfold.utils.config import configurable
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 
 def to_atom_layout(
@@ -67,6 +68,7 @@ class ConfidencePairSingleStack(torch.nn.Module):
         num_blocks: int,
         dropout: float,
         blocks_per_ckpt: int | None = None,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ) -> None:
         super().__init__()
         self.blocks_per_ckpt = blocks_per_ckpt
@@ -77,6 +79,7 @@ class ConfidencePairSingleStack(torch.nn.Module):
                     channel_z=channel_z,
                     num_heads=num_heads,
                     dropout=dropout,
+                    kernel_policy=kernel_policy,
                 )
                 for _ in range(num_blocks)
             ]
@@ -88,14 +91,12 @@ class ConfidencePairSingleStack(torch.nn.Module):
         s: torch.Tensor,
         pair_mask: torch.Tensor,
         mask: torch.Tensor,
-        use_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         blocks = [
             partial(
                 b,
                 pair_mask=pair_mask,
                 mask=mask,
-                use_kernels=use_kernels,
             )
             for b in self.blocks
         ]
@@ -114,15 +115,22 @@ class ConfidencePairSingleBlock(torch.nn.Module):
         channel_z: int,
         num_heads: int,
         dropout: float,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ) -> None:
         super().__init__()
-        self.pair_block = TriangularBlock(channel_z, dropout)
+        self.pair_block = TriangularBlock(
+            channel_z,
+            dropout,
+            kernel_policy=kernel_policy,
+        )
         self.layernorm_z = LayerNorm(channel_z)
         self.linear_pair_bias = LinearNoBias(channel_z, num_heads)
         self.attention = SelfAttentionPairBias(
             channel_a=channel_s,
             num_heads=num_heads,
             channel_s=None,
+            call_site="confidence",
+            backend=kernel_policy.attention_pair_bias,
         )
         self.transition = Transition(channel_s, expansion_factor=4)
 
@@ -132,14 +140,22 @@ class ConfidencePairSingleBlock(torch.nn.Module):
         s: torch.Tensor,
         pair_mask: torch.Tensor,
         mask: torch.Tensor,
-        use_kernels: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         _add = partial(add, inplace=not self.training)
 
-        z = self.pair_block(z, pair_mask, use_kernels)
+        z = self.pair_block(z, pair_mask)
         pair_bias = self.linear_pair_bias(self.layernorm_z(z))
         pair_bias = pair_bias.movedim(-1, -3)  # [B, H, L, L]
-        s = _add(s, self.attention(s, None, pair_bias, mask))
+        attention_update = self.attention(
+            s,
+            None,
+            pair_bias,
+            mask,
+        )
+        s = _add(
+            s,
+            attention_update,
+        )
         s = _add(s, self.transition(s))
         return z, s
 
@@ -183,12 +199,15 @@ class ConfidenceHead(torch.nn.Module):
         # For training
         blocks_per_ckpt: int | None = None
 
-    def __init__(self, cfg: Config, kernel_config: dict):
+    def __init__(
+        self,
+        cfg: Config,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
+    ):
         super().__init__()
         self.num_pae_bins = cfg.num_pae_bins
         self.num_pde_bins = cfg.num_pde_bins
         self.num_plddt_bins = cfg.num_plddt_bins
-        self.kernel_config = kernel_config
         self.is_compiled = False
 
         def create_bin_centers(d_min: float, d_max: float, num_bins: int) -> torch.Tensor:
@@ -234,6 +253,7 @@ class ConfidenceHead(torch.nn.Module):
             num_blocks=cfg.num_blocks,
             dropout=cfg.dropout,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
+            kernel_policy=kernel_policy,
         )
 
         self.pae_head = torch.nn.Sequential(
@@ -416,11 +436,10 @@ class ConfidenceHead(torch.nn.Module):
 
         # Jointly update pair and LM single representations.
         stack = self.get_stack()
-        use_cuequiv_kernels = self.kernel_config.get("cuequivariance", False)
 
         z = z + self.linear_distogram(dgram.to(z.dtype))
         pair_mask = mask[..., :, None] & mask[..., None, :]
-        z, s = stack(z, s, pair_mask, mask, use_cuequiv_kernels)
+        z, s = stack(z, s, pair_mask, mask)
         z, s = z.to(torch.float32), s.to(torch.float32)
 
         # Confidence heads.

--- a/src/kfold/model/modules/input_embedder.py
+++ b/src/kfold/model/modules/input_embedder.py
@@ -7,6 +7,7 @@ from kfold.model.layers.folding.embeddings import RelativePositionEncoding
 from kfold.model.layers.folding.input_encoder import InputFeatureEmbedder
 from kfold.model.primitives import LinearNoBias
 from kfold.utils.config import configurable
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 
 @configurable
@@ -43,7 +44,11 @@ class InputEmbedder(torch.nn.Module):
         atom_encoder_heads: int = 4
         ckpt_atom_stack: bool = False
 
-    def __init__(self, cfg: Config) -> None:
+    def __init__(
+        self,
+        cfg: Config,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
+    ) -> None:
         super().__init__()
         self.cfg = cfg
         self.channel_s: int = cfg.channel_s
@@ -58,6 +63,7 @@ class InputEmbedder(torch.nn.Module):
             atom_encoder_blocks=cfg.atom_encoder_blocks,
             atom_encoder_heads=cfg.atom_encoder_heads,
             ckpt_atom_stack=cfg.ckpt_atom_stack,
+            kernel_policy=kernel_policy,
         )
 
         # Initial linear layers for single and pair representations

--- a/src/kfold/model/modules/structure/score_model.py
+++ b/src/kfold/model/modules/structure/score_model.py
@@ -5,6 +5,7 @@ import torch
 from kfold.data.types.model_input import FoldingInput
 from kfold.model.layers.folding.diffusion import DiffusionStack
 from kfold.utils.config import configurable
+from kfold.utils.kernels import TORCH_POLICY, KernelPolicy
 
 
 @configurable
@@ -71,10 +72,13 @@ class DiffusionModule(torch.nn.Module):
         blocks_per_ckpt: int | None = None
         ckpt_atom_stack: bool = False
 
-    def __init__(self, cfg, kernel_config):
+    def __init__(
+        self,
+        cfg,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
+    ):
         super().__init__()
         self.cfg = cfg
-        self.kernel_config = kernel_config
         self.is_compiled: bool = False
         self.diffusion_stack = DiffusionStack(
             channel_a=cfg.channel_a,
@@ -93,6 +97,7 @@ class DiffusionModule(torch.nn.Module):
             atom_decoder_heads=cfg.atom_decoder_heads,
             blocks_per_ckpt=cfg.blocks_per_ckpt,
             ckpt_atom_stack=cfg.ckpt_atom_stack,
+            kernel_policy=kernel_policy,
         )
 
     def do_compile(self, **kwargs):

--- a/src/kfold/model/modules/tri_stack.py
+++ b/src/kfold/model/modules/tri_stack.py
@@ -12,6 +12,7 @@ from kfold.model.primitives import (
 )
 from kfold.model.primitives.utils import add
 from kfold.utils.checkpointing import checkpoint_blocks
+from kfold.utils.kernels import TORCH_POLICY, KernelBackend, KernelPolicy
 
 
 class TrianglularStack(nn.Module):
@@ -23,12 +24,14 @@ class TrianglularStack(nn.Module):
         num_blocks: int = 48,
         dropout: float = 0.25,
         blocks_per_ckpt: int | None = None,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the Pairformer module."""
         super().__init__()
         self.channel_z: int = channel_z
         self.dropout: float = dropout
         self.num_blocks: int = num_blocks
+        self.kernel_policy = kernel_policy
 
         self.blocks_per_ckpt: int | None = blocks_per_ckpt
 
@@ -38,6 +41,7 @@ class TrianglularStack(nn.Module):
                 TriangularBlock(
                     self.channel_z,
                     self.dropout,
+                    kernel_policy=kernel_policy,
                 )
             )
 
@@ -45,7 +49,7 @@ class TrianglularStack(nn.Module):
         self,
         z: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_kernels: bool = False,
+        use_cuequiv_kernels: bool | None = None,
     ) -> torch.Tensor:
         """Perform the forward pass.
 
@@ -55,19 +59,30 @@ class TrianglularStack(nn.Module):
             The pairwise embeddings
         pair mask : torch.Tensor
             The pair token mask
-        use_cuequiv_kernels : bool, optional
-            Whether to use CuEQuiv kernels, by default False
-
+        use_cuequiv_kernels : bool | None, optional
+            Legacy training argument. The backend is selected when the stack is
+            constructed.
         Returns
         -------
         torch.Tensor
             The updated sequence embeddings.
         """
+        if use_cuequiv_kernels is not None:
+            expected = (
+                KernelBackend.CUEQUIVARIANCE
+                if use_cuequiv_kernels
+                else KernelBackend.TORCH
+            )
+            if self.kernel_policy.triangle_multiplication is not expected:
+                raise ValueError(
+                    "The legacy training kernel flag does not match the "
+                    "stack backend selected at construction."
+                )
+
         blocks = [
             partial(
                 b,
                 pair_mask=pair_mask,
-                use_cuequiv_kernels=use_cuequiv_kernels,
             )
             for b in self.blocks
         ]
@@ -88,6 +103,7 @@ class TriangularBlock(nn.Module):
         self,
         channel_z: int = 256,
         dropout: float = 0.25,
+        kernel_policy: KernelPolicy = TORCH_POLICY,
     ):
         """Initialize the Pairformer module.
 
@@ -102,8 +118,12 @@ class TriangularBlock(nn.Module):
         self.channel_z: int = channel_z
         self.dropout: float = dropout
 
-        self.tri_mul_out = TriangleMultiplicationOutgoing(channel_z)
-        self.tri_mul_in = TriangleMultiplicationIncoming(channel_z)
+        self.tri_mul_out = TriangleMultiplicationOutgoing(
+            channel_z, backend=kernel_policy.triangle_multiplication
+        )
+        self.tri_mul_in = TriangleMultiplicationIncoming(
+            channel_z, backend=kernel_policy.triangle_multiplication
+        )
         self.transition_z = Transition(channel_z, expansion_factor=4)
 
         self.dropout_rowwise = DropoutRowwise(dropout)
@@ -113,7 +133,6 @@ class TriangularBlock(nn.Module):
         self,
         z: torch.Tensor,
         pair_mask: torch.Tensor,
-        use_cuequiv_kernels: bool = False,
     ) -> torch.Tensor:
         """Perform the forward pass.
         See Section 3.6 Algorithm 20 Pairformer Stack
@@ -122,16 +141,12 @@ class TriangularBlock(nn.Module):
 
         z = _add(
             z,
-            self.dropout_rowwise(
-                self.tri_mul_out(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_rowwise(self.tri_mul_out(z, pair_mask)),
         )
 
         z = _add(
             z,
-            self.dropout_rowwise(
-                self.tri_mul_in(z, pair_mask, use_kernels=use_cuequiv_kernels)
-            ),
+            self.dropout_rowwise(self.tri_mul_in(z, pair_mask)),
         )
 
         z = _add(z, self.transition_z(z))

--- a/src/kfold/model/primitives/attention.py
+++ b/src/kfold/model/primitives/attention.py
@@ -241,19 +241,19 @@ def attention_pair_bias(
     """
     if use_kernels:
         return _kernel_attention_pair_bias(
-            s,
-            q,
-            k,
-            v,
-            pair_bias,
-            mask,
-            w_proj_g,
-            w_proj_o,
-            b_proj_g,
-            b_proj_o,
-            num_heads,
-            inf,
-            attn_scale,
+            s=s,
+            q=q,
+            k=k,
+            v=v,
+            pair_bias=pair_bias,
+            mask=mask,
+            w_proj_g=w_proj_g,
+            w_proj_o=w_proj_o,
+            b_proj_g=b_proj_g,
+            b_proj_o=b_proj_o,
+            num_heads=num_heads,
+            inf=inf,
+            attn_scale=attn_scale,
         )
     else:
         return _torch_attention_pair_bias(

--- a/src/kfold/model/primitives/attention.py
+++ b/src/kfold/model/primitives/attention.py
@@ -3,12 +3,37 @@ import math
 import torch
 import torch.nn.functional as F
 
+from .utils import permute_final_dims
+
 try:
     from cuequivariance_torch import attention_pair_bias as cueq_attention_pair_bias
 except ImportError:
     cueq_attention_pair_bias = None
 
-from .utils import permute_final_dims
+
+@torch.compiler.disable
+def triton_attention_pair_bias(
+    module,
+    x_q: torch.Tensor,
+    x_k: torch.Tensor,
+    pair_bias: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    call_site: str,
+) -> torch.Tensor:
+    """Run the Triton APB implementation for normalized K-Fold inputs."""
+    from kfold.utils.kernels.triton.attention_pair_bias import (
+        triton_attention_pair_bias,
+    )
+
+    return triton_attention_pair_bias(
+        module,
+        x_q,
+        x_k,
+        pair_bias,
+        mask,
+        call_site=call_site,
+    )
 
 
 def _attention(

--- a/src/kfold/model/primitives/triangle_attention.py
+++ b/src/kfold/model/primitives/triangle_attention.py
@@ -26,9 +26,103 @@ try:
 except ImportError:
     cueq_triangle_attention = None
 
+from kfold.utils.kernels import KernelBackend
+
 from .linear import LinearNoBias
 from .normalization import LayerNorm
 from .utils import flatten_final_dims, permute_final_dims
+
+
+def _triton_compute_dtype(x: torch.Tensor) -> torch.dtype:
+    if torch.is_autocast_enabled(x.device.type):
+        return torch.get_autocast_dtype(x.device.type)
+    return x.dtype
+
+
+def _triton_cache_key(module: nn.Module, x: torch.Tensor, dtype: torch.dtype) -> tuple:
+    parameters = (
+        module.layer_norm.weight,
+        module.layer_norm.bias,
+        module.mha.linear_q.weight,
+        module.mha.linear_k.weight,
+        module.mha.linear_v.weight,
+        module.linear.weight,
+        module.mha.linear_g.weight,
+        module.mha.linear_o.weight,
+    )
+    return (x.device.type, x.device.index, dtype) + tuple(
+        value
+        for parameter in parameters
+        for value in (
+            parameter.data_ptr(),
+            None if torch.is_inference(parameter) else parameter._version,
+        )
+    )
+
+
+@torch.compiler.disable
+def triton_triangular_attn(
+    module: nn.Module,
+    x: torch.Tensor,
+    mask: torch.Tensor,
+) -> torch.Tensor:
+    if torch.is_grad_enabled():
+        raise RuntimeError("The Triton triangle attention backend is inference-only.")
+    if not x.is_cuda:
+        raise RuntimeError("The Triton triangle attention backend requires CUDA.")
+
+    from kfold.utils.kernels.triton.triangle_attention import forward, precompute
+
+    compute_dtype = _triton_compute_dtype(x)
+    key = _triton_cache_key(module, x, compute_dtype)
+    cached_key = getattr(module, "_triton_attention_cache_key", None)
+    cached = getattr(module, "_triton_attention_cache", None)
+
+    with torch.autocast(x.device.type, enabled=False):
+        if cached is None or cached_key != key:
+
+            def cast(parameter: torch.Tensor) -> torch.Tensor:
+                return parameter.to(device=x.device, dtype=compute_dtype)
+
+            cached = precompute(
+                cast(module.layer_norm.weight),
+                cast(module.layer_norm.bias),
+                cast(module.mha.linear_q.weight).t().contiguous(),
+                cast(module.mha.linear_k.weight).t().contiguous(),
+                cast(module.mha.linear_v.weight).t().contiguous(),
+                cast(module.linear.weight).t().contiguous(),
+                torch.zeros(
+                    module.no_heads,
+                    device=x.device,
+                    dtype=compute_dtype,
+                ),
+                module.no_heads,
+                module.c_hidden,
+            )
+            cached["gate_weight"] = cast(module.mha.linear_g.weight)
+            cached["output_weight"] = cast(module.mha.linear_o.weight)
+            module._triton_attention_cache = cached
+            module._triton_attention_cache_key = key
+
+        length, channel = x.shape[-2:]
+        batch_shape = x.shape[:-3]
+        flat_x = x.to(compute_dtype).reshape(-1, length, length, channel)
+        flat_mask = torch.broadcast_to(mask.bool(), x.shape[:-1]).reshape(
+            -1, length, length
+        )
+        output = forward(
+            flat_x,
+            cached,
+            mask=flat_mask,
+            scale=1.0 / math.sqrt(module.c_hidden),
+            eps=module.layer_norm.eps,
+            W_proj_g=cached["gate_weight"],
+            B_proj_g=None,
+            W_proj_o=cached["output_weight"],
+            B_proj_o=None,
+        )
+        output = output.reshape(batch_shape + (length, length, channel))
+    return output.to(x.dtype)
 
 
 def _attention(
@@ -55,7 +149,7 @@ def _attention(
 
 
 @torch.compiler.disable
-def kernel_triangular_attn(
+def cueq_triangular_attn(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -68,7 +162,20 @@ def kernel_triangular_attn(
             "cuequivariance_torch is not installed. "
             "Please install cuequivariance_torch to use the kernel implementation."
         )
-    return cueq_triangle_attention(q, k, v, bias.float(), mask=mask, scale=scale)
+    # cuEquivariance 0.10 raises its eager Torch-fallback threshold to 200 for
+    # head dimensions below 32, regardless of CUEQ_TRIATTN_FALLBACK_THRESHOLD.
+    # Requesting auxiliary outputs forces the supported native kernel path; the
+    # benchmark preflight turns any remaining unsupported fallback into an error.
+    output, _, _ = cueq_triangle_attention(
+        q,
+        k,
+        v,
+        bias.float(),
+        mask=mask,
+        scale=scale,
+        return_aux=True,
+    )
+    return output
 
 
 class MultiHeadAttention(nn.Module):
@@ -86,6 +193,7 @@ class MultiHeadAttention(nn.Module):
         no_heads: int,
         gating: bool = True,
         inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
     ):
         """Initialize the attention layer.
 
@@ -114,6 +222,9 @@ class MultiHeadAttention(nn.Module):
         self.no_heads: int = no_heads
         self.gating: bool = gating
         self.inf: float = inf
+        if backend not in (KernelBackend.TORCH, KernelBackend.CUEQUIVARIANCE):
+            raise ValueError(f"Unsupported multi-head attention backend: {backend!r}")
+        self.backend = backend
 
         # DISCREPANCY: c_hidden is not the per-head channel dimension, as
         # stated in the supplement, but the overall channel dimension.
@@ -184,7 +295,6 @@ class MultiHeadAttention(nn.Module):
         kv_x: torch.Tensor,
         tri_bias: torch.Tensor,
         mask: torch.Tensor,
-        use_kernels: bool = False,
     ) -> torch.Tensor:
         """Compute attention.
 
@@ -198,9 +308,6 @@ class MultiHeadAttention(nn.Module):
             [*, H, Q, K] triangular bias
         mask : torch.Tensor
             [*, Q, K] mask
-        use_kernels : bool, default=False
-            Whether to use optimized CUDA kernels
-
         Returns
         -------
             [*, Q, C_q] attention update
@@ -210,12 +317,12 @@ class MultiHeadAttention(nn.Module):
         q, k, v = self._prep_qkv(
             q_x,
             kv_x,
-            apply_scale=not use_kernels,
+            apply_scale=self.backend is not KernelBackend.CUEQUIVARIANCE,
         )
 
-        if use_kernels:
+        if self.backend is KernelBackend.CUEQUIVARIANCE:
             scale = 1.0 / math.sqrt(self.c_hidden)
-            o = kernel_triangular_attn(
+            o = cueq_triangular_attn(
                 q,
                 k,
                 v,
@@ -244,6 +351,7 @@ class TriangleAttention(nn.Module):
         no_heads: int,
         starting: bool,
         inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
     ) -> None:
         super().__init__()
         assert c_in % no_heads == 0, (
@@ -255,20 +363,30 @@ class TriangleAttention(nn.Module):
         self.no_heads: int = no_heads
         self.starting: bool = starting
         self.inf: float = inf
+        self.backend = backend
 
         self.layer_norm = LayerNorm(self.c_in)
 
         self.linear = LinearNoBias(c_in, self.no_heads, init="default")
 
+        attention_backend = (
+            KernelBackend.CUEQUIVARIANCE
+            if backend is KernelBackend.CUEQUIVARIANCE
+            else KernelBackend.TORCH
+        )
         self.mha = MultiHeadAttention(
-            self.c_in, self.c_in, self.c_in, self.c_hidden, self.no_heads
+            self.c_in,
+            self.c_in,
+            self.c_in,
+            self.c_hidden,
+            self.no_heads,
+            backend=attention_backend,
         )
 
     def forward(
         self,
         x: torch.Tensor,
         mask: torch.Tensor | None = None,
-        use_kernels: bool = False,
     ) -> torch.Tensor:
         """Compute triangle attention.
 
@@ -278,9 +396,6 @@ class TriangleAttention(nn.Module):
             Input tensor of shape [*, I, J, C_in]
         mask : torch.Tensor, optional
             Attention mask of shape [*, I, J]
-        use_kernels : bool, default=False
-            Whether to use optimized CUDA kernels
-
         Returns
         -------
         torch.Tensor
@@ -296,6 +411,12 @@ class TriangleAttention(nn.Module):
         if not self.starting:
             x = x.transpose(-2, -3)
             mask = mask.transpose(-1, -2)
+
+        if self.backend is KernelBackend.TRITON:
+            x = triton_triangular_attn(self, x, mask)
+            if not self.starting:
+                x = x.transpose(-2, -3)
+            return x
 
         # [*, I, J, C_in]
         x = self.layer_norm(x)
@@ -316,7 +437,6 @@ class TriangleAttention(nn.Module):
             x,
             triangle_bias,
             mask,
-            use_kernels=use_kernels,
         )
 
         if not self.starting:
@@ -329,12 +449,24 @@ class TriangleAttention(nn.Module):
 class TriangleAttentionStartingNode(TriangleAttention):
     """See Section 3.4 Algorithm 14 in the AlphaFold3 paper."""
 
-    def __init__(self, c_in: int, no_heads: int, inf: float = 1e9) -> None:
-        super().__init__(c_in, no_heads, starting=True, inf=inf)
+    def __init__(
+        self,
+        c_in: int,
+        no_heads: int,
+        inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
+    ) -> None:
+        super().__init__(c_in, no_heads, starting=True, inf=inf, backend=backend)
 
 
 class TriangleAttentionEndingNode(TriangleAttention):
     """See Section 3.4 Algorithm 15 in the AlphaFold3 paper."""
 
-    def __init__(self, c_in: int, no_heads: int, inf: float = 1e9) -> None:
-        super().__init__(c_in, no_heads, starting=False, inf=inf)
+    def __init__(
+        self,
+        c_in: int,
+        no_heads: int,
+        inf: float = 1e9,
+        backend: KernelBackend = KernelBackend.TORCH,
+    ) -> None:
+        super().__init__(c_in, no_heads, starting=False, inf=inf, backend=backend)

--- a/src/kfold/model/primitives/triangle_multiplication.py
+++ b/src/kfold/model/primitives/triangle_multiplication.py
@@ -174,9 +174,7 @@ class TriangleMultiplicationOutgoing(nn.Module):
 
         """
         if self.backend is KernelBackend.TRITON:
-            return triton_triangluar_mult(
-                self, x, mask, direction="outgoing"
-            )
+            return triton_triangluar_mult(self, x, mask, direction="outgoing")
         if self.backend is KernelBackend.CUEQUIVARIANCE:
             return cueq_triangluar_mult(
                 x,
@@ -260,9 +258,7 @@ class TriangleMultiplicationIncoming(nn.Module):
 
         """
         if self.backend is KernelBackend.TRITON:
-            return triton_triangluar_mult(
-                self, x, mask, direction="incoming"
-            )
+            return triton_triangluar_mult(self, x, mask, direction="incoming")
         if self.backend is KernelBackend.CUEQUIVARIANCE:
             return cueq_triangluar_mult(
                 x,

--- a/src/kfold/model/primitives/triangle_multiplication.py
+++ b/src/kfold/model/primitives/triangle_multiplication.py
@@ -8,12 +8,14 @@ try:
 except ImportError:
     triangle_multiplicative_update = None
 
+from kfold.utils.kernels import KernelBackend
+
 from .linear import LinearNoBias
 from .normalization import LayerNorm
 
 
 @torch.compiler.disable
-def kernel_triangular_mult(
+def cueq_triangluar_mult(
     x: torch.Tensor,
     direction: str,
     mask: torch.Tensor,
@@ -48,12 +50,95 @@ def kernel_triangular_mult(
     )
 
 
+def _triton_compute_dtype(x: torch.Tensor) -> torch.dtype:
+    if torch.is_autocast_enabled(x.device.type):
+        return torch.get_autocast_dtype(x.device.type)
+    return x.dtype
+
+
+def _triton_cache_key(module: nn.Module, x: torch.Tensor, dtype: torch.dtype) -> tuple:
+    parameters = (
+        module.layernorm_in.weight,
+        module.layernorm_in.bias,
+        module.linear_p_in.weight,
+        module.linear_g_in.weight,
+        module.layernorm_out.weight,
+        module.layernorm_out.bias,
+        module.linear_p_out.weight,
+        module.linear_g_out.weight,
+    )
+    return (x.device.type, x.device.index, dtype) + tuple(
+        value
+        for parameter in parameters
+        for value in (
+            parameter.data_ptr(),
+            None if torch.is_inference(parameter) else parameter._version,
+        )
+    )
+
+
+@torch.compiler.disable
+def triton_triangluar_mult(
+    module: nn.Module,
+    x: torch.Tensor,
+    mask: torch.Tensor,
+    direction: str,
+) -> torch.Tensor:
+    if torch.is_grad_enabled():
+        raise RuntimeError(
+            "The Triton triangle multiplication backend is inference-only."
+        )
+    if not x.is_cuda:
+        raise RuntimeError("The Triton triangle multiplication backend requires CUDA.")
+
+    from kfold.utils.kernels.triton.triangle_multiplication import forward, precompute
+
+    compute_dtype = _triton_compute_dtype(x)
+    key = _triton_cache_key(module, x, compute_dtype)
+    cached_key = getattr(module, "_triton_multiplication_cache_key", None)
+    cached = getattr(module, "_triton_multiplication_cache", None)
+
+    with torch.autocast(x.device.type, enabled=False):
+        if cached is None or cached_key != key:
+
+            def cast(parameter: torch.Tensor) -> torch.Tensor:
+                return parameter.to(device=x.device, dtype=compute_dtype)
+
+            cached = precompute(
+                cast(module.layernorm_in.weight),
+                cast(module.layernorm_in.bias),
+                cast(module.linear_p_in.weight),
+                cast(module.linear_g_in.weight),
+                cast(module.layernorm_out.weight),
+                cast(module.layernorm_out.bias),
+                cast(module.linear_p_out.weight),
+                cast(module.linear_g_out.weight),
+            )
+            module._triton_multiplication_cache = cached
+            module._triton_multiplication_cache_key = key
+
+        output = forward(
+            x.to(compute_dtype),
+            cached,
+            direction=direction,
+            mask=mask.bool(),
+            eps=module.layernorm_in.eps,
+        )
+    return output.to(x.dtype)
+
+
 class TriangleMultiplicationOutgoing(nn.Module):
     """TriangleMultiplicationOutgoing.
     See Section 3.4 Algorithm 12
     """
 
-    def __init__(self, dim: int = 128) -> None:
+    direction = "outgoing"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        backend: KernelBackend = KernelBackend.TORCH,
+    ) -> None:
         """Initialize the TriangularUpdate module.
 
         Parameters
@@ -63,6 +148,7 @@ class TriangleMultiplicationOutgoing(nn.Module):
 
         """
         super().__init__()
+        self.backend = backend
 
         self.layernorm_in = LayerNorm(dim)
         self.linear_p_in = LinearNoBias(dim, 2 * dim, init="default")
@@ -72,9 +158,7 @@ class TriangleMultiplicationOutgoing(nn.Module):
         self.linear_p_out = LinearNoBias(dim, dim, init="final")
         self.linear_g_out = LinearNoBias(dim, dim, init="gating")
 
-    def forward(
-        self, x: torch.Tensor, mask: torch.Tensor, use_kernels: bool = False
-    ) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         """Perform a forward pass.
 
         Parameters
@@ -83,19 +167,20 @@ class TriangleMultiplicationOutgoing(nn.Module):
             The input data of shape (B, N, N, D)
         mask: torch.Tensor
             The input mask of shape (B, N, N)
-        use_kernels: bool
-            Whether to use the kernel
-
         Returns
         -------
         x: torch.Tensor
             The output data of shape (B, N, N, D)
 
         """
-        if use_kernels:
-            return kernel_triangular_mult(
+        if self.backend is KernelBackend.TRITON:
+            return triton_triangluar_mult(
+                self, x, mask, direction="outgoing"
+            )
+        if self.backend is KernelBackend.CUEQUIVARIANCE:
+            return cueq_triangluar_mult(
                 x,
-                direction="outgoing",
+                direction=self.direction,
                 mask=mask,
                 norm_in_weight=self.layernorm_in.weight,
                 norm_in_bias=self.layernorm_in.bias,
@@ -133,7 +218,13 @@ class TriangleMultiplicationIncoming(nn.Module):
     See Section 3.4 Algorithm 13
     """
 
-    def __init__(self, dim: int = 128) -> None:
+    direction = "incoming"
+
+    def __init__(
+        self,
+        dim: int = 128,
+        backend: KernelBackend = KernelBackend.TORCH,
+    ) -> None:
         """Initialize the TriangularUpdate module.
 
         Parameters
@@ -143,6 +234,7 @@ class TriangleMultiplicationIncoming(nn.Module):
 
         """
         super().__init__()
+        self.backend = backend
 
         self.layernorm_in = LayerNorm(dim, eps=1e-5)
         self.linear_p_in = LinearNoBias(dim, 2 * dim, init="default")
@@ -152,9 +244,7 @@ class TriangleMultiplicationIncoming(nn.Module):
         self.linear_p_out = LinearNoBias(dim, dim, init="final")
         self.linear_g_out = LinearNoBias(dim, dim, init="gating")
 
-    def forward(
-        self, x: torch.Tensor, mask: torch.Tensor, use_kernels: bool = False
-    ) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         """Perform a forward pass.
 
         Parameters
@@ -163,19 +253,20 @@ class TriangleMultiplicationIncoming(nn.Module):
             The input data of shape (B, N, N, D)
         mask: torch.Tensor
             The input mask of shape (B, N, N)
-        use_kernels: bool
-            Whether to use the kernel
-
         Returns
         -------
         x: torch.Tensor
             The output data of shape (B, N, N, D)
 
         """
-        if use_kernels:
-            return kernel_triangular_mult(
+        if self.backend is KernelBackend.TRITON:
+            return triton_triangluar_mult(
+                self, x, mask, direction="incoming"
+            )
+        if self.backend is KernelBackend.CUEQUIVARIANCE:
+            return cueq_triangluar_mult(
                 x,
-                direction="incoming",
+                direction=self.direction,
                 mask=mask,
                 norm_in_weight=self.layernorm_in.weight,
                 norm_in_bias=self.layernorm_in.bias,

--- a/src/kfold/utils/kernels/__init__.py
+++ b/src/kfold/utils/kernels/__init__.py
@@ -1,0 +1,21 @@
+"""Kernel implementations and backend selection."""
+
+from .policy import (
+    CUEQUIVARIANCE_POLICY,
+    KERNEL_POLICIES,
+    TORCH_POLICY,
+    TRITON_POLICY,
+    KernelBackend,
+    KernelPolicy,
+    kernel_policy_from_name,
+)
+
+__all__ = [
+    "CUEQUIVARIANCE_POLICY",
+    "KERNEL_POLICIES",
+    "TORCH_POLICY",
+    "TRITON_POLICY",
+    "KernelBackend",
+    "KernelPolicy",
+    "kernel_policy_from_name",
+]

--- a/src/kfold/utils/kernels/policy.py
+++ b/src/kfold/utils/kernels/policy.py
@@ -1,0 +1,77 @@
+"""Kernel backend selection for optimized K-Fold operations."""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+from typing import Any
+
+
+class KernelBackend(enum.StrEnum):
+    """Implementations available to an optimized model operation."""
+
+    TORCH = "torch"
+    CUEQUIVARIANCE = "cuequivariance"
+    TRITON = "triton"
+
+
+@dataclasses.dataclass(frozen=True)
+class KernelPolicy:
+    """Backend selected for each optimized operation."""
+
+    triangle_attention: KernelBackend
+    triangle_multiplication: KernelBackend
+    attention_pair_bias: KernelBackend
+
+    @classmethod
+    def from_config(cls, config: Any) -> KernelPolicy:
+        """Resolve the new backend field or the legacy cueq boolean."""
+        backend = getattr(config, "kernel_backend", None)
+        if backend is None:
+            backend = (
+                KernelBackend.CUEQUIVARIANCE
+                if getattr(config, "kernel_cuequivariance", True)
+                else KernelBackend.TORCH
+            )
+        return kernel_policy_from_name(backend)
+
+
+TORCH_POLICY = KernelPolicy(
+    triangle_attention=KernelBackend.TORCH,
+    triangle_multiplication=KernelBackend.TORCH,
+    attention_pair_bias=KernelBackend.TORCH,
+)
+CUEQUIVARIANCE_POLICY = KernelPolicy(
+    triangle_attention=KernelBackend.CUEQUIVARIANCE,
+    triangle_multiplication=KernelBackend.CUEQUIVARIANCE,
+    attention_pair_bias=KernelBackend.CUEQUIVARIANCE,
+)
+TRITON_POLICY = KernelPolicy(
+    triangle_attention=KernelBackend.TRITON,
+    triangle_multiplication=KernelBackend.TRITON,
+    attention_pair_bias=KernelBackend.TRITON,
+)
+
+KERNEL_POLICIES = {
+    KernelBackend.TORCH.value: TORCH_POLICY,
+    KernelBackend.CUEQUIVARIANCE.value: CUEQUIVARIANCE_POLICY,
+    KernelBackend.TRITON.value: TRITON_POLICY,
+}
+
+_BACKEND_ALIASES = {
+    "naive": KernelBackend.TORCH.value,
+    "cueq": KernelBackend.CUEQUIVARIANCE.value,
+}
+
+
+def kernel_policy_from_name(name: str | KernelBackend) -> KernelPolicy:
+    """Return a named policy and reject unknown YAML values."""
+    normalized = str(name)
+    normalized = _BACKEND_ALIASES.get(normalized, normalized)
+    try:
+        return KERNEL_POLICIES[normalized]
+    except (KeyError, TypeError) as exc:
+        expected = tuple(KERNEL_POLICIES)
+        raise ValueError(
+            f"Unknown kernel backend {name!r}; expected one of {expected}."
+        ) from exc

--- a/src/kfold/utils/kernels/triton/__init__.py
+++ b/src/kfold/utils/kernels/triton/__init__.py
@@ -1,0 +1,17 @@
+"""Triton kernels optimized for K-Fold inference."""
+
+from .attention_pair_bias import (
+    apb_diffusion_forward,
+    gated_output_projection_bhld,
+    gated_output_projection_blc,
+)
+from .triangle_attention import triangle_attention
+from .triangle_multiplication import triangle_multiplicative_update
+
+__all__ = [
+    "apb_diffusion_forward",
+    "gated_output_projection_bhld",
+    "gated_output_projection_blc",
+    "triangle_attention",
+    "triangle_multiplicative_update",
+]

--- a/src/kfold/utils/kernels/triton/_common/__init__.py
+++ b/src/kfold/utils/kernels/triton/_common/__init__.py
@@ -1,0 +1,14 @@
+"""Shared low-level helpers used by all three fused ops."""
+
+from .dtypes import TORCH_TO_TL, tl_io_dtype
+from .layouts import interleave_kv, interleave_qkv
+from .ln_absorption import absorb_ln, absorb_ln_matmul
+
+__all__ = [
+    "TORCH_TO_TL",
+    "tl_io_dtype",
+    "absorb_ln",
+    "absorb_ln_matmul",
+    "interleave_qkv",
+    "interleave_kv",
+]

--- a/src/kfold/utils/kernels/triton/_common/dtypes.py
+++ b/src/kfold/utils/kernels/triton/_common/dtypes.py
@@ -1,0 +1,21 @@
+"""Shared dtype helpers."""
+
+import torch
+import triton.language as tl
+
+# Map a torch IO dtype to the Triton constexpr the kernels store/cast with.
+TORCH_TO_TL = {
+    torch.float16: tl.float16,
+    torch.bfloat16: tl.bfloat16,
+    torch.float32: tl.float32,
+}
+
+
+def tl_io_dtype(dtype: torch.dtype):
+    """Return the `tl.*` dtype for a torch IO dtype, raising on unsupported."""
+    try:
+        return TORCH_TO_TL[dtype]
+    except KeyError as e:
+        raise ValueError(
+            f"unsupported IO dtype {dtype}; expected one of {list(TORCH_TO_TL)}"
+        ) from e

--- a/src/kfold/utils/kernels/triton/_common/layouts.py
+++ b/src/kfold/utils/kernels/triton/_common/layouts.py
@@ -1,0 +1,33 @@
+"""Weight-layout helpers for per-head concatenated projections.
+
+Interleaving Q/K/V (or K/V) per head into one contiguous weight lets a kernel
+issue a single matmul + single weight load instead of N separate ones, and
+keeps each head's slice contiguous for L2 locality.
+"""
+
+import torch
+
+
+def interleave_qkv(
+    WQ: torch.Tensor, WK: torch.Tensor, WV: torch.Tensor, H: int, D: int
+) -> torch.Tensor:
+    """Concat WQ/WK/WV (each (N, H*D)) → (N, 3*H*D), per-head block-interleaved:
+    columns [3*h*D : 3*(h+1)*D] hold [Q_h | K_h | V_h].  (matmul convention: x @ W)
+    """
+    N = WQ.shape[0]
+    assert WQ.shape == WK.shape == WV.shape == (N, H * D)
+    WQ_r, WK_r, WV_r = WQ.view(N, H, D), WK.view(N, H, D), WV.view(N, H, D)
+    W = torch.stack([WQ_r, WK_r, WV_r], dim=2)  # (N, H, 3, D)
+    return W.contiguous().view(N, 3 * H * D)
+
+
+def interleave_kv(WK: torch.Tensor, WV: torch.Tensor, H: int, D: int) -> torch.Tensor:
+    """Concat WK/WV (each (C_in, H*D)) → (C_in, 2*H*D), FEATURE-interleaved per head:
+    per-head 2*D cols = [K[0], V[0], K[1], V[1], ...] so a (·, D, 2) reshape +
+    `tl.split` recovers K, V.  (matmul convention: x @ W)
+    """
+    C_in = WK.shape[0]
+    assert WK.shape == WV.shape == (C_in, H * D)
+    WK_hv, WV_hv = WK.view(C_in, H, D), WV.view(C_in, H, D)
+    W = torch.stack([WK_hv, WV_hv], dim=-1)  # (C_in, H, D, 2) — K=0, V=1 in last
+    return W.contiguous().view(C_in, 2 * H * D)

--- a/src/kfold/utils/kernels/triton/_common/ln_absorption.py
+++ b/src/kfold/utils/kernels/triton/_common/ln_absorption.py
@@ -1,0 +1,63 @@
+"""LayerNorm-affine absorption — the shared lever behind all three kernels.
+
+A LayerNorm immediately followed by a linear projection can be collapsed so the
+LN affine is folded into the projection weight.  This removes the separate LN
+kernel/buffer and lets the fused kernel produce (mean, var, projection) in one
+pass over the feature dim.
+
+Derivation (per token, over feature dim of size C):
+    LN(x)[i] = (x[i] - mean) · rstd · w_ln[i] + b_ln[i]
+    (LN(x) @ Wᵀ)[o] = rstd · ( Σ_i x[i]·Wc[o,i] − mean·ΣW[o] ) + Bc[o]
+        Wc[o,i] = w_ln[i] · W[o,i]
+        ΣW[o]   = Σ_i Wc[o,i]
+        Bc[o]   = Σ_i b_ln[i] · W[o,i]
+
+So a model-init precompute of (Wc, ΣW, Bc) lets the kernel apply the LN affine
+with only the per-token (mean, rstd) it already computes via Welford.
+
+Two conventions are provided because the three ops carry weights differently:
+  - `absorb_ln`        : weight is (out, in)  — torch.nn.Linear `.weight` style.
+  - `absorb_ln_matmul` : weight is (in, out)  — bare `x @ W` matmul style.
+Both return ΣW and Bc in fp32 (they feed fp32 accumulators); Wc is cast to
+`weight_dtype` (default = weight.dtype) so it can stay bf16/fp16 for tensor cores.
+"""
+
+import torch
+
+
+def absorb_ln(
+    weight: torch.Tensor,
+    w_ln: torch.Tensor,
+    b_ln: torch.Tensor,
+    *,
+    weight_dtype: torch.dtype | None = None,
+):
+    """Fold LN affine into an (out, in) nn.Linear-convention weight.
+
+    Returns: Wc (out, in)[weight_dtype], sum_W (out,)[fp32], B_const (out,)[fp32].
+    """
+    Wf = weight.float()
+    Wc = Wf * w_ln.float().unsqueeze(0)  # (out, in)
+    sum_W = Wc.sum(dim=1).contiguous()  # (out,)
+    B_const = (Wf @ b_ln.float()).contiguous()  # (out,)
+    wd = weight_dtype if weight_dtype is not None else weight.dtype
+    return Wc.to(wd).contiguous(), sum_W, B_const
+
+
+def absorb_ln_matmul(
+    weight: torch.Tensor,
+    w_ln: torch.Tensor,
+    b_ln: torch.Tensor,
+    *,
+    weight_dtype: torch.dtype | None = None,
+):
+    """Fold LN affine into an (in, out) matmul-convention weight (y = LN(x) @ W).
+
+    Returns: Wc (in, out)[weight_dtype], sum_W (out,)[fp32], B_const (out,)[fp32].
+    """
+    Wf = weight.float()
+    Wc = Wf * w_ln.float().unsqueeze(-1)  # (in, out)
+    sum_W = Wc.sum(dim=0).contiguous()  # (out,)
+    B_const = (b_ln.float() @ Wf).contiguous()  # (out,)
+    wd = weight_dtype if weight_dtype is not None else weight.dtype
+    return Wc.to(wd).contiguous(), sum_W, B_const

--- a/src/kfold/utils/kernels/triton/attention_pair_bias/__init__.py
+++ b/src/kfold/utils/kernels/triton/attention_pair_bias/__init__.py
@@ -1,0 +1,10 @@
+from .dispatch import triton_attention_pair_bias
+from .kernels import apb_diffusion_forward
+from .ops import gated_output_projection_bhld, gated_output_projection_blc
+
+__all__ = [
+    "apb_diffusion_forward",
+    "gated_output_projection_bhld",
+    "gated_output_projection_blc",
+    "triton_attention_pair_bias",
+]

--- a/src/kfold/utils/kernels/triton/attention_pair_bias/dispatch.py
+++ b/src/kfold/utils/kernels/triton/attention_pair_bias/dispatch.py
@@ -1,0 +1,458 @@
+import math
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from cuequivariance_ops_torch.attention_pair_bias_torch import (
+        attention_pair_bias_mask as cueq_attention_pair_bias_mask,
+    )
+except ImportError:
+    cueq_attention_pair_bias_mask = None
+
+from .._common.layouts import interleave_qkv
+from .kernels import apb_diffusion_forward as triton_apb_forward
+from .ops import gated_output_projection_blc
+
+_TRITON_GLOBAL_FUSED_MAX_LENGTH = 64
+_TRITON_GLOBAL_MAX_LENGTH = 608
+_TRITON_LOCAL_TRUE_EPILOGUE_MIN_WINDOWS = 80
+_TRITON_CONFIDENCE_EAGER_MAX_LENGTH = 1504
+_TRITON_CONFIDENCE_FUSED_MAX_LENGTH = 1600
+
+
+def _triton_apb_dispatch(
+    call_site: str,
+    query_length: int,
+    *,
+    local_windows: int | None = None,
+) -> tuple[str, bool]:
+    """Return ``(attention mode, true epilogue)`` for a KFold APB call site."""
+    if call_site == "diffusion_global":
+        if query_length <= _TRITON_GLOBAL_FUSED_MAX_LENGTH:
+            return "fused", False
+        if query_length <= _TRITON_GLOBAL_MAX_LENGTH:
+            return "split", False
+        return "cueq_packed_strided", False
+    if call_site == "diffusion_local":
+        if local_windows is None:
+            raise ValueError("diffusion local APB dispatch requires local_windows")
+        return "fused", local_windows >= _TRITON_LOCAL_TRUE_EPILOGUE_MIN_WINDOWS
+    if call_site == "confidence":
+        if query_length <= _TRITON_CONFIDENCE_EAGER_MAX_LENGTH:
+            return "fused", False
+        if query_length <= _TRITON_CONFIDENCE_FUSED_MAX_LENGTH:
+            return "fused", True
+        return "split", False
+    raise ValueError(f"Unknown Triton APB call site: {call_site!r}")
+
+
+def _triton_parameter_key(module, dtype: torch.dtype) -> tuple:
+    parameters = (
+        module.linear_q.weight,
+        module.linear_q.bias,
+        module.linear_k.weight,
+        module.linear_k.bias,
+        module.linear_v.weight,
+        module.linear_v.bias,
+        module.linear_g.weight,
+        module.linear_out.weight,
+    )
+    return (
+        module.linear_q.weight.device.type,
+        module.linear_q.weight.device.index,
+        dtype,
+        module.num_heads,
+        module.head_dim,
+        *(
+            value
+            for parameter in parameters
+            if parameter is not None
+            for value in (
+                parameter.data_ptr(),
+                None if torch.is_inference(parameter) else parameter._version,
+            )
+        ),
+    )
+
+
+def _triton_packed_weights(module, dtype: torch.dtype) -> dict[str, torch.Tensor]:
+    """Pack APB weights once and invalidate the cache after parameter changes."""
+    if interleave_qkv is None:
+        raise ImportError("triton is required for the Triton APB backend")
+    cache_key = _triton_parameter_key(module, dtype)
+    if getattr(module, "_triton_apb_weight_cache_key", None) == cache_key:
+        return module._triton_apb_weight_cache
+
+    device = module.linear_q.weight.device
+
+    def matmul_weight(linear) -> torch.Tensor:
+        return linear.weight.t().to(device=device, dtype=dtype).contiguous()
+
+    wq = matmul_weight(module.linear_q)
+    wk = matmul_weight(module.linear_k)
+    wv = matmul_weight(module.linear_v)
+    w_qkv = interleave_qkv(wq, wk, wv, module.num_heads, module.head_dim)
+    packed = w_qkv.view(
+        module.channel_a,
+        module.num_heads,
+        3,
+        module.head_dim,
+    )
+    bq = module.linear_q.bias
+    if bq is None:
+        bq = torch.zeros(module.channel_a, device=device, dtype=dtype)
+    else:
+        bq = bq.to(device=device, dtype=dtype).contiguous()
+    packed_linear_weight = (
+        torch.cat(
+            (
+                module.linear_q.weight,
+                module.linear_k.weight,
+                module.linear_v.weight,
+            ),
+            dim=0,
+        )
+        .to(device=device, dtype=dtype)
+        .contiguous()
+    )
+
+    def linear_bias(linear) -> torch.Tensor:
+        if linear.bias is None:
+            return torch.zeros(module.channel_a, device=device, dtype=dtype)
+        return linear.bias.to(device=device, dtype=dtype)
+
+    packed_linear_bias = torch.cat(
+        (
+            linear_bias(module.linear_q),
+            linear_bias(module.linear_k),
+            linear_bias(module.linear_v),
+        )
+    ).contiguous()
+    cache = {
+        "w_qkv": w_qkv,
+        "w_qkv_linear": packed_linear_weight,
+        "b_qkv_linear": packed_linear_bias,
+        "w_q": packed[:, :, 0, :]
+        .reshape(module.channel_a, module.channel_a)
+        .contiguous(),
+        "w_kv": packed[:, :, 1:, :]
+        .reshape(module.channel_a, 2 * module.channel_a)
+        .contiguous(),
+        "bq": bq,
+        "wg": matmul_weight(module.linear_g),
+        "wo": matmul_weight(module.linear_out),
+    }
+    module._triton_apb_weight_cache = cache
+    module._triton_apb_weight_cache_key = cache_key
+    return cache
+
+
+def _aligned_batch_shape(shape: torch.Size, ndim: int) -> tuple[int, ...]:
+    if len(shape) > ndim:
+        raise ValueError(f"batch rank {len(shape)} exceeds query batch rank {ndim}")
+    return (1,) * (ndim - len(shape)) + tuple(shape)
+
+
+def _triton_flatten_batches(
+    x_q: torch.Tensor,
+    x_k: torch.Tensor,
+    pair_bias: torch.Tensor,
+    mask: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    tuple[int, ...],
+    tuple[int, ...],
+]:
+    """Flatten KFold batches with compact bias-sharing entries kept adjacent."""
+    if x_q.shape[:-2] != x_k.shape[:-2]:
+        raise ValueError(f"query/key batch dims differ: {x_q.shape} vs {x_k.shape}")
+    query_batch = tuple(x_q.shape[:-2])
+    batch_ndim = len(query_batch)
+    lq, lk = x_q.shape[-2], x_k.shape[-2]
+    if pair_bias.shape[-2:] != (lq, lk):
+        raise ValueError(
+            f"pair bias has wrong attention shape: {pair_bias.shape}, expected {lq}x{lk}"
+        )
+
+    pair_batch = _aligned_batch_shape(pair_bias.shape[:-3], batch_ndim)
+    try:
+        broadcast_batch = torch.broadcast_shapes(query_batch, pair_batch)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"pair bias batch dims are not broadcastable: {query_batch} vs {pair_batch}"
+        ) from exc
+    if tuple(broadcast_batch) != query_batch:
+        raise ValueError("pair bias would expand the query batch dimensions")
+
+    context_axes = [
+        axis
+        for axis, (pair_size, query_size) in enumerate(
+            zip(pair_batch, query_batch, strict=True)
+        )
+        if pair_size == query_size
+    ]
+    multiplicity_axes = [
+        axis
+        for axis, (pair_size, query_size) in enumerate(
+            zip(pair_batch, query_batch, strict=True)
+        )
+        if pair_size == 1 and pair_size != query_size
+    ]
+    ordered_axes = tuple(context_axes + multiplicity_axes)
+    if len(ordered_axes) != batch_ndim:
+        raise ValueError(
+            f"unsupported pair-bias broadcast: query={query_batch}, pair={pair_batch}"
+        )
+
+    def reorder(tensor: torch.Tensor, trailing_dims: int) -> torch.Tensor:
+        return tensor.permute(
+            *ordered_axes,
+            *range(batch_ndim, batch_ndim + trailing_dims),
+        )
+
+    self_attention = (
+        x_q.data_ptr() == x_k.data_ptr()
+        and x_q.shape == x_k.shape
+        and x_q.stride() == x_k.stride()
+    )
+    flat_q = reorder(x_q, 2).reshape(-1, lq, x_q.shape[-1]).contiguous()
+    if self_attention:
+        flat_k = flat_q
+    else:
+        flat_k = reorder(x_k, 2).reshape(-1, lk, x_k.shape[-1]).contiguous()
+
+    heads = pair_bias.shape[-3]
+    pair_bias = pair_bias.reshape(*pair_batch, heads, lq, lk)
+    context_count = math.prod(query_batch[axis] for axis in context_axes)
+    flat_bias = reorder(pair_bias, 3).reshape(context_count, heads, lq, lk)
+    flat_bias = flat_bias.contiguous()
+
+    mask_batch = _aligned_batch_shape(mask.shape[:-1], batch_ndim)
+    try:
+        mask_broadcast_batch = torch.broadcast_shapes(query_batch, mask_batch)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"mask batch dims are not broadcastable: {query_batch} vs {mask_batch}"
+        ) from exc
+    if tuple(mask_broadcast_batch) != query_batch or mask.shape[-1] != lk:
+        raise ValueError(f"mask would expand or has wrong key length: {mask.shape}")
+
+    compact_mask = all(mask_batch[axis] == 1 for axis in multiplicity_axes)
+    if compact_mask:
+        mask_target_batch = tuple(
+            query_batch[axis] if axis in context_axes else 1 for axis in range(batch_ndim)
+        )
+    else:
+        mask_target_batch = query_batch
+    flat_mask = mask.reshape(*mask_batch, lk).expand(*mask_target_batch, lk)
+    flat_mask = reorder(flat_mask, 1).reshape(-1, lk).contiguous()
+
+    ordered_batch = tuple(query_batch[axis] for axis in ordered_axes)
+    return (
+        flat_q,
+        flat_k,
+        flat_bias,
+        flat_mask,
+        ordered_axes,
+        ordered_batch,
+    )
+
+
+def _triton_restore_batches(
+    output: torch.Tensor,
+    original_shape: torch.Size,
+    ordered_axes: tuple[int, ...],
+    ordered_batch: tuple[int, ...],
+) -> torch.Tensor:
+    batch_ndim = len(ordered_axes)
+    inverse_order = tuple(ordered_axes.index(axis) for axis in range(batch_ndim))
+    output = output.reshape(*ordered_batch, *original_shape[-2:])
+    return output.permute(
+        *inverse_order,
+        batch_ndim,
+        batch_ndim + 1,
+    ).reshape(original_shape)
+
+
+def _packed_strided_qkv(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    packed_bias: torch.Tensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Project QKV in one GEMM and return strided BHLD views."""
+    qkv = F.linear(x, packed_weight, packed_bias)
+    qkv = qkv.view(*x.shape[:-1], 3, num_heads, head_dim)
+    return tuple(qkv[..., index, :, :].movedim(-2, -3) for index in range(3))
+
+
+def _cueq_packed_strided_attention_pair_bias(
+    module,
+    x: torch.Tensor,
+    pair_bias: torch.Tensor,
+    mask: torch.Tensor,
+    weights: dict[str, torch.Tensor],
+) -> torch.Tensor:
+    """Keep cuEq bias/SDPA while removing three QKV GEMMs and layout copies."""
+    if cueq_attention_pair_bias_mask is None:
+        raise ImportError("cuequivariance_ops_torch is required for global APB")
+    if pair_bias.shape[0] < 1 or x.shape[0] % pair_bias.shape[0] != 0:
+        raise ValueError(
+            "global APB packed path requires an integer bias multiplicity: "
+            f"x={x.shape}, pair_bias={pair_bias.shape}"
+        )
+    if mask.shape[0] != pair_bias.shape[0]:
+        raise ValueError(
+            "global APB packed path requires a compact mask per bias batch: "
+            f"mask={mask.shape}, pair_bias={pair_bias.shape}"
+        )
+
+    q, k, v = _packed_strided_qkv(
+        x,
+        weights["w_qkv_linear"],
+        weights["b_qkv_linear"],
+        num_heads=module.num_heads,
+        head_dim=module.head_dim,
+    )
+    dense_bias, _ = cueq_attention_pair_bias_mask(
+        pair_bias,
+        mask,
+        None,
+        None,
+        None,
+        None,
+        num_heads=module.num_heads,
+        multiplicity=x.shape[0] // pair_bias.shape[0],
+        inf=module.inf,
+        return_z_proj=False,
+        is_cached_z_proj=True,
+    )
+    with torch.nn.attention.sdpa_kernel(
+        backends=[
+            torch.nn.attention.SDPBackend.CUDNN_ATTENTION,
+            torch.nn.attention.SDPBackend.FLASH_ATTENTION,
+            torch.nn.attention.SDPBackend.EFFICIENT_ATTENTION,
+        ],
+        set_priority=True,
+    ):
+        attention_out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=dense_bias,
+            scale=module.head_dim**-0.5,
+        )
+    attention_out = attention_out.movedim(-3, -2).contiguous().reshape_as(x)
+    return _attention_epilogue(module, x, attention_out)
+
+
+@torch.compiler.disable
+def triton_attention_pair_bias(
+    module,
+    x_q: torch.Tensor,
+    x_k: torch.Tensor,
+    pair_bias: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    call_site: str,
+) -> torch.Tensor:
+    """Run the measured Triton APB policy and restore KFold's batch layout."""
+    if torch.is_grad_enabled():
+        raise RuntimeError("The Triton APB backend is inference-only.")
+    if not x_q.is_cuda:
+        raise RuntimeError("Triton APB requires CUDA tensors")
+
+    local_windows = pair_bias.shape[-4] if call_site == "diffusion_local" else None
+    mode, true_epilogue = _triton_apb_dispatch(
+        call_site,
+        x_q.shape[-2],
+        local_windows=local_windows,
+    )
+    if mode == "cueq_packed_strided" and cueq_attention_pair_bias_mask is None:
+        mode = "split"
+    if torch.is_autocast_enabled(x_q.device.type):
+        compute_dtype = torch.get_autocast_dtype(x_q.device.type)
+    else:
+        compute_dtype = x_q.dtype
+    original_shape = x_q.shape
+    x_q = x_q.to(compute_dtype)
+    x_k = x_k.to(compute_dtype)
+    pair_bias = pair_bias.to(compute_dtype)
+    (
+        flat_q,
+        flat_k,
+        flat_bias,
+        flat_mask,
+        ordered_axes,
+        ordered_batch,
+    ) = _triton_flatten_batches(x_q, x_k, pair_bias, mask)
+    weights = _triton_packed_weights(module, compute_dtype)
+    if mode == "cueq_packed_strided":
+        if flat_q.data_ptr() != flat_k.data_ptr():
+            raise ValueError("global APB packed path requires self attention")
+        output = _cueq_packed_strided_attention_pair_bias(
+            module,
+            flat_q,
+            flat_bias,
+            flat_mask,
+            weights,
+        )
+        return _triton_restore_batches(
+            output,
+            original_shape,
+            ordered_axes,
+            ordered_batch,
+        )
+
+    attention_out = torch.empty_like(flat_q)
+    triton_apb_forward(
+        flat_q,
+        flat_k,
+        weights["w_qkv"],
+        weights["bq"],
+        flat_bias,
+        flat_mask,
+        attention_out,
+        scale=module.head_dim**-0.5,
+        inf=module.inf,
+        mode=mode,
+        fp32_dot_precision="ieee",
+        split_w_q=weights["w_q"] if flat_q.data_ptr() != flat_k.data_ptr() else None,
+        split_w_kv=weights["w_kv"] if flat_q.data_ptr() != flat_k.data_ptr() else None,
+    )
+
+    use_true_epilogue = (
+        true_epilogue and module.linear_g.bias is None and module.linear_out.bias is None
+    )
+    if use_true_epilogue:
+        output = gated_output_projection_blc(
+            flat_q,
+            attention_out,
+            weights["wg"],
+            weights["wo"],
+            fp32_dot_precision="ieee",
+        )
+    else:
+        output = _attention_epilogue(module, flat_q, attention_out)
+    return _triton_restore_batches(
+        output,
+        original_shape,
+        ordered_axes,
+        ordered_batch,
+    )
+
+
+def _attention_epilogue(module, s, attention_out):
+    """Apply the unfused APB gate and output projection under caller autocast."""
+    gate = torch.sigmoid(F.linear(s, module.linear_g.weight, module.linear_g.bias))
+    return F.linear(
+        gate * attention_out.to(gate.dtype),
+        module.linear_out.weight,
+        module.linear_out.bias,
+    )

--- a/src/kfold/utils/kernels/triton/attention_pair_bias/kernels.py
+++ b/src/kfold/utils/kernels/triton/attention_pair_bias/kernels.py
@@ -1,0 +1,592 @@
+"""Triton kernels for attention with a cached pair bias.
+
+Short queries fuse QKV projection with attention; longer queries use a single
+QKV projection followed by attention.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .._common.dtypes import tl_io_dtype
+
+
+@triton.autotune(
+    configs=[
+        # ---- Small BLOCK_M (16) — short query rows, min registers ----
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 32, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 32, "BLOCK_C": 64}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 64, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 64, "BLOCK_C": 64}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 128, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_K": 128, "BLOCK_C": 64}, num_warps=8, num_stages=2
+        ),
+        # ---- Medium BLOCK_M (32) — one program per atom window (Lq=32) ----
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 32, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 32, "BLOCK_C": 32}, num_warps=4, num_stages=3
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 32, "BLOCK_C": 64}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 64, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 64, "BLOCK_C": 64}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 64, "BLOCK_C": 64}, num_warps=8, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 64, "BLOCK_C": 128}, num_warps=8, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_K": 128, "BLOCK_C": 32}, num_warps=8, num_stages=2
+        ),
+        # ---- Large BLOCK_M (64) — token lengths: fewer K/V re-projections ----
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_K": 32, "BLOCK_C": 32}, num_warps=4, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_K": 32, "BLOCK_C": 64}, num_warps=8, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_K": 64, "BLOCK_C": 32}, num_warps=8, num_stages=2
+        ),
+        # Do not add BLOCK_M/K/C=64/64/64 with 8 warps here. On H100 with
+        # Triton 3.7.0 both stage-2 and stage-3 variants pass a single launch,
+        # but reproducibly illegal-address during triton.autotune's repeated
+        # local-APB benchmark (MQ/MK/N/H/D=32/128/128/4/32, BF16).
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_K": 64, "BLOCK_C": 128}, num_warps=8, num_stages=2
+        ),
+        # ---- XL BLOCK_M (128) — long token rows; recompute amortized hardest ----
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_K": 32, "BLOCK_C": 64}, num_warps=8, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_K": 64, "BLOCK_C": 32}, num_warps=8, num_stages=2
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_K": 64, "BLOCK_C": 64}, num_warps=8, num_stages=2
+        ),
+    ],
+    key=["MQ", "MK", "N", "H", "D"],
+)
+@triton.jit
+def _apb_fused_qkv_attention_kernel(
+    AQ_ptr,
+    AQ_stride0,
+    AQ_stride1,
+    AQ_stride2,  # (B, MQ, N) normalized query-side input
+    AK_ptr,
+    AK_stride0,
+    AK_stride1,
+    AK_stride2,  # (B, MK, N) normalized key/value-side input
+    Wqkv_ptr,
+    Wqkv_stride0,
+    Wqkv_stride1,  # (N, 3*H*D) concat: per-head [Q | K | V]
+    Bq_ptr,
+    Bq_stride0,  # (H*D,) linear_q bias (K/V projections have none)
+    Z_ptr,
+    Z_stride0,
+    Z_stride1,
+    Z_stride2,
+    Z_stride3,  # (B/Z_MULT, H, MQ, MK) cached projected pair bias
+    Msk_ptr,
+    Msk_stride0,
+    Msk_stride1,  # (B/MSK_MULT, MK) key mask (nonzero = attend); unused if not HAS_MASK
+    Og_ptr,
+    Og_stride0,
+    Og_stride1,
+    Og_stride2,  # (B, MQ, H*D) attention output (pre-gate, pre-Wo)
+    MQ: tl.constexpr,
+    MK: tl.constexpr,
+    N: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,  # next_pow2(D); d_offs >= D lanes are masked to 0
+    Z_MULT: tl.constexpr,  # batch entries sharing one Z batch slot
+    MSK_MULT: tl.constexpr,  # batch entries sharing one mask row
+    HAS_MASK: tl.constexpr,
+    SCALE: tl.constexpr,
+    INF: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    DOT_INPUT_PRECISION: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_b = tl.program_id(2)
+
+    q_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, BLOCK_D)
+    q_mask = q_offs < MQ
+    d_mask = d_offs < D
+
+    qkv_base = 3 * pid_h * D
+    head_col = pid_h * D + d_offs
+
+    AQ_b = AQ_ptr + pid_b * AQ_stride0
+    AK_b = AK_ptr + pid_b * AK_stride0
+    Z_bh = Z_ptr + (pid_b // Z_MULT) * Z_stride0 + pid_h * Z_stride1
+    Msk_b = Msk_ptr + (pid_b // MSK_MULT) * Msk_stride0
+
+    # --- Q projection: Q = A_q @ WQ_h + bq_h, streamed over BLOCK_C chunks ---
+    Q_acc = tl.zeros((BLOCK_M, BLOCK_D), dtype=tl.float32)
+    for c_start in range(0, N, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < N
+        X_q = tl.load(
+            AQ_b + q_offs[:, None] * AQ_stride1 + c_offs[None, :] * AQ_stride2,
+            mask=q_mask[:, None] & c_mask[None, :],
+            other=0.0,
+        )
+        WQ_c = tl.load(
+            Wqkv_ptr
+            + c_offs[:, None] * Wqkv_stride0
+            + (qkv_base + d_offs)[None, :] * Wqkv_stride1,
+            mask=c_mask[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+        Q_acc += tl.dot(X_q, WQ_c, input_precision=DOT_INPUT_PRECISION)
+    Bq_h = tl.load(Bq_ptr + head_col * Bq_stride0, mask=d_mask, other=0.0).to(tl.float32)
+    Q_io = (Q_acc + Bq_h[None, :]).to(IO_DTYPE)
+
+    m_i = tl.full((BLOCK_M,), -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    O_acc = tl.zeros((BLOCK_M, BLOCK_D), dtype=tl.float32)
+
+    for k_start in range(0, MK, BLOCK_K):
+        k_offs = k_start + tl.arange(0, BLOCK_K)
+        k_mask = k_offs < MK
+
+        # --- K/V projection for this key block (recomputed per q_block) ---
+        K_acc = tl.zeros((BLOCK_K, BLOCK_D), dtype=tl.float32)
+        V_acc = tl.zeros((BLOCK_K, BLOCK_D), dtype=tl.float32)
+        for c_start in range(0, N, BLOCK_C):
+            c_offs = c_start + tl.arange(0, BLOCK_C)
+            c_mask = c_offs < N
+            X_k = tl.load(
+                AK_b + k_offs[:, None] * AK_stride1 + c_offs[None, :] * AK_stride2,
+                mask=k_mask[:, None] & c_mask[None, :],
+                other=0.0,
+            )
+            WK_c = tl.load(
+                Wqkv_ptr
+                + c_offs[:, None] * Wqkv_stride0
+                + (qkv_base + D + d_offs)[None, :] * Wqkv_stride1,
+                mask=c_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            WV_c = tl.load(
+                Wqkv_ptr
+                + c_offs[:, None] * Wqkv_stride0
+                + (qkv_base + 2 * D + d_offs)[None, :] * Wqkv_stride1,
+                mask=c_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            K_acc += tl.dot(X_k, WK_c, input_precision=DOT_INPUT_PRECISION)
+            V_acc += tl.dot(X_k, WV_c, input_precision=DOT_INPUT_PRECISION)
+        K_io = K_acc.to(IO_DTYPE)
+        V_io = V_acc.to(IO_DTYPE)
+
+        S = (
+            tl.dot(Q_io, tl.trans(K_io), input_precision=DOT_INPUT_PRECISION).to(
+                tl.float32
+            )
+            * SCALE
+        )
+
+        bias_tile = tl.load(
+            Z_bh + q_offs[:, None] * Z_stride2 + k_offs[None, :] * Z_stride3,
+            mask=q_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+
+        # attn_bias = pair_bias + (~mask) * (-INF): FINITE (matches the additive
+        # -1e9 upstream), so an all-masked row stays NaN-free; only the k >= MK
+        # padding uses a true -inf (never a whole block, so m_i stays finite).
+        if HAS_MASK:
+            key_valid = tl.load(Msk_b + k_offs * Msk_stride1, mask=k_mask, other=0) != 0
+            bias_tile += tl.where(key_valid, 0.0, -INF)[None, :]
+        S += bias_tile
+        S = tl.where(k_mask[None, :], S, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(S, axis=1))
+        alpha = tl.exp(m_i - m_new)
+        P = tl.exp(S - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(P, axis=1)
+        O_acc = O_acc * alpha[:, None] + tl.dot(
+            P.to(IO_DTYPE), V_io, input_precision=DOT_INPUT_PRECISION
+        ).to(tl.float32)
+        m_i = m_new
+
+    Out = O_acc / l_i[:, None]
+    tl.store(
+        Og_ptr
+        + pid_b * Og_stride0
+        + q_offs[:, None] * Og_stride1
+        + head_col[None, :] * Og_stride2,
+        Out.to(IO_DTYPE),
+        mask=q_mask[:, None] & d_mask[None, :],
+    )
+
+
+@triton.autotune(
+    configs=[
+        # No projection inside: register pressure is just Q/K/V/S tiles, so
+        # larger BLOCK_M/BLOCK_K are viable than in the fused kernel.
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 128}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 128}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["MQ", "MK", "H", "D"],
+)
+@triton.jit
+def _apb_split_attention_kernel(
+    Q_ptr,
+    Q_stride0,
+    Q_stride1,
+    Q_stride2,
+    Q_stride3,  # (B, MQ, H, D) pre-projected, possibly strided view of a QKV GEMM
+    K_ptr,
+    K_stride0,
+    K_stride1,
+    K_stride2,
+    K_stride3,  # (B, MK, H, D)
+    V_ptr,
+    V_stride0,
+    V_stride1,
+    V_stride2,
+    V_stride3,  # (B, MK, H, D)
+    Bq_ptr,
+    Bq_stride0,  # (H*D,) linear_q bias, added to the loaded Q tile
+    Z_ptr,
+    Z_stride0,
+    Z_stride1,
+    Z_stride2,
+    Z_stride3,  # (B/Z_MULT, H, MQ, MK) cached projected pair bias
+    Msk_ptr,
+    Msk_stride0,
+    Msk_stride1,  # (B/MSK_MULT, MK) key mask; unused if not HAS_MASK
+    Og_ptr,
+    Og_stride0,
+    Og_stride1,
+    Og_stride2,  # (B, MQ, H*D)
+    MQ: tl.constexpr,
+    MK: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    Z_MULT: tl.constexpr,
+    MSK_MULT: tl.constexpr,
+    HAS_MASK: tl.constexpr,
+    SCALE: tl.constexpr,
+    INF: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    DOT_INPUT_PRECISION: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_b = tl.program_id(2)
+
+    q_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, BLOCK_D)
+    q_mask = q_offs < MQ
+    d_mask = d_offs < D
+
+    head_col = pid_h * D + d_offs
+
+    Q_bh = Q_ptr + pid_b * Q_stride0 + pid_h * Q_stride2
+    K_bh = K_ptr + pid_b * K_stride0 + pid_h * K_stride2
+    V_bh = V_ptr + pid_b * V_stride0 + pid_h * V_stride2
+    Z_bh = Z_ptr + (pid_b // Z_MULT) * Z_stride0 + pid_h * Z_stride1
+    Msk_b = Msk_ptr + (pid_b // MSK_MULT) * Msk_stride0
+
+    Q_tile = tl.load(
+        Q_bh + q_offs[:, None] * Q_stride1 + d_offs[None, :] * Q_stride3,
+        mask=q_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    Bq_h = tl.load(Bq_ptr + head_col * Bq_stride0, mask=d_mask, other=0.0).to(tl.float32)
+    Q_io = (Q_tile + Bq_h[None, :]).to(IO_DTYPE)
+
+    m_i = tl.full((BLOCK_M,), -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    O_acc = tl.zeros((BLOCK_M, BLOCK_D), dtype=tl.float32)
+
+    for k_start in range(0, MK, BLOCK_K):
+        k_offs = k_start + tl.arange(0, BLOCK_K)
+        k_mask = k_offs < MK
+
+        kv_mask = k_mask[:, None] & d_mask[None, :]
+        K_io = tl.load(
+            K_bh + k_offs[:, None] * K_stride1 + d_offs[None, :] * K_stride3,
+            mask=kv_mask,
+            other=0.0,
+        ).to(IO_DTYPE)
+        V_io = tl.load(
+            V_bh + k_offs[:, None] * V_stride1 + d_offs[None, :] * V_stride3,
+            mask=kv_mask,
+            other=0.0,
+        ).to(IO_DTYPE)
+
+        S = (
+            tl.dot(Q_io, tl.trans(K_io), input_precision=DOT_INPUT_PRECISION).to(
+                tl.float32
+            )
+            * SCALE
+        )
+
+        bias_tile = tl.load(
+            Z_bh + q_offs[:, None] * Z_stride2 + k_offs[None, :] * Z_stride3,
+            mask=q_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        if HAS_MASK:
+            key_valid = tl.load(Msk_b + k_offs * Msk_stride1, mask=k_mask, other=0) != 0
+            bias_tile += tl.where(key_valid, 0.0, -INF)[None, :]
+        S += bias_tile
+        S = tl.where(k_mask[None, :], S, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(S, axis=1))
+        alpha = tl.exp(m_i - m_new)
+        P = tl.exp(S - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(P, axis=1)
+        O_acc = O_acc * alpha[:, None] + tl.dot(
+            P.to(IO_DTYPE), V_io, input_precision=DOT_INPUT_PRECISION
+        ).to(tl.float32)
+        m_i = m_new
+
+    Out = O_acc / l_i[:, None]
+    tl.store(
+        Og_ptr
+        + pid_b * Og_stride0
+        + q_offs[:, None] * Og_stride1
+        + head_col[None, :] * Og_stride2,
+        Out.to(IO_DTYPE),
+        mask=q_mask[:, None] & d_mask[None, :],
+    )
+
+
+# Above this many query rows the fused kernel's per-q_block K/V re-projection
+# (ceil(MQ/BLOCK_M) duplicates) outweighs one QKV GEMM + HBM round trip.
+_SPLIT_MQ_THRESHOLD = 128
+
+
+def _apb_split_qkv_projection(A_q, A_k, W_QKV, H, D, W_Q=None, W_KV=None):
+    """Project QKV once and return (B, L, H, D) views."""
+    N = A_q.shape[-1]
+    if (
+        A_q.data_ptr() == A_k.data_ptr()
+        and A_q.shape == A_k.shape
+        and A_q.stride() == A_k.stride()
+    ):
+        # Self attention: one dense GEMM, then strided per-head [Q|K|V] views.
+        qkv = A_q @ W_QKV  # (B, L, 3*H*D)
+        qkv = qkv.view(*qkv.shape[:-1], H, 3, D)
+        return qkv[..., 0, :], qkv[..., 1, :], qkv[..., 2, :]
+    if W_Q is not None or W_KV is not None:
+        if W_Q is None or W_KV is None:
+            raise ValueError("cross-attention split requires both W_Q and W_KV")
+        if W_Q.shape != (N, H * D) or W_KV.shape != (N, 2 * H * D):
+            raise ValueError(
+                "invalid packed cross-attention weights: expected "
+                f"{(N, H * D)} and {(N, 2 * H * D)}, got "
+                f"{W_Q.shape} and {W_KV.shape}"
+            )
+        q = (A_q @ W_Q).view(*A_q.shape[:-1], H, D)
+        kv = (A_k @ W_KV).view(*A_k.shape[:-1], H, 2, D)
+        return q, kv[..., 0, :], kv[..., 1, :]
+
+    # Compatibility fallback. Production callers should pre-pack W_Q/W_KV
+    # once; these slices otherwise copy weights and launch three GEMMs.
+    W = W_QKV.view(N, H, 3, D)
+    q = (A_q @ W[:, :, 0, :].reshape(N, H * D)).view(*A_q.shape[:-1], H, D)
+    k = (A_k @ W[:, :, 1, :].reshape(N, H * D)).view(*A_k.shape[:-1], H, D)
+    v = (A_k @ W[:, :, 2, :].reshape(N, H * D)).view(*A_k.shape[:-1], H, D)
+    return q, k, v
+
+
+def apb_diffusion_forward(
+    A_q,
+    A_k,
+    W_QKV,
+    B_q,
+    Z,
+    key_mask,
+    Og,
+    scale=1.0,
+    inf=1e9,
+    mode="auto",
+    fp32_dot_precision="ieee",
+    split_w_q=None,
+    split_w_kv=None,
+):
+    """Write cached-pair-bias attention output to Og.
+
+    mode selects fused or split QKV projection. Z and key_mask may broadcast over
+    consecutive batch groups.
+    """
+    if A_q.ndim == 2:
+        A_q, A_k = A_q.unsqueeze(0), A_k.unsqueeze(0)
+    if Z.ndim == 3:
+        Z = Z.unsqueeze(0)
+
+    B, MQ, N = A_q.shape
+    MK = A_k.shape[1]
+    H = Z.shape[1]
+    D = W_QKV.shape[1] // (3 * H)
+    assert A_k.shape == (B, MK, N)
+    assert W_QKV.shape == (N, 3 * H * D)
+    assert B_q.shape == (H * D,)
+    assert Z.shape == (Z.shape[0], H, MQ, MK) and B % Z.shape[0] == 0
+    assert Og.shape == (B, MQ, H * D)
+    assert D >= 16, "tl.dot needs head_dim >= 16"
+    if fp32_dot_precision not in ("ieee", "tf32"):
+        raise ValueError(
+            f"fp32_dot_precision must be 'ieee' or 'tf32', got {fp32_dot_precision!r}"
+        )
+
+    if key_mask is None:
+        # No mask: point the mask args at Z with zero strides; never loaded.
+        has_mask, msk_mult = False, 1
+        key_mask, msk_stride0, msk_stride1 = Z, 0, 0
+    else:
+        if key_mask.ndim == 1:
+            key_mask = key_mask.unsqueeze(0)
+        if key_mask.dtype == torch.bool:
+            key_mask = key_mask.to(torch.uint8)
+        assert key_mask.shape == (key_mask.shape[0], MK) and B % key_mask.shape[0] == 0
+        has_mask, msk_mult = True, B // key_mask.shape[0]
+        msk_stride0, msk_stride1 = key_mask.stride(0), key_mask.stride(1)
+
+    if mode == "auto":
+        mode = "fused" if MQ <= _SPLIT_MQ_THRESHOLD else "split"
+
+    def grid(meta):
+        return (triton.cdiv(MQ, meta["BLOCK_M"]), H, B)
+
+    common = dict(
+        MQ=MQ,
+        MK=MK,
+        H=H,
+        D=D,
+        BLOCK_D=triton.next_power_of_2(D),
+        Z_MULT=B // Z.shape[0],
+        MSK_MULT=msk_mult,
+        HAS_MASK=has_mask,
+        SCALE=scale,
+        INF=inf,
+        IO_DTYPE=tl_io_dtype(A_q.dtype),
+        # KFold and AtlasFold inference use "highest" FP32 matmul precision.
+        # Keep BF16/FP16 on tensor cores, but do not silently lower FP32 APB
+        # to TF32 inside Triton.
+        DOT_INPUT_PRECISION=(
+            fp32_dot_precision if A_q.dtype == torch.float32 else "tf32"
+        ),
+    )
+    if mode == "fused":
+        _apb_fused_qkv_attention_kernel[grid](
+            A_q,
+            A_q.stride(0),
+            A_q.stride(1),
+            A_q.stride(2),
+            A_k,
+            A_k.stride(0),
+            A_k.stride(1),
+            A_k.stride(2),
+            W_QKV,
+            W_QKV.stride(0),
+            W_QKV.stride(1),
+            B_q,
+            B_q.stride(0),
+            Z,
+            Z.stride(0),
+            Z.stride(1),
+            Z.stride(2),
+            Z.stride(3),
+            key_mask,
+            msk_stride0,
+            msk_stride1,
+            Og,
+            Og.stride(0),
+            Og.stride(1),
+            Og.stride(2),
+            N=N,
+            **common,
+        )
+    elif mode == "split":
+        q, k, v = _apb_split_qkv_projection(
+            A_q,
+            A_k,
+            W_QKV,
+            H,
+            D,
+            W_Q=split_w_q,
+            W_KV=split_w_kv,
+        )  # (B, L, H, D) views
+        _apb_split_attention_kernel[grid](
+            q,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k,
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v,
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            B_q,
+            B_q.stride(0),
+            Z,
+            Z.stride(0),
+            Z.stride(1),
+            Z.stride(2),
+            Z.stride(3),
+            key_mask,
+            msk_stride0,
+            msk_stride1,
+            Og,
+            Og.stride(0),
+            Og.stride(1),
+            Og.stride(2),
+            **common,
+        )
+    else:
+        raise ValueError(f"unknown mode {mode!r}; expected 'auto', 'fused', or 'split'")
+    return Og

--- a/src/kfold/utils/kernels/triton/attention_pair_bias/ops.py
+++ b/src/kfold/utils/kernels/triton/attention_pair_bias/ops.py
@@ -1,0 +1,262 @@
+"""Triton epilogues for attention-pair-bias output projection."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from .._common.dtypes import tl_io_dtype
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_M": 16, "BLOCK_N": 32, "BLOCK_K": 32},
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 32},
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_warps=4,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_warps=4,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32},
+            num_warps=8,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_warps=8,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32},
+            num_warps=8,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64},
+            num_warps=8,
+            num_stages=2,
+        ),
+    ],
+    key=["M", "N", "K", "ATTENTION_BHLD", "IO_DTYPE", "DOT_INPUT_PRECISION"],
+)
+@triton.jit
+def _gated_output_projection_kernel(
+    gate_logits_ptr,
+    attention_ptr,
+    weight_ptr,
+    output_ptr,
+    attention_stride_b,
+    attention_stride_h,
+    attention_stride_l,
+    attention_stride_d,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    LENGTH: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    ATTENTION_BHLD: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    DOT_INPUT_PRECISION: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    m_offsets = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_offsets = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_start in range(0, K, BLOCK_K):
+        k_offsets = k_start + tl.arange(0, BLOCK_K)
+        input_mask = (m_offsets[:, None] < M) & (k_offsets[None, :] < K)
+        gate_logits = tl.load(
+            gate_logits_ptr + m_offsets[:, None] * K + k_offsets[None, :],
+            mask=input_mask,
+            other=0.0,
+        ).to(tl.float32)
+
+        if ATTENTION_BHLD:
+            batch_offsets = m_offsets // LENGTH
+            length_offsets = m_offsets % LENGTH
+            head_offsets = k_offsets // HEAD_DIM
+            dim_offsets = k_offsets % HEAD_DIM
+            attention = tl.load(
+                attention_ptr
+                + batch_offsets[:, None] * attention_stride_b
+                + head_offsets[None, :] * attention_stride_h
+                + length_offsets[:, None] * attention_stride_l
+                + dim_offsets[None, :] * attention_stride_d,
+                mask=input_mask,
+                other=0.0,
+            )
+        else:
+            attention = tl.load(
+                attention_ptr + m_offsets[:, None] * K + k_offsets[None, :],
+                mask=input_mask,
+                other=0.0,
+            )
+
+        gate = 1.0 / (1.0 + tl.exp(-gate_logits))
+        gated = (gate * attention.to(tl.float32)).to(IO_DTYPE)
+        weight = tl.load(
+            weight_ptr + k_offsets[:, None] * N + n_offsets[None, :],
+            mask=(k_offsets[:, None] < K) & (n_offsets[None, :] < N),
+            other=0.0,
+        )
+        accumulator += tl.dot(
+            gated,
+            weight,
+            input_precision=DOT_INPUT_PRECISION,
+        ).to(tl.float32)
+
+    tl.store(
+        output_ptr + m_offsets[:, None] * N + n_offsets[None, :],
+        accumulator.to(IO_DTYPE),
+        mask=(m_offsets[:, None] < M) & (n_offsets[None, :] < N),
+    )
+
+
+def _validate_projection_inputs(
+    x: torch.Tensor,
+    attention: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_out: torch.Tensor,
+) -> None:
+    if not x.is_cuda:
+        raise RuntimeError("APB fused epilogue requires CUDA tensors")
+    if x.ndim != 3 or not x.is_contiguous():
+        raise ValueError(f"x must be contiguous BLC, got {x.shape} {x.stride()}")
+    channel = x.shape[-1]
+    if w_gate.shape != (channel, channel) or w_out.shape != (channel, channel):
+        raise ValueError(
+            "gate/output weights must use matmul convention (C, C), got "
+            f"{w_gate.shape} and {w_out.shape} for C={channel}"
+        )
+    tensors = (attention, w_gate, w_out)
+    if any(tensor.device != x.device for tensor in tensors):
+        raise ValueError("attention and projection weights must share x.device")
+    if any(tensor.dtype != x.dtype for tensor in tensors):
+        raise ValueError("attention and projection weights must share x.dtype")
+    if not w_gate.is_contiguous() or not w_out.is_contiguous():
+        raise ValueError("projection weights must be contiguous")
+
+
+def _gated_output_projection(
+    x: torch.Tensor,
+    attention: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_out: torch.Tensor,
+    *,
+    attention_bhld: bool,
+    fp32_dot_precision: str,
+) -> torch.Tensor:
+    _validate_projection_inputs(x, attention, w_gate, w_out)
+    if fp32_dot_precision not in {"ieee", "tf32"}:
+        raise ValueError(f"unsupported FP32 dot precision {fp32_dot_precision!r}")
+
+    batch, length, channel = x.shape
+    if attention_bhld:
+        if (
+            attention.ndim != 4
+            or attention.shape[0] != batch
+            or attention.shape[2] != length
+        ):
+            raise ValueError(f"attention must be BHLD for gate shape {x.shape}")
+        heads, head_dim = attention.shape[1], attention.shape[3]
+        if heads * head_dim != channel:
+            raise ValueError(
+                f"attention H*D must equal C, got {heads}*{head_dim} != {channel}"
+            )
+        attention_strides = attention.stride()
+    else:
+        if attention.shape != x.shape or not attention.is_contiguous():
+            raise ValueError(
+                f"attention must be contiguous BLC with x shape, got {attention.shape} "
+                f"{attention.stride()}"
+            )
+        head_dim = channel
+        attention_strides = (0, 0, 0, 0)
+
+    gate_logits = x @ w_gate
+    output = torch.empty_like(x)
+    rows = batch * length
+
+    def grid(meta):
+        return (
+            triton.cdiv(rows, meta["BLOCK_M"]),
+            triton.cdiv(channel, meta["BLOCK_N"]),
+        )
+
+    _gated_output_projection_kernel[grid](
+        gate_logits,
+        attention,
+        w_out,
+        output,
+        *attention_strides,
+        M=rows,
+        N=channel,
+        K=channel,
+        LENGTH=length,
+        HEAD_DIM=head_dim,
+        ATTENTION_BHLD=attention_bhld,
+        IO_DTYPE=tl_io_dtype(x.dtype),
+        DOT_INPUT_PRECISION=(fp32_dot_precision if x.dtype == torch.float32 else "tf32"),
+    )
+    return output
+
+
+def gated_output_projection_blc(
+    x: torch.Tensor,
+    attention: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_out: torch.Tensor,
+    *,
+    fp32_dot_precision: str = "ieee",
+) -> torch.Tensor:
+    """Apply gating and output projection to BLC attention output."""
+    return _gated_output_projection(
+        x,
+        attention,
+        w_gate,
+        w_out,
+        attention_bhld=False,
+        fp32_dot_precision=fp32_dot_precision,
+    )
+
+
+def gated_output_projection_bhld(
+    x: torch.Tensor,
+    attention: torch.Tensor,
+    w_gate: torch.Tensor,
+    w_out: torch.Tensor,
+    *,
+    fp32_dot_precision: str = "ieee",
+) -> torch.Tensor:
+    """Apply gating and output projection directly to BHLD attention output."""
+    return _gated_output_projection(
+        x,
+        attention,
+        w_gate,
+        w_out,
+        attention_bhld=True,
+        fp32_dot_precision=fp32_dot_precision,
+    )
+
+
+__all__ = ["gated_output_projection_bhld", "gated_output_projection_blc"]

--- a/src/kfold/utils/kernels/triton/triangle_attention/__init__.py
+++ b/src/kfold/utils/kernels/triton/triangle_attention/__init__.py
@@ -1,0 +1,4 @@
+from .kernels import triangle_attn_forward
+from .ops import forward, precompute, triangle_attention
+
+__all__ = ["triangle_attention", "precompute", "forward", "triangle_attn_forward"]

--- a/src/kfold/utils/kernels/triton/triangle_attention/kernels.py
+++ b/src/kfold/utils/kernels/triton/triangle_attention/kernels.py
@@ -1,0 +1,565 @@
+"""Triton kernels for triangle attention.
+
+The implementation materializes shared pair bias once, fuses QKV projection
+with attention, and uses a separate gated epilogue.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .._common.dtypes import tl_io_dtype
+
+
+# ===========================================================================
+# Kernel 1: bias projection  (LN(x) + W_proj_z → Bp (H, N, N), materialized once)
+# ===========================================================================
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_QK": 32}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_QK": 64}, num_warps=2, num_stages=2),
+        triton.Config({"BLOCK_QK": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_QK": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_QK": 128}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_QK": 256}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_QK": 256}, num_warps=4, num_stages=2),
+    ],
+    key=["N", "C_in", "H"],
+)
+@triton.jit
+def bias_proj_kernel(
+    X_ptr,
+    X_strideB,
+    X_stride0,
+    X_stride1,
+    X_stride2,
+    WZ_ptr,
+    WZ_stride0,
+    WZ_stride1,
+    BZ_ptr,
+    BZ_stride0,
+    Bias_ptr,
+    Bias_strideB,
+    Bias_stride0,
+    Bias_stride1,
+    Bias_stride2,
+    B: tl.constexpr,
+    N: tl.constexpr,
+    C_in: tl.constexpr,
+    H: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    USE_INT64: tl.constexpr,
+    BLOCK_QK: tl.constexpr,
+):
+    # X is the pre-normalized x̃ = LN(x); bias[h,q,k] = Σ_c x̃[q,k,c]·WZ[h,c] + BZ[h].
+    # Grid is (batched_qk_blocks, H) so qk_blocks (large for big N) uses x dim,
+    # avoiding the 65535 CUDA y-dim limit at N ≥ 1536 with small BLOCK_QK.
+    pid_qk = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    global_qk_offs = pid_qk * BLOCK_QK + tl.arange(0, BLOCK_QK)
+    c_offs = tl.arange(0, C_in)
+    qk_mask = global_qk_offs < (B * N * N)
+
+    b_idx = global_qk_offs // (N * N)
+    qk_offs = global_qk_offs % (N * N)
+    q_idx = qk_offs // N
+    k_idx = qk_offs % N
+    b_ptr_idx = b_idx.to(tl.int64) if USE_INT64 else b_idx
+    q_ptr_idx = q_idx.to(tl.int64) if USE_INT64 else q_idx
+    k_ptr_idx = k_idx.to(tl.int64) if USE_INT64 else k_idx
+
+    X_tile = tl.load(
+        X_ptr
+        + b_ptr_idx[:, None] * X_strideB
+        + q_ptr_idx[:, None] * X_stride0
+        + k_ptr_idx[:, None] * X_stride1
+        + c_offs[None, :] * X_stride2,
+        mask=qk_mask[:, None],
+        other=0.0,
+    )
+    X_fp32 = X_tile.to(tl.float32)
+
+    w_z = tl.load(WZ_ptr + pid_h * WZ_stride0 + c_offs * WZ_stride1)
+    BZ_h = tl.load(BZ_ptr + pid_h * BZ_stride0)
+
+    bias = tl.sum(X_fp32 * w_z[None, :], axis=-1) + BZ_h
+
+    tl.store(
+        Bias_ptr
+        + b_ptr_idx * Bias_strideB
+        + pid_h * Bias_stride0
+        + q_ptr_idx * Bias_stride1
+        + k_ptr_idx * Bias_stride2,
+        bias.to(IO_DTYPE),
+        mask=qk_mask,
+    )
+
+
+# ===========================================================================
+# Kernel 2: triangle attention with K/V concat (+ tl.split)
+#
+# D=16 uses a separate-WK/WV specialization.  Triton's reshape/split lowering
+# for the interleaved (BLOCK_K, D, 2) accumulator is not memory-safe for that
+# shape on Hopper (it can fail during autotuning with an illegal memory access).
+# Keeping this as a constexpr branch preserves the existing D>=32 generated
+# kernel while giving the K-Fold Apo module a fully Triton implementation.
+# ===========================================================================
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 16, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=8, num_stages=3),
+    ],
+    key=["N", "C_in", "H", "D"],
+)
+@triton.jit
+def triangle_attn_kernel(
+    X_ptr,
+    X_strideB,
+    X_stride0,
+    X_stride1,
+    X_stride2,
+    WQ_ptr,
+    WQ_stride0,
+    WQ_stride1,  # (C_in, H*D)
+    WKV_ptr,
+    WKV_stride0,
+    WKV_stride1,  # (C_in, 2*H*D) feature-interleaved per head
+    WK_ptr,
+    WK_stride0,
+    WK_stride1,  # (C_in, H*D), used iff SEPARATE_KV
+    WV_ptr,
+    WV_stride0,
+    WV_stride1,  # (C_in, H*D), used iff SEPARATE_KV
+    Bias_ptr,
+    Bias_strideB,
+    Bias_stride0,
+    Bias_stride1,
+    Bias_stride2,  # (H, N, N)
+    Mask_ptr,
+    Mask_strideB,
+    Mask_stride0,
+    Mask_stride1,
+    O_ptr,
+    O_strideB,
+    O_stride0,
+    O_stride1,
+    O_stride2,  # (N, N, H*D)
+    N: tl.constexpr,
+    C_in: tl.constexpr,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    SCALE: tl.constexpr,
+    NEG_INF: tl.constexpr,
+    HAS_MASK: tl.constexpr,
+    SEPARATE_KV: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    USE_INT64: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    # X is the pre-normalized x̃ = LN(x); Q/K/V are plain projections of x̃.
+    pid_bn = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    pid_m = tl.program_id(2)
+    pid_b = pid_bn // N
+    pid_n = pid_bn % N
+    pid_b_ptr = pid_b.to(tl.int64) if USE_INT64 else pid_b
+
+    q_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, D)
+    kv_cols = pid_h * 2 * D + tl.arange(0, 2 * D)
+    c_offs = tl.arange(0, C_in)
+    head_col = pid_h * D + d_offs
+    q_mask = q_offs < N
+
+    X_q = tl.load(
+        X_ptr
+        + pid_b_ptr * X_strideB
+        + pid_n * X_stride0
+        + q_offs[:, None] * X_stride1
+        + c_offs[None, :] * X_stride2,
+        mask=q_mask[:, None],
+        other=0.0,
+    )
+
+    WQ_h = tl.load(WQ_ptr + c_offs[:, None] * WQ_stride0 + head_col[None, :] * WQ_stride1)
+    if SEPARATE_KV:
+        WK_h = tl.load(
+            WK_ptr + c_offs[:, None] * WK_stride0 + head_col[None, :] * WK_stride1
+        )
+        WV_h = tl.load(
+            WV_ptr + c_offs[:, None] * WV_stride0 + head_col[None, :] * WV_stride1
+        )
+    else:
+        WKV_h = tl.load(
+            WKV_ptr + c_offs[:, None] * WKV_stride0 + kv_cols[None, :] * WKV_stride1
+        )
+
+    Q_acc = tl.dot(X_q, WQ_h)
+    Q_scaled = (Q_acc * SCALE).to(IO_DTYPE)
+
+    m_i = tl.full((BLOCK_M,), -float("inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    O_acc = tl.zeros((BLOCK_M, D), dtype=tl.float32)
+
+    for k_start in range(0, N, BLOCK_K):
+        k_offs = k_start + tl.arange(0, BLOCK_K)
+        k_mask = k_offs < N
+
+        X_k = tl.load(
+            X_ptr
+            + pid_b_ptr * X_strideB
+            + pid_n * X_stride0
+            + k_offs[:, None] * X_stride1
+            + c_offs[None, :] * X_stride2,
+            mask=k_mask[:, None],
+            other=0.0,
+        )
+
+        if SEPARATE_KV:
+            K_acc = tl.dot(X_k, WK_h)
+            V_acc = tl.dot(X_k, WV_h)
+        else:
+            KV_acc = tl.dot(X_k, WKV_h)  # (BLOCK_K, 2*D)
+            KV_3d = tl.reshape(KV_acc, (BLOCK_K, D, 2))
+            K_acc, V_acc = tl.split(KV_3d)  # each (BLOCK_K, D)
+        K_block = K_acc.to(IO_DTYPE)
+        V_block = V_acc.to(IO_DTYPE)
+
+        S = tl.dot(Q_scaled, tl.trans(K_block)).to(tl.float32)
+
+        bias_tile = tl.load(
+            Bias_ptr
+            + pid_b_ptr * Bias_strideB
+            + pid_h * Bias_stride0
+            + q_offs[:, None] * Bias_stride1
+            + k_offs[None, :] * Bias_stride2,
+            mask=(q_mask[:, None] & k_mask[None, :]),
+            other=0.0,
+        ).to(tl.float32)
+        S = S + bias_tile
+
+        if HAS_MASK:
+            mask_row = tl.load(
+                Mask_ptr
+                + pid_b_ptr * Mask_strideB
+                + pid_n * Mask_stride0
+                + k_offs * Mask_stride1,
+                mask=k_mask,
+                other=0,
+            )
+            mask_bias = tl.where(mask_row != 0, 0.0, NEG_INF)
+            S = S + mask_bias[None, :]
+        S = tl.where(k_mask[None, :], S, -float("inf"))
+
+        m_new = tl.maximum(m_i, tl.max(S, axis=1))
+        alpha = tl.exp(m_i - m_new)
+        P = tl.exp(S - m_new[:, None])
+        l_i = l_i * alpha + tl.sum(P, axis=1)
+        O_acc = O_acc * alpha[:, None] + tl.dot(P.to(IO_DTYPE), V_block).to(tl.float32)
+        m_i = m_new
+
+    Out = O_acc / l_i[:, None]
+    o_col = pid_h * D + d_offs
+    tl.store(
+        O_ptr
+        + pid_b_ptr * O_strideB
+        + pid_n * O_stride0
+        + q_offs[:, None] * O_stride1
+        + o_col[None, :] * O_stride2,
+        Out.to(IO_DTYPE),
+        mask=q_mask[:, None],
+    )
+
+
+def triangle_attn_forward(
+    X_ln,
+    WQ_c,
+    WKV_c,
+    WZ_c,
+    BZ,
+    out,
+    scale=1.0,
+    mask=None,
+    Bias_buf=None,
+    *,
+    WK_c=None,
+    WV_c=None,
+):
+    """Run bias projection and attention for batched or unbatched pair tensors."""
+    original_out = out
+    if X_ln.ndim == 3:
+        if out.ndim != 3:
+            raise ValueError(f"unbatched X_ln requires rank-3 out, got {out.shape}")
+        X_ln = X_ln.unsqueeze(0)
+        out = out.unsqueeze(0)
+        if mask is not None:
+            mask = mask.unsqueeze(0)
+        if Bias_buf is not None:
+            Bias_buf = Bias_buf.unsqueeze(0)
+    elif X_ln.ndim != 4 or out.ndim != 4:
+        raise ValueError(
+            f"X_ln/out must both be rank 3 or 4, got {X_ln.shape} and {out.shape}"
+        )
+
+    B, N, N2, C_in = X_ln.shape
+    assert N == N2
+    H = WZ_c.shape[0]
+    D = WQ_c.shape[1] // H
+    assert WKV_c.shape == (C_in, 2 * H * D)
+    assert out.shape == (B, N, N, H * D)
+
+    # The interleaved tl.reshape/tl.split path is retained unchanged for the
+    # tuned D>=32 cases.  D=16 is the K-Fold Apo-module configuration and uses
+    # separate projection matrices to avoid Hopper's illegal-access lowering.
+    separate_kv = D == 16
+    if separate_kv:
+        if WK_c is None or WV_c is None:
+            # Preserve the low-level public API: callers that only provide the
+            # historical interleaved WKV tensor are deinterleaved once here.
+            wkv_view = WKV_c.view(C_in, H, D, 2)
+            WK_c = wkv_view[..., 0].reshape(C_in, H * D).contiguous()
+            WV_c = wkv_view[..., 1].reshape(C_in, H * D).contiguous()
+        assert WK_c.shape == WV_c.shape == (C_in, H * D)
+        wk_ptr, wv_ptr = WK_c, WV_c
+        wk_stride0, wk_stride1 = WK_c.stride()
+        wv_stride0, wv_stride1 = WV_c.stride()
+    else:
+        # These pointers are compiled out when SEPARATE_KV=False.
+        wk_ptr = wv_ptr = WKV_c
+        wk_stride0 = wk_stride1 = wv_stride0 = wv_stride1 = 0
+
+    io_dtype = tl_io_dtype(X_ln.dtype)
+    use_int64 = max(X_ln.numel(), out.numel(), B * H * N * N) > (1 << 31)
+
+    if Bias_buf is None:
+        Bias_buf = torch.empty(B, H, N, N, device=X_ln.device, dtype=X_ln.dtype)
+    elif Bias_buf.shape != (B, H, N, N):
+        raise ValueError(f"Bias_buf must have shape {(B, H, N, N)}, got {Bias_buf.shape}")
+
+    def grid_b(meta):
+        return (triton.cdiv(B * N * N, meta["BLOCK_QK"]), H)
+
+    bias_proj_kernel[grid_b](
+        X_ln,
+        X_ln.stride(0),
+        X_ln.stride(1),
+        X_ln.stride(2),
+        X_ln.stride(3),
+        WZ_c,
+        WZ_c.stride(0),
+        WZ_c.stride(1),
+        BZ,
+        BZ.stride(0),
+        Bias_buf,
+        Bias_buf.stride(0),
+        Bias_buf.stride(1),
+        Bias_buf.stride(2),
+        Bias_buf.stride(3),
+        B=B,
+        N=N,
+        C_in=C_in,
+        H=H,
+        IO_DTYPE=io_dtype,
+        USE_INT64=use_int64,
+    )
+
+    has_mask = mask is not None
+    if has_mask:
+        if mask.shape != (B, N, N):
+            raise ValueError(f"mask must have shape {(B, N, N)}, got {mask.shape}")
+        mask_i8 = mask.to(torch.int8).contiguous()
+        mask_ptr, mask_strideB, mask_stride0, mask_stride1 = (
+            mask_i8,
+            mask_i8.stride(0),
+            mask_i8.stride(1),
+            mask_i8.stride(2),
+        )
+    else:
+        mask_ptr, mask_strideB, mask_stride0, mask_stride1 = X_ln, 0, 0, 0
+
+    def grid_a(meta):
+        return (B * N, H, triton.cdiv(N, meta["BLOCK_M"]))
+
+    triangle_attn_kernel[grid_a](
+        X_ln,
+        X_ln.stride(0),
+        X_ln.stride(1),
+        X_ln.stride(2),
+        X_ln.stride(3),
+        WQ_c,
+        WQ_c.stride(0),
+        WQ_c.stride(1),
+        WKV_c,
+        WKV_c.stride(0),
+        WKV_c.stride(1),
+        wk_ptr,
+        wk_stride0,
+        wk_stride1,
+        wv_ptr,
+        wv_stride0,
+        wv_stride1,
+        Bias_buf,
+        Bias_buf.stride(0),
+        Bias_buf.stride(1),
+        Bias_buf.stride(2),
+        Bias_buf.stride(3),
+        mask_ptr,
+        mask_strideB,
+        mask_stride0,
+        mask_stride1,
+        out,
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        out.stride(3),
+        N=N,
+        C_in=C_in,
+        H=H,
+        D=D,
+        SCALE=scale,
+        NEG_INF=-1e9,
+        HAS_MASK=has_mask,
+        SEPARATE_KV=separate_kv,
+        IO_DTYPE=io_dtype,
+        USE_INT64=use_int64,
+    )
+    return original_out
+
+
+# ===========================================================================
+# Kernel 3: fused gate epilogue  —  Out = (O * sigmoid(g_in @ Wg)) @ Wo
+# Shared by triangle-attn wrap-up AND attention-pair-bias (trunk). The ONLY
+# difference is how O is read (STRIDED_O constexpr):
+#   STRIDED_O=True  : triangle wrap-up — O is (N, N, H, D), non-contiguous.
+#                     decode row m -> (n1, n2), col c -> (h, d); gather at strides.
+#   STRIDED_O=False : apb — O is (M, C) contiguous; read m*C + c directly.
+# Everything else (g_in read, both matmuls, sigmoid, multiply, store) is shared.
+# Compile-time branch -> two specialized kernels, zero runtime cost.
+# ===========================================================================
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": bm}, num_warps=w, num_stages=s)
+        for bm in (64, 128, 256, 512)
+        for w in (4, 8)
+        for s in (2, 3)
+    ],
+    key=["M", "C"],
+)
+@triton.jit
+def fused_gate_kernel(
+    O_ptr,
+    O_sB,
+    O_sN1,
+    O_sN2,
+    O_sH,
+    O_sD,  # strided-O args (used iff STRIDED_O)
+    GIN_ptr,  # gate input (M, C) contiguous: LN(x) [tri] or ã [apb]
+    WG_ptr,
+    WO_ptr,  # (C, C) matmul-convention (already transposed)
+    Out_ptr,  # (M, C) contiguous output
+    M,
+    N,  # N used iff STRIDED_O
+    C: tl.constexpr,
+    D: tl.constexpr,
+    USE_INT64: tl.constexpr,
+    STRIDED_O: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    row_ptr = rows.to(tl.int64) if USE_INT64 else rows
+    rmask = rows < M
+    cols = tl.arange(0, C)
+
+    if STRIDED_O:  # triangle wrap-up: O = (B, N, N, H, D), possibly strided
+        b = row_ptr // (N * N)
+        pair = row_ptr % (N * N)
+        n1 = pair // N
+        n2 = pair % N
+        h = cols // D
+        d = cols % D
+        o_off = (
+            b[:, None] * O_sB
+            + n1[:, None] * O_sN1
+            + n2[:, None] * O_sN2
+            + h[None, :] * O_sH
+            + d[None, :] * O_sD
+        )
+        o = tl.load(O_ptr + o_off, mask=rmask[:, None], other=0.0)
+    else:  # apb: O = (M, C) contiguous
+        o = tl.load(
+            O_ptr + row_ptr[:, None] * C + cols[None, :], mask=rmask[:, None], other=0.0
+        )
+
+    gin = tl.load(
+        GIN_ptr + row_ptr[:, None] * C + cols[None, :], mask=rmask[:, None], other=0.0
+    )
+    wg = tl.load(WG_ptr + cols[:, None] * C + cols[None, :])
+    wo = tl.load(WO_ptr + cols[:, None] * C + cols[None, :])
+
+    g = tl.sigmoid(tl.dot(gin, wg))  # gate = sigmoid(g_in @ Wg)
+    acc = tl.dot((o.to(tl.float32) * g).to(gin.dtype), wo)  # (O * g) @ Wo
+    tl.store(
+        Out_ptr + row_ptr[:, None] * C + cols[None, :],
+        acc.to(gin.dtype),
+        mask=rmask[:, None],
+    )
+
+
+def fused_gate_forward(o_attn, qx_ln, WG, WO):
+    """Apply sigmoid gating and output projection to triangle-attention output."""
+    unbatched = o_attn.ndim == 4
+    if unbatched:
+        o_attn = o_attn.unsqueeze(0)
+        qx_ln = qx_ln.unsqueeze(0)
+    if o_attn.ndim != 5 or qx_ln.ndim != 4:
+        raise ValueError(
+            f"invalid triangle gate shapes: {o_attn.shape} and {qx_ln.shape}"
+        )
+    B, N1, N2, H, D = o_attn.shape
+    if N1 != N2 or qx_ln.shape != (B, N1, N2, H * D):
+        raise ValueError(
+            f"incompatible triangle gate shapes: {o_attn.shape} and {qx_ln.shape}"
+        )
+    N, C, M = N1, H * D, B * N1 * N2
+    out = torch.empty(B, N1, N2, C, device=o_attn.device, dtype=o_attn.dtype)
+    Qf = qx_ln.reshape(M, C)  # free view (contiguous)
+    Of = out.reshape(M, C)  # free view (contiguous)
+    wg = WG.t().contiguous()  # (out,in) -> (in,out) so qx @ wg == linear_g(qx)
+    wo = WO.t().contiguous()
+
+    def grid(meta):
+        return (triton.cdiv(M, meta["BLOCK_M"]),)
+
+    fused_gate_kernel[grid](
+        o_attn,
+        o_attn.stride(0),
+        o_attn.stride(1),
+        o_attn.stride(2),
+        o_attn.stride(3),
+        o_attn.stride(4),
+        Qf,
+        wg,
+        wo,
+        Of,
+        M,
+        N,
+        USE_INT64=M * C > (1 << 31),
+        C=C,
+        D=D,
+        STRIDED_O=True,
+    )
+    return out.squeeze(0) if unbatched else out

--- a/src/kfold/utils/kernels/triton/triangle_attention/ops.py
+++ b/src/kfold/utils/kernels/triton/triangle_attention/ops.py
@@ -1,0 +1,161 @@
+"""Public API for fused starting- and ending-node triangle attention."""
+
+import torch
+
+from .._common.layouts import interleave_kv
+from .kernels import fused_gate_forward, triangle_attn_forward
+
+
+def precompute(W_ln, B_ln, WQ, WK, WV, W_proj_z, B_proj_z, H, D):
+    """Pack projection weights into layouts consumed by forward."""
+    WQ_c = WQ.contiguous()  # (C_in, H*D) matmul convention, no fold
+    WKV_c = interleave_kv(WK, WV, H, D).contiguous()  # (C_in, 2*H*D), no fold
+    # Triton's reshape/split lowering used by the interleaved K/V fast path can
+    # issue an illegal access for the Apo-module shape D=16 on Hopper.  Keep the
+    # original K and V layouts as well so the kernel can select a genuine
+    # two-matmul Triton specialization for D=16.  D>=32 continues to use WKV_c.
+    WK_c = WK.contiguous() if D == 16 else None
+    WV_c = WV.contiguous() if D == 16 else None
+    WZ_c = W_proj_z.t().contiguous()  # (C_in, H) -> (H, C_in) for the bias kernel
+
+    # bias-proj bias as an (H,) fp32 tensor (K-Fold's bias-proj is LinearNoBias).
+    if B_proj_z is None:
+        BZ = torch.zeros(H, device=WQ.device, dtype=torch.float32)
+    else:
+        BZ = B_proj_z.float().contiguous()
+
+    return {
+        "WQ_c": WQ_c,
+        "WKV_c": WKV_c,
+        "WK_c": WK_c,
+        "WV_c": WV_c,
+        "WZ_c": WZ_c,
+        "BZ": BZ,
+        # x̃ = LN(x) is computed once in `forward`; the kernels and the gate
+        # epilogue all consume it, so the LN affine is needed here.
+        "W_ln": W_ln,
+        "B_ln": B_ln,
+    }
+
+
+def forward(
+    X,
+    pre,
+    *,
+    mask=None,
+    scale=1.0,
+    eps=1e-5,
+    W_proj_g,
+    B_proj_g,
+    W_proj_o,
+    B_proj_o,
+    pad_to=32,
+):
+    """Run triangle attention on batched or unbatched pair features.
+
+    The output rank matches X; pad_to controls sequence padding.
+    """
+    assert B_proj_g is None and B_proj_o is None, (
+        "fused gate path assumes bias-free linear_g / linear_o (K-Fold LinearNoBias)"
+    )
+    unbatched = X.ndim == 3
+    if unbatched:
+        X = X.unsqueeze(0)
+        if mask is not None:
+            mask = mask.unsqueeze(0)
+    elif X.ndim != 4:
+        raise ValueError(f"X must have shape (N,N,C) or (B,N,N,C), got {X.shape}")
+    B, N, N2, C_in = X.shape
+    if N != N2:
+        raise ValueError(f"triangle attention requires square pair axes, got {X.shape}")
+    H = pre["WZ_c"].shape[0]
+    D = pre["WQ_c"].shape[1] // H
+    if mask is not None and mask.shape != (B, N, N):
+        raise ValueError(f"mask must have shape {(B, N, N)}, got {mask.shape}")
+    # x̃ = LN(x) computed once and shared by the kernels and the gate.
+    X_ln = torch.nn.functional.layer_norm(
+        X,
+        (C_in,),
+        pre["W_ln"].to(X.dtype),
+        pre["B_ln"].to(X.dtype) if pre["B_ln"] is not None else None,
+        eps,
+    )
+
+    Np = ((N + pad_to - 1) // pad_to) * pad_to if pad_to and pad_to > 1 else N
+    if Np != N:
+        # Pad both N dims with zeros; mask the padding keys (and rows, which are
+        # discarded).  This runs triangle_attn on the fast (multiple-of-pad_to) shape.
+        X_ln_k = torch.nn.functional.pad(X_ln, (0, 0, 0, Np - N, 0, Np - N))
+        if mask is None:
+            mask_k = torch.zeros(B, Np, Np, dtype=torch.bool, device=X.device)
+            mask_k[..., :N] = True
+        else:
+            mask_k = torch.nn.functional.pad(
+                mask.bool(), (0, Np - N, 0, Np - N), value=False
+            )
+        O_pad = torch.empty(B, Np, Np, H * D, device=X.device, dtype=X.dtype)
+        triangle_attn_forward(
+            X_ln_k,
+            pre["WQ_c"],
+            pre["WKV_c"],
+            pre["WZ_c"],
+            pre["BZ"],
+            O_pad,
+            scale=scale,
+            mask=mask_k,
+            WK_c=pre["WK_c"],
+            WV_c=pre["WV_c"],
+        )
+        O_attn = O_pad[:, :N, :N]  # strided view; gate reads native batch/pair strides
+    else:
+        O_attn = torch.empty(B, N, N, H * D, device=X.device, dtype=X.dtype)
+        triangle_attn_forward(
+            X_ln,
+            pre["WQ_c"],
+            pre["WKV_c"],
+            pre["WZ_c"],
+            pre["BZ"],
+            O_attn,
+            scale=scale,
+            mask=mask,
+            WK_c=pre["WK_c"],
+            WV_c=pre["WV_c"],
+        )
+    # Gate epilogue (fused): K-Fold gates on q_x = LN(x), so reuse normalized x directly.
+    # O_attn may be a strided padded slice; the gate gathers at native strides.
+    output = fused_gate_forward(O_attn.view(B, N, N, H, D), X_ln, W_proj_g, W_proj_o)
+    return output.squeeze(0) if unbatched else output
+
+
+def triangle_attention(
+    X,
+    W_ln,
+    B_ln,
+    WQ,
+    WK,
+    WV,
+    W_proj_z,
+    B_proj_z,
+    W_proj_g,
+    B_proj_g,
+    W_proj_o,
+    B_proj_o,
+    H,
+    D,
+    scale=1.0,
+    eps=1e-5,
+    mask=None,
+):
+    """Run triangle attention with projection precomputation included."""
+    pre = precompute(W_ln, B_ln, WQ, WK, WV, W_proj_z, B_proj_z, H, D)
+    return forward(
+        X,
+        pre,
+        mask=mask,
+        scale=scale,
+        eps=eps,
+        W_proj_g=W_proj_g,
+        B_proj_g=B_proj_g,
+        W_proj_o=W_proj_o,
+        B_proj_o=B_proj_o,
+    )

--- a/src/kfold/utils/kernels/triton/triangle_multiplication/__init__.py
+++ b/src/kfold/utils/kernels/triton/triangle_multiplication/__init__.py
@@ -1,0 +1,10 @@
+from .kernels import input_phase, output_phase
+from .ops import forward, precompute, triangle_multiplicative_update
+
+__all__ = [
+    "triangle_multiplicative_update",
+    "precompute",
+    "forward",
+    "input_phase",
+    "output_phase",
+]

--- a/src/kfold/utils/kernels/triton/triangle_multiplication/kernels.py
+++ b/src/kfold/utils/kernels/triton/triangle_multiplication/kernels.py
@@ -1,0 +1,348 @@
+"""Triton kernels for triangle multiplicative update projection phases.
+
+The shared kernel applies LayerNorm with folded projection parameters, sigmoid
+gating, optional masking, and layout-aware stores.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .._common.dtypes import tl_io_dtype
+
+
+def _early_config_prune(configs, named_args, **_kwargs):
+    """Drop register-infeasible wide tiles for the K-Fold C=256 path."""
+    arguments = {**(named_args or {}), **_kwargs}
+    wide_channel = max(int(arguments["D"]), int(arguments["D_OUT"])) >= 256
+    if not wide_channel:
+        return configs
+    return [
+        config
+        for config in configs
+        if not (config.kwargs["BLOCK_M"] >= 128 and config.kwargs["BLOCK_K"] >= 128)
+    ]
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 256, "BLOCK_K": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_K": 64}, num_warps=4, num_stages=2),
+        # output phase (D_OUT=128) likes one-shot BLOCK_K=128
+        triton.Config({"BLOCK_M": 64, "BLOCK_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 128, "BLOCK_K": 128}, num_warps=4, num_stages=2),
+    ],
+    key=["M", "D", "D_OUT", "TWO_INPUTS", "X1_DMAJOR", "TRANS", "HAS_MASK", "USE_INT64"],
+    prune_configs_by={"early_config_prune": _early_config_prune},
+)
+@triton.jit
+def fused_layer_norm_sigmoid_gated_transpose(
+    X1_ptr,
+    X1_stride0,
+    X1_stride1,  # value-branch input (stride0=token-m, stride1=feature-d)
+    X2_ptr,
+    X2_stride0,
+    X2_stride1,  # gate-branch input  (unused if not TWO_INPUTS)
+    Wp_ptr,
+    Wp_stride0,
+    Wp_stride1,  # (D_OUT, D) value proj (LN-folded)
+    Wg_ptr,
+    Wg_stride0,
+    Wg_stride1,  # (D_OUT, D) gate proj  (LN-folded)
+    sWp_ptr,
+    sWg_ptr,
+    BPc_ptr,
+    BGc_ptr,
+    Mask_ptr,
+    Mask_stride0,
+    Out_ptr,
+    Out_stride0,
+    Out_stride1,  # output strides: stride0=token-m, stride1=feature-k
+    M: tl.constexpr,
+    D: tl.constexpr,
+    D_OUT: tl.constexpr,
+    EPS: tl.constexpr,
+    IO_DTYPE: tl.constexpr,
+    HAS_MASK: tl.constexpr,
+    USE_INT64: tl.constexpr,
+    TWO_INPUTS: tl.constexpr,
+    X1_DMAJOR: tl.constexpr,
+    TRANS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    # Flattened pair tensors cross the signed-int32 element-offset limit when
+    # D_OUT=512 and L>2048. Promote pointer offsets only for those large shapes.
+    d_offs = tl.arange(0, D)
+    if USE_INT64:
+        m_ptr_offs = m_offs.to(tl.int64)
+        d_ptr_offs = d_offs.to(tl.int64)
+    else:
+        m_ptr_offs = m_offs
+        d_ptr_offs = d_offs
+    m_mask = m_offs < M
+    inv_D = 1.0 / D
+
+    # ---- load X1 (value branch) as (BLOCK_M, D), coalesced for either layout ----
+    if X1_DMAJOR:  # X1 is (D, M): load (D, BM) coalesced, then trans
+        X1t = tl.load(
+            X1_ptr + d_ptr_offs[:, None] * X1_stride1 + m_ptr_offs[None, :] * X1_stride0,
+            mask=m_mask[None, :],
+            other=0.0,
+        )
+        X1 = tl.trans(X1t)
+    else:  # X1 is (M, D): load (BM, D) directly
+        X1 = tl.load(
+            X1_ptr + m_ptr_offs[:, None] * X1_stride0 + d_offs[None, :] * X1_stride1,
+            mask=m_mask[:, None],
+            other=0.0,
+        )
+
+    X1_fp32 = X1.to(tl.float32)
+    mean1 = tl.sum(X1_fp32, axis=-1) * inv_D
+    diff1 = X1_fp32 - mean1[:, None]
+    rstd1 = 1.0 / tl.sqrt(tl.sum(diff1 * diff1, axis=-1) * inv_D + EPS)
+
+    # ---- load X2 (gate branch) — reuse X1 if single-input ----
+    if TWO_INPUTS:
+        X2 = tl.load(
+            X2_ptr + m_ptr_offs[:, None] * X2_stride0 + d_offs[None, :] * X2_stride1,
+            mask=m_mask[:, None],
+            other=0.0,
+        )
+        X2_fp32 = X2.to(tl.float32)
+        mean2 = tl.sum(X2_fp32, axis=-1) * inv_D
+        diff2 = X2_fp32 - mean2[:, None]
+        rstd2 = 1.0 / tl.sqrt(tl.sum(diff2 * diff2, axis=-1) * inv_D + EPS)
+    else:
+        X2 = X1
+        mean2 = mean1
+        rstd2 = rstd1
+
+    if HAS_MASK:
+        m_val = tl.load(Mask_ptr + m_ptr_offs * Mask_stride0, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
+
+    for k in tl.range(0, D_OUT, BLOCK_K):
+        k_offs = k + tl.arange(0, BLOCK_K)
+        k_mask = k_offs < D_OUT
+        k_ptr_offs = k_offs.to(tl.int64) if USE_INT64 else k_offs
+        Wp = tl.load(
+            Wp_ptr + k_offs[None, :] * Wp_stride0 + d_offs[:, None] * Wp_stride1,
+            mask=k_mask[None, :],
+            other=0.0,
+        )
+        Wg = tl.load(
+            Wg_ptr + k_offs[None, :] * Wg_stride0 + d_offs[:, None] * Wg_stride1,
+            mask=k_mask[None, :],
+            other=0.0,
+        )
+        sWp = tl.load(sWp_ptr + k_offs, mask=k_mask, other=0.0)
+        sWg = tl.load(sWg_ptr + k_offs, mask=k_mask, other=0.0)
+        BPc = tl.load(BPc_ptr + k_offs, mask=k_mask, other=0.0)
+        BGc = tl.load(BGc_ptr + k_offs, mask=k_mask, other=0.0)
+
+        P = tl.dot(X1, Wp)  # value ← X1
+        G = tl.dot(X2, Wg)  # gate  ← X2
+        P = rstd1[:, None] * (P - mean1[:, None] * sWp[None, :]) + BPc[None, :]
+        G = rstd2[:, None] * (G - mean2[:, None] * sWg[None, :]) + BGc[None, :]
+        Out = tl.sigmoid(G) * P
+        if HAS_MASK:
+            Out = Out * m_val[:, None]
+
+        if TRANS:  # write (D_OUT, M): Out[k, m], m contiguous
+            tl.store(
+                Out_ptr
+                + k_ptr_offs[:, None] * Out_stride1
+                + m_ptr_offs[None, :] * Out_stride0,
+                tl.trans(Out).to(IO_DTYPE),
+                mask=k_mask[:, None] & m_mask[None, :],
+            )
+        else:  # write (M, D_OUT): Out[m, k]
+            tl.store(
+                Out_ptr
+                + m_ptr_offs[:, None] * Out_stride0
+                + k_ptr_offs[None, :] * Out_stride1,
+                Out.to(IO_DTYPE),
+                mask=m_mask[:, None] & k_mask[None, :],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Phase launch wrappers (signatures unchanged — module.py depends on them)
+# ---------------------------------------------------------------------------
+def _launch(
+    X1,
+    X1_s0,
+    X1_s1,
+    X2,
+    X2_s0,
+    X2_s1,
+    Wp,
+    Wg,
+    sWp,
+    sWg,
+    BPc,
+    BGc,
+    mask,
+    out,
+    out_s0,
+    out_s1,
+    M,
+    D,
+    D_OUT,
+    eps,
+    *,
+    two_inputs,
+    x1_dmajor,
+    trans,
+):
+    if mask is not None:
+        mask_ptr, mask_s0, has_mask = mask, mask.stride(0), True
+    else:
+        mask_ptr, mask_s0, has_mask = X1, 0, False
+    if X2 is None:
+        X2, X2_s0, X2_s1 = X1, X1_s0, X1_s1
+
+    def grid(meta):
+        return (triton.cdiv(M, meta["BLOCK_M"]),)
+
+    use_int64 = max(M * D, M * D_OUT) > (1 << 31)
+    fused_layer_norm_sigmoid_gated_transpose[grid](
+        X1,
+        X1_s0,
+        X1_s1,
+        X2,
+        X2_s0,
+        X2_s1,
+        Wp,
+        Wp.stride(0),
+        Wp.stride(1),
+        Wg,
+        Wg.stride(0),
+        Wg.stride(1),
+        sWp,
+        sWg,
+        BPc,
+        BGc,
+        mask_ptr,
+        mask_s0,
+        out,
+        out_s0,
+        out_s1,
+        M=M,
+        D=D,
+        D_OUT=D_OUT,
+        EPS=eps,
+        IO_DTYPE=tl_io_dtype(X1.dtype),
+        HAS_MASK=has_mask,
+        USE_INT64=use_int64,
+        TWO_INPUTS=two_inputs,
+        X1_DMAJOR=x1_dmajor,
+        TRANS=trans,
+    )
+
+
+def input_phase(
+    x,
+    mask,
+    p_in_combined,
+    g_in_combined,
+    sum_W_p_in,
+    sum_W_g_in,
+    B_p_in_const,
+    B_g_in_const,
+    eps,
+):
+    """Compute the masked input projection in D-major layout."""
+    B, L, _, D = x.shape
+    D_OUT = p_in_combined.shape[0]
+    M = B * L * L
+    x_flat = x.reshape(M, D)
+    out_t = torch.empty(D_OUT, M, device=x.device, dtype=x.dtype)  # (D_OUT, M)
+    mask_flat = mask.reshape(M).to(torch.int8).contiguous() if mask is not None else None
+    # X1=x (M,D): s0=token=D, s1=feature=1.  Out (D_OUT,M): s0=token=1, s1=feature=M.
+    _launch(
+        x_flat,
+        x_flat.stride(0),
+        x_flat.stride(1),
+        None,
+        0,
+        0,
+        p_in_combined,
+        g_in_combined,
+        sum_W_p_in,
+        sum_W_g_in,
+        B_p_in_const,
+        B_g_in_const,
+        mask_flat,
+        out_t,
+        1,
+        M,
+        M,
+        D,
+        D_OUT,
+        eps,
+        two_inputs=False,
+        x1_dmajor=False,
+        trans=True,
+    )
+    return out_t.view(D_OUT, B, L, L)
+
+
+def output_phase(
+    y_t,
+    x,
+    p_out_combined,
+    g_out_combined,
+    sum_W_p_out,
+    sum_W_g_out,
+    B_p_out_const,
+    B_g_out_const,
+    eps,
+):
+    """Gate the triangle product and return row-major output."""
+    B, L, _, D = x.shape
+    D_OUT = p_out_combined.shape[0]
+    M = B * L * L
+    y_flat = y_t.reshape(D, M)  # (D, M)
+    x_flat = x.reshape(M, D)
+    out = torch.empty(M, D_OUT, device=x.device, dtype=x.dtype)  # (M, D_OUT)
+    # X1=y (D,M): s0=token=1, s1=feature=M. X2=x (M,D): s0=D, s1=1.
+    # Out (M,D_OUT): s0=D_OUT, s1=1.
+    _launch(
+        y_flat,
+        1,
+        M,
+        x_flat,
+        x_flat.stride(0),
+        x_flat.stride(1),
+        p_out_combined,
+        g_out_combined,
+        sum_W_p_out,
+        sum_W_g_out,
+        B_p_out_const,
+        B_g_out_const,
+        None,
+        out,
+        out.stride(0),
+        out.stride(1),
+        M,
+        D,
+        D_OUT,
+        eps,
+        two_inputs=True,
+        x1_dmajor=True,
+        trans=False,
+    )
+    return out.view(B, L, L, D_OUT)

--- a/src/kfold/utils/kernels/triton/triangle_multiplication/ops.py
+++ b/src/kfold/utils/kernels/triton/triangle_multiplication/ops.py
@@ -1,0 +1,112 @@
+"""Public API for fused incoming and outgoing triangle multiplicative update."""
+
+import torch
+
+from .._common.ln_absorption import absorb_ln
+from .kernels import input_phase, output_phase
+
+
+def precompute(
+    norm_in_weight,
+    norm_in_bias,
+    p_in_weight,
+    g_in_weight,
+    norm_out_weight,
+    norm_out_bias,
+    p_out_weight,
+    g_out_weight,
+):
+    """Fold LayerNorm affine parameters into the four projection weights."""
+    proj_dtype = p_in_weight.dtype
+    p_in_c, sWp_in, Bp_in = absorb_ln(
+        p_in_weight, norm_in_weight, norm_in_bias, weight_dtype=proj_dtype
+    )
+    g_in_c, sWg_in, Bg_in = absorb_ln(
+        g_in_weight, norm_in_weight, norm_in_bias, weight_dtype=proj_dtype
+    )
+    p_out_c, sWp_out, Bp_out = absorb_ln(
+        p_out_weight, norm_out_weight, norm_out_bias, weight_dtype=proj_dtype
+    )
+    g_out_c, sWg_out, Bg_out = absorb_ln(
+        g_out_weight, norm_in_weight, norm_in_bias, weight_dtype=proj_dtype
+    )
+    return {
+        "p_in_combined": p_in_c,
+        "g_in_combined": g_in_c,
+        "p_out_combined": p_out_c,
+        "g_out_combined": g_out_c,
+        "sum_W_p_in": sWp_in,
+        "sum_W_g_in": sWg_in,
+        "sum_W_p_out": sWp_out,
+        "sum_W_g_out": sWg_out,
+        "B_p_in_const": Bp_in,
+        "B_g_in_const": Bg_in,
+        "B_p_out_const": Bp_out,
+        "B_g_out_const": Bg_out,
+    }
+
+
+def forward(x, pre, *, direction, mask=None, eps=1e-5):
+    """Apply the selected update direction using precomputed weights."""
+    ab_t = input_phase(
+        x,
+        mask,
+        pre["p_in_combined"],
+        pre["g_in_combined"],
+        pre["sum_W_p_in"],
+        pre["sum_W_g_in"],
+        pre["B_p_in_const"],
+        pre["B_g_in_const"],
+        eps,
+    )  # (2D, B, L, L)
+
+    a, b_ab = torch.chunk(ab_t, 2, dim=0)  # each (D, B, L, L)
+    if direction == "outgoing":
+        y = torch.einsum("dbik,dbjk->dbij", a, b_ab)
+    elif direction == "incoming":
+        y = torch.einsum("dbki,dbkj->dbij", a, b_ab)
+    else:
+        raise ValueError(
+            f"unknown direction: {direction!r} (expected 'outgoing'/'incoming')"
+        )
+
+    return output_phase(
+        y,
+        x,
+        pre["p_out_combined"],
+        pre["g_out_combined"],
+        pre["sum_W_p_out"],
+        pre["sum_W_g_out"],
+        pre["B_p_out_const"],
+        pre["B_g_out_const"],
+        eps,
+    )
+
+
+def triangle_multiplicative_update(
+    x,
+    *,
+    direction,
+    mask=None,
+    eps=1e-5,
+    norm_in_weight,
+    norm_in_bias,
+    p_in_weight,
+    g_in_weight,
+    norm_out_weight,
+    norm_out_bias,
+    p_out_weight,
+    g_out_weight,
+):
+    """Run triangle multiplicative update with projection precomputation included."""
+    pre = precompute(
+        norm_in_weight,
+        norm_in_bias,
+        p_in_weight,
+        g_in_weight,
+        norm_out_weight,
+        norm_out_bias,
+        p_out_weight,
+        g_out_weight,
+    )
+    return forward(x, pre, direction=direction, mask=mask, eps=eps)


### PR DESCRIPTION
## Summary

This PR adds an inference-only Triton backend for the main folding kernels and
keeps the existing torch/cuequivariance paths available through a single kernel
policy. It also applies the measured `torch.compile` path to transition blocks
during standalone CUDA inference.

## What changed

- Add `KernelPolicy` and the `kernel_backend` model configuration option.
  `null` preserves the legacy configuration, while `cuequivariance` and
  `triton` select an explicit inference backend.
- Add Triton implementations for triangle multiplication, triangle attention,
  and attention pair bias under `kfold.utils.kernels.triton`.
- Dispatch attention pair bias by workload shape: use fused or split Triton
  paths where they are beneficial and fall back to the packed cuequivariance
  path for unsupported or unfavorable shapes.
- Thread the selected policy through the diffusion, confidence, trunk, and apo
  inference modules without changing the training entry point.
- Compile standard and conditioned transition blocks with
  `max-autotune-no-cudagraphs` for CUDA evaluation under `no_grad`; eager
  execution remains the fallback for training, grad-enabled evaluation, CPU,
  and nested compilation.
- Add inference CLI controls for kernel backend selection and non-strict
  checkpoint loading.
- Pin cuequivariance to the 0.10 API used by the attention-pair-bias adapter.

## Compatibility and fallback behavior

- The Triton path is selected only when `kernel_backend: triton` is set for
  inference. Existing configurations continue to use their legacy backend.
- Unsupported attention-pair-bias shapes fall back to cuequivariance instead of
  changing model semantics.
- Triton operations guard CUDA, dtype, shape, and gradient requirements before
  dispatch. Training behavior is not changed by this PR.
- cuequivariance 0.11 changes the attention-pair-bias API; this implementation
  intentionally targets and pins the 0.10 API.